### PR TITLE
fix: 修复 PipeWire 虚拟音频设备创建问题

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/platform/VirtualAudioDevice.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/platform/VirtualAudioDevice.kt
@@ -116,8 +116,8 @@ object VirtualAudioDevice {
         return try {
             val process = ProcessBuilder(
                 "pw-loopback",
-                "--capture-props=target.object=$SINK_NAME",
-                "--playback-props=node.name=$SOURCE_NAME media.class=Audio/Source/Virtual"
+                "--capture-props={\"node.target\": \"$SINK_NAME\", \"media.class\": \"Stream/Input/Audio\", \"stream.capture.sink\": true}",
+                "--playback-props={\"node.description\": \"$SOURCE_NAME\", \"media.class\": \"Audio/Source\"}"
             ).redirectErrorStream(true).start()
             
             loopbackProcess = process


### PR DESCRIPTION
- 移除错误的 createVirtualSource() 方法，使用 support.null-audio-sink 创建 Source 会导致节点属性不完整
- 修改 createLoopback() 使用正确的 pw-loopback 命令替代无效的 pw-cli create-node loopback
- 更新 cleanup() 方法正确终止 pw-loopback 进程