### PR TITLE
chore: 升级 Compose Multiplatform 到 1.9.0

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -30,15 +30,21 @@ plugins {
 }
 
 val composeVersion = libs.versions.composeMultiplatform.get()
-val skikoVersion = "0.8.18"
+val composeMaterial3Version = libs.versions.composeMaterial3.get()
 
 configurations.configureEach {
     resolutionStrategy.eachDependency {
         if (requested.group == "org.jetbrains.compose" || requested.group.startsWith("org.jetbrains.compose.")) {
-            useVersion(composeVersion)
-        }
-        if (requested.group == "org.jetbrains.skiko") {
-            useVersion(skikoVersion)
+            val name = requested.name
+            if (name == "material-icons-extended" || name == "material-icons-extended-desktop" || 
+                name == "material-icons-core" || name == "material-icons-core-desktop" ||
+                name == "material") {
+                useVersion("1.7.3")
+            } else if (name == "material3") {
+                useVersion(composeMaterial3Version)
+            } else {
+                useVersion(composeVersion)
+            }
         }
         // 强制使用dorkbox/OS 1.11版本以修复60秒阻塞问题
         if (requested.group == "com.dorkbox" && requested.name == "OS") {
@@ -80,6 +86,7 @@ kotlin {
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.serialization.kotlinx.json)
             implementation(libs.kotlinx.serialization.protobuf)
+            implementation(libs.kotlinx.datetime)
             implementation(libs.compose.material.icons.extended)
         }
         commonTest.dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,10 +10,12 @@ androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.9.6"
 androidx-testExt = "1.3.0"
 composeHotReload = "1.0.0"
-composeMultiplatform = "1.7.3"
+composeMultiplatform = "1.9.0"
+composeMaterial3 = "1.9.0-beta06"
 junit = "4.13.2"
 kotlin = "2.2.20"
 kotlinx-coroutines = "1.10.2"
+kotlinx-datetime = "0.7.1"
 material3 = "1.8.0"
 ktor = "3.4.0"
 kotlinx-serialization = "1.8.1"
@@ -33,12 +35,13 @@ androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecyc
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "composeMultiplatform" }
-compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "composeMultiplatform" }
+compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "composeMaterial3" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
-compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "composeMultiplatform" }
+compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "composeMaterial3" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 ktor-network = { module = "io.ktor:ktor-network", version.ref = "ktor" }
 kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }


### PR DESCRIPTION
- 升级 composeMultiplatform 从 1.7.3 到 1.9.0
- 添加 composeMaterial3 1.9.0-beta06（解耦版本控制）
- 添加 kotlinx-datetime 0.7.1 依赖
- 添加依赖版本覆盖逻辑，material icons 保持 1.7.3
- 移除手动指定的 skiko 版本，使用 Compose 1.9.0 兼容版本