### PR TITLE
fix: 修复版本号检查更新

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Localization.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Localization.kt
@@ -133,6 +133,8 @@ data class AppStrings(
     val checkUpdate: String = "Check for Updates",
     val isLatestVersion: String = "Already the latest version",
     val checkingUpdate: String = "Checking for updates...",
+    val updateCheckFailed: String = "Failed to check for updates: %s",
+    val newVersionReleased: String = "New version released",
 
     // BlackHole (macOS virtual audio)
     val blackHoleInstalled: String = "BlackHole is installed, please configure in System Settings",

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
@@ -252,7 +252,7 @@ class MainViewModel : ViewModel() {
                     _uiState.update { it.copy(snackbarMessage = strings.isLatestVersion) }
                 }
             }.onFailure { e ->
-                _uiState.update { it.copy(snackbarMessage = "检查更新失败: ${e.message}") }
+                _uiState.update { it.copy(snackbarMessage = strings.updateCheckFailed.format(e.message)) }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/UpdateChecker.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/UpdateChecker.kt
@@ -49,17 +49,17 @@ class UpdateChecker {
             
             if (apiResponse.status == HttpStatusCode.Forbidden || apiResponse.status == HttpStatusCode.TooManyRequests) {
                 Logger.w("UpdateChecker", "GitHub API rate limited, trying website fallback...")
-                return checkUpdateViaWebsite(currentVersion)
+                return checkUpdateViaWebsite(currentVersion, "New version released")
             }
 
             Result.failure(Exception("HTTP Error: ${apiResponse.status.value}"))
         } catch (e: Exception) {
             Logger.e("UpdateChecker", "API check failed, trying fallback...", e)
-            return checkUpdateViaWebsite(currentVersion)
+            return checkUpdateViaWebsite(currentVersion, "New version released")
         }
     }
 
-    private suspend fun checkUpdateViaWebsite(currentVersion: String): Result<GitHubRelease?> {
+    private suspend fun checkUpdateViaWebsite(currentVersion: String, releaseBody: String): Result<GitHubRelease?> {
         return try {
             val response = client.get("https://github.com/LanRhyme/MicYou/releases/latest") {
                 header(HttpHeaders.UserAgent, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
@@ -75,7 +75,7 @@ class UpdateChecker {
                     return Result.success(GitHubRelease(
                         tagName = tag,
                         htmlUrl = finalUrl,
-                        body = "新版本已发布"
+                        body = releaseBody
                     ))
                 }
             }


### PR DESCRIPTION
### 测试版本1.1.0

https://github.com/user-attachments/assets/6f893826-1902-4dba-b3fb-0e119e8fac7e

### 当版本升级到1.1.1后问题依旧存在

https://github.com/user-attachments/assets/2708618a-1a74-461b-abcd-b2f9a1ffaf54


### 日志
[micyou.log](https://github.com/user-attachments/files/25508430/micyou.log)
将最后一段日志报错丢给AI后
> 简单来说，这是一个 JSON 解析失败的报错。 Micyou在尝试通过 GitHub API 检查更新时，收到的数据和你定义的代码模型对不上。

### 解决方案
1. **引入 Result 状态封装：**
   将 `checkUpdate` 的返回值从单一的 `GitHubRelease?` 重构为 `Result<GitHubRelease?>`。在 `MainViewModel` 层通过 `onSuccess` 和 `onFailure` 优雅地处理网络结果，并结合 Snackbar 提供准确的 UI 错误反馈，彻底避免因未捕获异常导致的应用崩溃。
2. **状态码拦截与异常分发：**
   在处理 API 响应前，增加 `apiResponse.status.isSuccess()` 校验。当检测到 `403` 或 API 请求抛出异常时，主动将其拦截。
3. **新增网页端兜底方案 (Fallback Mechanism)：**
   为了彻底解决 GitHub API 容易限流的问题，引入了 `checkUpdateViaWebsite` 兜底策略。当 API 受限时，程序会转而请求 GitHub Release 的网页端 URL (`/releases/latest`)。通过捕获请求重定向后的最终 URL (包含 `/tag/v1.1.x`)，直接从中提取最新版本号。该方案巧妙绕过了 API 接口的频率限制。
4. **增强版本对比鲁棒性：**
   优化了 `parseParts` 函数，通过 `substringBefore("-")` 预处理版本字符串。这确保了在面对带有后缀的先行版本号（如 `1.1.1-alpha`）时，系统依然能正确提取主版本数字进行对比，防止 `toIntOrNull` 转换失败。

fix/updatechecker ci已过: https://github.com/UsonTong/MicYou/actions/runs/22336909804
如需测试可使用此版本: https://github.com/UsonTong/MicYou/releases/tag/v1.1.2-20260224-0448

**TODO:** 
- 暂未抽离 i18n 资源，若 **合并** 需后续补全。
- 故障诊断与解决方案均由 **vibe/ai coding** 总结/完成，需要 **代码审查**。