### PR TITLE
feat(build): 添加发布签名配置和ProGuard规则以优化APK大小

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -122,21 +122,21 @@ android {
         buildConfig = true
     }
     
+    val keystorePath = providers.environmentVariable("ANDROID_KEYSTORE_PATH").orNull
+    val keystorePassword = providers.environmentVariable("ANDROID_KEYSTORE_PASSWORD").orNull
+    val keyAlias = providers.environmentVariable("ANDROID_KEY_ALIAS").orNull
+    val keyPassword = providers.environmentVariable("ANDROID_KEY_PASSWORD").orNull
+    
     val hasReleaseSigning =
-        !System.getenv("ANDROID_KEYSTORE_PATH").isNullOrEmpty() &&
-        !System.getenv("ANDROID_KEYSTORE_PASSWORD").isNullOrEmpty() &&
-        !System.getenv("ANDROID_KEY_ALIAS").isNullOrEmpty() &&
-        !System.getenv("ANDROID_KEY_PASSWORD").isNullOrEmpty()
+        !keystorePath.isNullOrEmpty() &&
+        !keystorePassword.isNullOrEmpty() &&
+        !keyAlias.isNullOrEmpty() &&
+        !keyPassword.isNullOrEmpty()
 
     signingConfigs {
         create("release") {
-            val keystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
-            val keystorePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
-            val keyAlias = System.getenv("ANDROID_KEY_ALIAS")
-            val keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
-            
-            if (!keystorePath.isNullOrEmpty() && !keystorePassword.isNullOrEmpty()) {
-                storeFile = file(keystorePath)
+            if (hasReleaseSigning) {
+                storeFile = file(keystorePath!!)
                 storePassword = keystorePassword
                 this.keyAlias = keyAlias
                 this.keyPassword = keyPassword

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -122,6 +122,12 @@ android {
         buildConfig = true
     }
     
+    val hasReleaseSigning =
+        !System.getenv("ANDROID_KEYSTORE_PATH").isNullOrEmpty() &&
+        !System.getenv("ANDROID_KEYSTORE_PASSWORD").isNullOrEmpty() &&
+        !System.getenv("ANDROID_KEY_ALIAS").isNullOrEmpty() &&
+        !System.getenv("ANDROID_KEY_PASSWORD").isNullOrEmpty()
+
     signingConfigs {
         create("release") {
             val keystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
@@ -145,8 +151,16 @@ android {
     }
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = false
-            signingConfig = signingConfigs.getByName("release")
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+
+            if (hasReleaseSigning) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
     compileOptions {

--- a/composeApp/proguard-rules.pro
+++ b/composeApp/proguard-rules.pro
@@ -1,0 +1,38 @@
+# MicYou Android release shrink rules
+#
+# 目标：
+# 1) 保持宿主与外部插件(plugin.dex)之间的二进制兼容
+# 2) 尽量避免过宽 keep，保留 R8 压缩收益
+
+# 插件系统通过 DexClassLoader + manifest.mainClass 动态加载外部插件，
+# 外部插件编译期依赖 plugin-api 的完整符号名与方法签名。
+# 因此需要保留 plugin-api 对外 ABI（类名 + 成员签名）。
+-keep interface com.lanrhyme.micyou.plugin.Plugin { *; }
+-keep interface com.lanrhyme.micyou.plugin.PluginContext { *; }
+-keep interface com.lanrhyme.micyou.plugin.PluginHost { *; }
+-keep interface com.lanrhyme.micyou.plugin.PluginUIProvider { *; }
+-keep interface com.lanrhyme.micyou.plugin.PluginSettingsProvider { *; }
+-keep interface com.lanrhyme.micyou.plugin.AudioEffectPlugin { *; }
+-keep interface com.lanrhyme.micyou.plugin.AudioEffectProvider { *; }
+-keep interface com.lanrhyme.micyou.plugin.PluginDataChannel { *; }
+-keep interface com.lanrhyme.micyou.plugin.PluginDataChannelProvider { *; }
+-keep interface com.lanrhyme.micyou.plugin.PluginLocalization { *; }
+-keep interface com.lanrhyme.micyou.plugin.PluginLocalizationProvider { *; }
+
+-keep class com.lanrhyme.micyou.plugin.PluginManifest { *; }
+-keep class com.lanrhyme.micyou.plugin.PluginInfo { *; }
+-keep class com.lanrhyme.micyou.plugin.AudioConfig { *; }
+-keep class com.lanrhyme.micyou.plugin.ConnectionInfo { *; }
+-keep class com.lanrhyme.micyou.plugin.DataChannelConfig { *; }
+-keep class com.lanrhyme.micyou.plugin.PlatformInfo { *; }
+-keep class com.lanrhyme.micyou.plugin.PluginHost$PlatformInfo { *; }
+
+-keep enum com.lanrhyme.micyou.plugin.StreamState { *; }
+-keep enum com.lanrhyme.micyou.plugin.ConnectionMode { *; }
+-keep enum com.lanrhyme.micyou.plugin.NoiseReductionType { *; }
+-keep enum com.lanrhyme.micyou.plugin.PluginPlatform { *; }
+
+# 保留序列化/注解元数据（插件清单与协议对象使用 kotlinx.serialization）。
+-keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod
+
+# 可选：若第三方依赖在 release 下出现仅告警类缺失，再按需添加 dontwarn。

--- a/composeApp/proguard-rules.pro
+++ b/composeApp/proguard-rules.pro
@@ -24,15 +24,23 @@
 -keep class com.lanrhyme.micyou.plugin.AudioConfig { *; }
 -keep class com.lanrhyme.micyou.plugin.ConnectionInfo { *; }
 -keep class com.lanrhyme.micyou.plugin.DataChannelConfig { *; }
--keep class com.lanrhyme.micyou.plugin.PlatformInfo { *; }
 -keep class com.lanrhyme.micyou.plugin.PluginHost$PlatformInfo { *; }
+-keep class com.lanrhyme.micyou.plugin.PluginDataChannel$ReceivedPacket { *; }
 
 -keep enum com.lanrhyme.micyou.plugin.StreamState { *; }
 -keep enum com.lanrhyme.micyou.plugin.ConnectionMode { *; }
 -keep enum com.lanrhyme.micyou.plugin.NoiseReductionType { *; }
 -keep enum com.lanrhyme.micyou.plugin.PluginPlatform { *; }
+-keep enum com.lanrhyme.micyou.plugin.DataChannelMode { *; }
+-keep enum com.lanrhyme.micyou.plugin.MobileUIMode { *; }
 
 # 保留序列化/注解元数据（插件清单与协议对象使用 kotlinx.serialization）。
 -keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod
+
+# 保留 kotlinx.serialization 生成的成员，避免序列化异常。
+-keepclassmembers class * {
+    *** Companion;
+    *** $serializer;
+}
 
 # 可选：若第三方依赖在 release 下出现仅告警类缺失，再按需添加 dontwarn。


### PR DESCRIPTION
rt

---

This pull request improves the Android release build process by enabling code shrinking and resource shrinking, and by adding ProGuard rules to ensure binary compatibility for the plugin system. It also makes release signing conditional on the presence of environment variables.

**Release build optimizations:**

* Enabled code shrinking (`isMinifyEnabled = true`) and resource shrinking (`isShrinkResources = true`) for the `release` build type, and configured ProGuard with a new rules file (`proguard-rules.pro`).
* Added a comprehensive `proguard-rules.pro` file to keep plugin API interfaces, classes, and enums required for dynamic plugin loading, and to preserve serialization/annotation metadata.

**Release signing improvements:**

* Made release signing conditional: the release signing configuration is only applied if all required environment variables are set, improving build flexibility and security. [[1]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aR125-R130) [[2]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aL148-R165)