### PR TITLE
升级 Compose Multiplatform 到 1.10.1

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -40,8 +40,10 @@ configurations.configureEach {
                 name == "material-icons-core" || name == "material-icons-core-desktop" ||
                 name == "material") {
                 useVersion("1.7.3")
-            } else if (name == "material3") {
+            } else if (name == "material3" || name == "material3-desktop") {
                 useVersion(composeMaterial3Version)
+            } else if (name == "material-symbols" || name == "material-symbols-core") {
+                useVersion(composeVersion)
             } else {
                 useVersion(composeVersion)
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,8 @@ androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.9.6"
 androidx-testExt = "1.3.0"
 composeHotReload = "1.0.0"
-composeMultiplatform = "1.9.0"
-composeMaterial3 = "1.9.0-beta06"
+composeMultiplatform = "1.10.1"
+composeMaterial3 = "1.10.0-alpha05"
 junit = "4.13.2"
 kotlin = "2.2.20"
 kotlinx-coroutines = "1.10.2"
@@ -39,7 +39,7 @@ compose-material3 = { module = "org.jetbrains.compose.material3:material3", vers
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
-compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "composeMaterial3" }
+compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "composeMultiplatform" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 ktor-network = { module = "io.ktor:ktor-network", version.ref = "ktor" }


### PR DESCRIPTION
- 升级 composeMultiplatform: 1.9.0 → 1.10.1
- 升级 composeMaterial3: 1.9.0-beta06 → 1.10.0-alpha05