### PR TITLE
fix: Windows 防火墙检查优化和对话框显示改进

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
@@ -35,6 +35,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -172,7 +176,19 @@ fun DesktopHome(
         AlertDialog(
             onDismissRequest = { viewModel.dismissFirewallDialog() },
             title = { Text(strings.firewallTitle) },
-            text = { Text(strings.firewallMessage.replace("%d", state.pendingFirewallPort?.toString() ?: "")) },
+            text = { 
+                Column(
+                    modifier = Modifier
+                        .widthIn(min = 400.dp, max = 500.dp)
+                        .heightIn(max = 400.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    Text(
+                        text = strings.firewallMessage.replace("%d", state.pendingFirewallPort?.toString() ?: ""),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            },
             confirmButton = {
                 Button(onClick = { viewModel.confirmAddFirewallRule() }) {
                     Text(strings.firewallConfirm)

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -87,7 +89,19 @@ fun DesktopHomeEnhanced(
         AlertDialog(
             onDismissRequest = { viewModel.dismissFirewallDialog() },
             title = { Text(strings.firewallTitle) },
-            text = { Text(strings.firewallMessage.replace("%d", state.pendingFirewallPort?.toString() ?: "")) },
+            text = { 
+                Column(
+                    modifier = Modifier
+                        .widthIn(min = 400.dp, max = 500.dp)
+                        .heightIn(max = 400.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    Text(
+                        text = strings.firewallMessage.replace("%d", state.pendingFirewallPort?.toString() ?: ""),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            },
             confirmButton = { Button(onClick = { viewModel.confirmAddFirewallRule() }) { Text(strings.firewallConfirm) } },
             dismissButton = { TextButton(onClick = { viewModel.dismissFirewallDialog() }) { Text(strings.firewallDismiss) } }
         )

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
@@ -4,6 +4,8 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
 import com.lanrhyme.micyou.platform.FirewallManager
 import com.lanrhyme.micyou.platform.PlatformInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.net.InetAddress
 
 class JVMPlatform: Platform {
@@ -82,9 +84,19 @@ actual fun openUrl(url: String) {
     }
 }
 
-actual suspend fun isPortAllowed(port: Int, protocol: String): Boolean = FirewallManager.isPortAllowed(port)
-actual suspend fun addFirewallRule(port: Int, protocol: String): Result<Unit> = 
-    if (FirewallManager.addFirewallRule(port)) Result.success(Unit) else Result.failure(Exception("Failed to add firewall rule"))
+actual suspend fun isPortAllowed(port: Int, protocol: String): Boolean =
+    withContext(Dispatchers.IO) {
+        FirewallManager.isPortAllowed(port)
+    }
+
+actual suspend fun addFirewallRule(port: Int, protocol: String): Result<Unit> =
+    withContext(Dispatchers.IO) {
+        if (FirewallManager.addFirewallRule(port)) {
+            Result.success(Unit)
+        } else {
+            Result.failure(Exception("Failed to add firewall rule"))
+        }
+    }
 
 @Composable
 actual fun getDynamicColorScheme(isDark: Boolean): ColorScheme? {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/main.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/main.kt
@@ -133,14 +133,14 @@ fun main() {
 
         val windowState = rememberWindowState(
             width = if (pocketMode) 600.dp else 600.dp,
-            height = if (pocketMode) 240.dp else 550.dp,
+            height = if (pocketMode) 320.dp else 550.dp,
             position = WindowPosition(Alignment.Center)
         )
 
         LaunchedEffect(pocketMode) {
             windowState.size = androidx.compose.ui.unit.DpSize(
                 if (pocketMode) 600.dp else 1100.dp,
-                if (pocketMode) 240.dp else 650.dp
+                if (pocketMode) 320.dp else 650.dp
             )
         }
 


### PR DESCRIPTION
- 将防火墙检查移至 IO 线程以防止 UI 卡顿（5-8秒）
- 为确保显示（需要管理员权限）的文字显示增大了一下窗口