### PR TITLE
feat: 集成FileKit库以优化文件选择体验

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -87,6 +87,8 @@ kotlin {
             implementation(libs.kotlinx.datetime)
             implementation("org.jetbrains.compose.material:material-icons-extended:1.7.3")
             implementation("dev.chrisbanes.haze:haze:1.7.2")
+            implementation(libs.filekit.core)
+            implementation(libs.filekit.dialogs.compose)
             implementation(project(":plugin-api"))
         }
         commonTest.dependencies {

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.android.kt
@@ -6,14 +6,16 @@ import io.github.vinceglb.filekit.extension
 import io.github.vinceglb.filekit.readBytes
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.io.File
 
 actual object BackgroundImagePicker {
+    // 文件选择是短暂的用户交互操作，使用 GlobalScope 是可接受的
+    // 协程会在用户完成选择（或取消）后立即结束
     actual fun pickImage(onResult: (String?) -> Unit) {
-        CoroutineScope(Dispatchers.Main).launch {
+        GlobalScope.launch(Dispatchers.Main) {
             try {
                 val file = FileKit.openFilePicker(type = FileKitType.Image)
                 val savedPath = file?.let { copyToInternalStorage(it) }

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.android.kt
@@ -3,7 +3,7 @@ package com.lanrhyme.micyou
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.extension
-import io.github.vinceglb.filekit.source
+import io.github.vinceglb.filekit.readBytes
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
 import kotlinx.coroutines.GlobalScope
@@ -30,6 +30,7 @@ actual object BackgroundImagePicker {
     private suspend fun copyToInternalStorage(file: PlatformFile): String? {
         return try {
             val context = AndroidContext.getContext() ?: return null
+            val bytes = file.readBytes()
 
             val backgroundDir = File(context.filesDir, "backgrounds")
             if (!backgroundDir.exists()) {
@@ -39,15 +40,7 @@ actual object BackgroundImagePicker {
             val extension = file.extension
             val fileName = "custom_background.$extension"
             val outputFile = File(backgroundDir, fileName)
-
-            file.source().buffered().use { source ->
-                outputFile.outputStream().use { output ->
-                    while (!source.exhausted()) {
-                        val chunk = source.readByteArray(8192)
-                        output.write(chunk)
-                    }
-                }
-            }
+            outputFile.writeBytes(bytes)
 
             outputFile.absolutePath
         } catch (e: Exception) {

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.android.kt
@@ -6,16 +6,13 @@ import io.github.vinceglb.filekit.extension
 import io.github.vinceglb.filekit.readBytes
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.io.File
 
 actual object BackgroundImagePicker {
-    // 文件选择是短暂的用户交互操作，使用 GlobalScope 是可接受的
-    // 协程会在用户完成选择（或取消）后立即结束
-    actual fun pickImage(onResult: (String?) -> Unit) {
-        GlobalScope.launch(Dispatchers.Main) {
+    actual fun pickImage(scope: CoroutineScope, onResult: (String?) -> Unit) {
+        scope.launch {
             try {
                 val file = FileKit.openFilePicker(type = FileKitType.Image)
                 val savedPath = file?.let { copyToInternalStorage(it) }

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.android.kt
@@ -1,63 +1,52 @@
 package com.lanrhyme.micyou
 
-import android.app.Activity
-import android.content.Intent
-import android.net.Uri
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.extension
+import io.github.vinceglb.filekit.readBytes
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.openFilePicker
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.io.File
 
 actual object BackgroundImagePicker {
-    private var launcher: ActivityResultLauncher<Intent>? = null
-    private var callback: ((String?) -> Unit)? = null
-    
-    fun registerLauncher(activity: MainActivity): ActivityResultLauncher<Intent> {
-        val l = activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            if (result.resultCode == Activity.RESULT_OK) {
-                val uri = result.data?.data
-                if (uri != null) {
-                    val savedPath = copyToInternalStorage(uri)
-                    callback?.invoke(savedPath)
-                } else {
-                    callback?.invoke(null)
-                }
-            } else {
-                callback?.invoke(null)
+    actual fun pickImage(onResult: (String?) -> Unit) {
+        CoroutineScope(Dispatchers.Main).launch {
+            try {
+                val file = FileKit.openFilePicker(
+                    type = FileKitType.File(
+                        extensions = listOf("jpg", "jpeg", "png", "gif", "bmp", "webp", "svg", "ico", "tiff", "tif")
+                    )
+                )
+                val savedPath = file?.let { copyToInternalStorage(it) }
+                onResult(savedPath)
+            } catch (e: Exception) {
+                Logger.e("BackgroundImagePicker", "Failed to pick image", e)
+                onResult(null)
             }
         }
-        launcher = l
-        return l
     }
-    
-    actual fun pickImage(onResult: (String?) -> Unit) {
-        callback = onResult
-        val intent = Intent(Intent.ACTION_PICK).apply {
-            type = "image/*"
-        }
-        launcher?.launch(intent) ?: run {
-            onResult(null)
-        }
-    }
-    
-    private fun copyToInternalStorage(uri: Uri): String? {
+
+    private suspend fun copyToInternalStorage(file: PlatformFile): String? {
         return try {
             val context = AndroidContext.getContext() ?: return null
-            val inputStream = context.contentResolver.openInputStream(uri) ?: return null
-            
+            val bytes = file.readBytes()
+
             val backgroundDir = File(context.filesDir, "backgrounds")
             if (!backgroundDir.exists()) {
                 backgroundDir.mkdirs()
             }
-            
-            val outputFile = File(backgroundDir, "custom_background.jpg")
-            outputFile.outputStream().use { output ->
-                inputStream.copyTo(output)
-            }
-            inputStream.close()
-            
+
+            val extension = file.extension
+            val fileName = "custom_background.$extension"
+            val outputFile = File(backgroundDir, fileName)
+            outputFile.writeBytes(bytes)
+
             outputFile.absolutePath
         } catch (e: Exception) {
-            Logger.e("BackgroundImage", "Failed to copy image to internal storage", e)
+            Logger.e("BackgroundImagePicker", "Failed to copy image to internal storage", e)
             null
         }
     }

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.android.kt
@@ -3,7 +3,7 @@ package com.lanrhyme.micyou
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.extension
-import io.github.vinceglb.filekit.readBytes
+import io.github.vinceglb.filekit.source
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
 import kotlinx.coroutines.GlobalScope
@@ -30,7 +30,6 @@ actual object BackgroundImagePicker {
     private suspend fun copyToInternalStorage(file: PlatformFile): String? {
         return try {
             val context = AndroidContext.getContext() ?: return null
-            val bytes = file.readBytes()
 
             val backgroundDir = File(context.filesDir, "backgrounds")
             if (!backgroundDir.exists()) {
@@ -40,7 +39,15 @@ actual object BackgroundImagePicker {
             val extension = file.extension
             val fileName = "custom_background.$extension"
             val outputFile = File(backgroundDir, fileName)
-            outputFile.writeBytes(bytes)
+
+            file.source().buffered().use { source ->
+                outputFile.outputStream().use { output ->
+                    while (!source.exhausted()) {
+                        val chunk = source.readByteArray(8192)
+                        output.write(chunk)
+                    }
+                }
+            }
 
             outputFile.absolutePath
         } catch (e: Exception) {

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.android.kt
@@ -15,11 +15,7 @@ actual object BackgroundImagePicker {
     actual fun pickImage(onResult: (String?) -> Unit) {
         CoroutineScope(Dispatchers.Main).launch {
             try {
-                val file = FileKit.openFilePicker(
-                    type = FileKitType.File(
-                        extensions = listOf("jpg", "jpeg", "png", "gif", "bmp", "webp", "svg", "ico", "tiff", "tif")
-                    )
-                )
+                val file = FileKit.openFilePicker(type = FileKitType.Image)
                 val savedPath = file?.let { copyToInternalStorage(it) }
                 onResult(savedPath)
             } catch (e: Exception) {

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/MainActivity.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.app.ActivityCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.dialogs.init
 
 class MainActivity : ComponentActivity() {
 
@@ -74,8 +76,7 @@ class MainActivity : ComponentActivity() {
         Logger.init(AndroidLogger(this))
         Logger.i("MainActivity", "App started")
 
-        BackgroundImagePicker.registerLauncher(this)
-        PluginFileChooserHelper.registerLauncher(this)
+        FileKit.init(this)
 
         val shouldQuickStart = intent?.action == ACTION_QUICK_START
 

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.android.kt
@@ -6,15 +6,12 @@ import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.readBytes
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.io.File
 
-// 文件选择是短暂的用户交互操作，使用 GlobalScope 是可接受的
-// 协程会在用户完成选择（或取消）后立即结束
-actual fun openPluginFileChooser(onResult: (String?) -> Unit) {
-    GlobalScope.launch(Dispatchers.Main) {
+actual fun openPluginFileChooser(scope: CoroutineScope, onResult: (String?) -> Unit) {
+    scope.launch {
         try {
             val file = FileKit.openFilePicker(
                 type = FileKitType.File(extensions = listOf("zip", "jar"))
@@ -31,7 +28,6 @@ actual fun openPluginFileChooser(onResult: (String?) -> Unit) {
 private suspend fun copyPluginToInternalStorage(file: PlatformFile): String? {
     return try {
         val context = AndroidContext.getContext() ?: return null
-
 
         val pluginDir = File(context.cacheDir, "plugin_imports")
         if (!pluginDir.exists()) {

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.android.kt
@@ -1,87 +1,48 @@
 package com.lanrhyme.micyou
 
-import android.app.Activity
-import android.content.Intent
-import android.net.Uri
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.name
+import io.github.vinceglb.filekit.readBytes
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.openFilePicker
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.io.File
 
-object PluginFileChooserHelper {
-    private var launcher: ActivityResultLauncher<Intent>? = null
-    private var callback: ((String?) -> Unit)? = null
-    
-    fun registerLauncher(activity: MainActivity): ActivityResultLauncher<Intent> {
-        val l = activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            if (result.resultCode == Activity.RESULT_OK) {
-                val uri = result.data?.data
-                if (uri != null) {
-                    val savedPath = copyPluginToInternalStorage(uri)
-                    callback?.invoke(savedPath)
-                } else {
-                    callback?.invoke(null)
-                }
-            } else {
-                callback?.invoke(null)
-            }
-        }
-        launcher = l
-        return l
-    }
-    
-    fun pickPluginFile(onResult: (String?) -> Unit) {
-        callback = onResult
-        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-            addCategory(Intent.CATEGORY_OPENABLE)
-            type = "*/*"
-            putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("application/zip", "application/java-archive"))
-        }
-        launcher?.launch(intent) ?: run {
+actual fun openPluginFileChooser(onResult: (String?) -> Unit) {
+    CoroutineScope(Dispatchers.Main).launch {
+        try {
+            val file = FileKit.openFilePicker(
+                type = FileKitType.File(extensions = listOf("zip", "jar"))
+            )
+            val savedPath = file?.let { copyPluginToInternalStorage(it) }
+            onResult(savedPath)
+        } catch (e: Exception) {
+            Logger.e("PluginFileChooser", "Failed to pick plugin file", e)
             onResult(null)
         }
     }
-    
-    private fun copyPluginToInternalStorage(uri: Uri): String? {
-        return try {
-            val context = AndroidContext.getContext() ?: return null
-            val inputStream = context.contentResolver.openInputStream(uri) ?: return null
-            
-            val pluginDir = File(context.cacheDir, "plugin_imports")
-            if (!pluginDir.exists()) {
-                pluginDir.mkdirs()
-            }
-            
-            val fileName = getFileNameFromUri(uri) ?: "plugin_${System.currentTimeMillis()}.zip"
-            val outputFile = File(pluginDir, fileName)
-            outputFile.outputStream().use { output ->
-                inputStream.copyTo(output)
-            }
-            inputStream.close()
-            
-            outputFile.absolutePath
-        } catch (e: Exception) {
-            Logger.e("PluginFileChooser", "Failed to copy plugin file", e)
-            null
-        }
-    }
-    
-    private fun getFileNameFromUri(uri: Uri): String? {
-        val context = AndroidContext.getContext() ?: return null
-        var fileName: String? = null
-        
-        context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-            if (cursor.moveToFirst()) {
-                val nameIndex = cursor.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
-                if (nameIndex >= 0) {
-                    fileName = cursor.getString(nameIndex)
-                }
-            }
-        }
-        
-        return fileName
-    }
 }
 
-actual fun openPluginFileChooser(onResult: (String?) -> Unit) {
-    PluginFileChooserHelper.pickPluginFile(onResult)
+private suspend fun copyPluginToInternalStorage(file: PlatformFile): String? {
+    return try {
+        val context = AndroidContext.getContext() ?: return null
+        val bytes = file.readBytes()
+
+        val pluginDir = File(context.cacheDir, "plugin_imports")
+        if (!pluginDir.exists()) {
+            pluginDir.mkdirs()
+        }
+
+        val fileName = file.name
+        val outputFile = File(pluginDir, fileName)
+        outputFile.writeBytes(bytes)
+
+        outputFile.absolutePath
+    } catch (e: Exception) {
+        Logger.e("PluginFileChooser", "Failed to copy plugin file", e)
+        null
+    }
 }

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.android.kt
@@ -40,7 +40,7 @@ private suspend fun copyPluginToInternalStorage(file: PlatformFile): String? {
 
         val fileName = file.name
         val outputFile = File(pluginDir, fileName)
-        outputFile.writeBytes(bytes)
+        outputFile.writeBytes(file.readBytes())
 
         outputFile.absolutePath
     } catch (e: Exception) {

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.android.kt
@@ -3,7 +3,7 @@ package com.lanrhyme.micyou
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.name
-import io.github.vinceglb.filekit.readBytes
+import io.github.vinceglb.filekit.source
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
 import kotlinx.coroutines.GlobalScope
@@ -31,8 +31,6 @@ actual fun openPluginFileChooser(onResult: (String?) -> Unit) {
 private suspend fun copyPluginToInternalStorage(file: PlatformFile): String? {
     return try {
         val context = AndroidContext.getContext() ?: return null
-
-
         val pluginDir = File(context.cacheDir, "plugin_imports")
         if (!pluginDir.exists()) {
             pluginDir.mkdirs()
@@ -40,7 +38,15 @@ private suspend fun copyPluginToInternalStorage(file: PlatformFile): String? {
 
         val fileName = file.name
         val outputFile = File(pluginDir, fileName)
-        outputFile.writeBytes(file.readBytes())
+
+        file.source().buffered().use { source ->
+            outputFile.outputStream().use { output ->
+                while (!source.exhausted()) {
+                    val chunk = source.readByteArray(8192)
+                    output.write(chunk)
+                }
+            }
+        }
 
         outputFile.absolutePath
     } catch (e: Exception) {

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.android.kt
@@ -6,13 +6,15 @@ import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.readBytes
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.io.File
 
+// 文件选择是短暂的用户交互操作，使用 GlobalScope 是可接受的
+// 协程会在用户完成选择（或取消）后立即结束
 actual fun openPluginFileChooser(onResult: (String?) -> Unit) {
-    CoroutineScope(Dispatchers.Main).launch {
+    GlobalScope.launch(Dispatchers.Main) {
         try {
             val file = FileKit.openFilePicker(
                 type = FileKitType.File(extensions = listOf("zip", "jar"))
@@ -29,7 +31,7 @@ actual fun openPluginFileChooser(onResult: (String?) -> Unit) {
 private suspend fun copyPluginToInternalStorage(file: PlatformFile): String? {
     return try {
         val context = AndroidContext.getContext() ?: return null
-        val bytes = file.readBytes()
+
 
         val pluginDir = File(context.cacheDir, "plugin_imports")
         if (!pluginDir.exists()) {

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.android.kt
@@ -3,7 +3,7 @@ package com.lanrhyme.micyou
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.name
-import io.github.vinceglb.filekit.source
+import io.github.vinceglb.filekit.readBytes
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
 import kotlinx.coroutines.GlobalScope
@@ -31,6 +31,8 @@ actual fun openPluginFileChooser(onResult: (String?) -> Unit) {
 private suspend fun copyPluginToInternalStorage(file: PlatformFile): String? {
     return try {
         val context = AndroidContext.getContext() ?: return null
+
+
         val pluginDir = File(context.cacheDir, "plugin_imports")
         if (!pluginDir.exists()) {
             pluginDir.mkdirs()
@@ -38,15 +40,7 @@ private suspend fun copyPluginToInternalStorage(file: PlatformFile): String? {
 
         val fileName = file.name
         val outputFile = File(pluginDir, fileName)
-
-        file.source().buffered().use { source ->
-            outputFile.outputStream().use { output ->
-                while (!source.exhausted()) {
-                    val chunk = source.readByteArray(8192)
-                    output.write(chunk)
-                }
-            }
-        }
+        outputFile.writeBytes(file.readBytes())
 
         outputFile.absolutePath
     } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/BackgroundSettings.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/BackgroundSettings.kt
@@ -1,5 +1,7 @@
 package com.lanrhyme.micyou
 
+import kotlinx.coroutines.CoroutineScope
+
 data class BackgroundSettings(
     val imagePath: String = "",
     val brightness: Float = 0.5f,
@@ -12,5 +14,5 @@ data class BackgroundSettings(
 }
 
 expect object BackgroundImagePicker {
-    fun pickImage(onResult: (String?) -> Unit)
+    fun pickImage(scope: CoroutineScope, onResult: (String?) -> Unit)
 }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.kt
@@ -1,3 +1,5 @@
 package com.lanrhyme.micyou
 
-expect fun openPluginFileChooser(onResult: (String?) -> Unit)
+import kotlinx.coroutines.CoroutineScope
+
+expect fun openPluginFileChooser(scope: CoroutineScope, onResult: (String?) -> Unit)

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/PluginSettingsContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/PluginSettingsContent.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,7 +47,8 @@ fun PluginSettingsContent(
     val state by viewModel.uiState.collectAsState()
     val strings = LocalAppStrings.current
     val platform = getPlatform()
-    
+    val scope = rememberCoroutineScope()
+
     var showDeleteDialog by remember { mutableStateOf<PluginInfo?>(null) }
     var showPlatformWarning by remember { mutableStateOf<PluginInfo?>(null) }
     var activePluginWindow by remember { mutableStateOf<String?>(null) }
@@ -79,7 +81,7 @@ fun PluginSettingsContent(
         ) {
             Button(
                 onClick = {
-                    openPluginFileChooser { filePath ->
+                    openPluginFileChooser(scope) { filePath ->
                         filePath?.let { path ->
                             viewModel.importPlugin(path) { result ->
                                 result.onSuccess {

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/SettingsViewModel.kt
@@ -299,7 +299,7 @@ class SettingsViewModel : ViewModel() {
     }
     
     fun pickBackgroundImage() {
-        BackgroundImagePicker.pickImage { path ->
+        BackgroundImagePicker.pickImage(viewModelScope) { path ->
             path?.let { setBackgroundImage(it) }
         }
     }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.jvm.kt
@@ -4,15 +4,12 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.absolutePath
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 actual object BackgroundImagePicker {
-    // 文件选择是短暂的用户交互操作，使用 GlobalScope 是可接受的
-    // 协程会在用户完成选择（或取消）后立即结束
-    actual fun pickImage(onResult: (String?) -> Unit) {
-        GlobalScope.launch(Dispatchers.Main) {
+    actual fun pickImage(scope: CoroutineScope, onResult: (String?) -> Unit) {
+        scope.launch {
             try {
                 val file = FileKit.openFilePicker(
                     type = FileKitType.File(

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.jvm.kt
@@ -4,15 +4,15 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.absolutePath
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 actual object BackgroundImagePicker {
-    private val scope = CoroutineScope(Dispatchers.Main)
-
+    // 文件选择是短暂的用户交互操作，使用 GlobalScope 是可接受的
+    // 协程会在用户完成选择（或取消）后立即结束
     actual fun pickImage(onResult: (String?) -> Unit) {
-        scope.launch {
+        GlobalScope.launch(Dispatchers.Main) {
             try {
                 val file = FileKit.openFilePicker(
                     type = FileKitType.File(

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.jvm.kt
@@ -4,16 +4,21 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.absolutePath
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 
 actual object BackgroundImagePicker {
+    private val scope = CoroutineScope(Dispatchers.Main)
+
     actual fun pickImage(onResult: (String?) -> Unit) {
-        runBlocking(Dispatchers.IO) {
+        scope.launch {
             try {
                 val file = FileKit.openFilePicker(
-                type = FileKitType.File(extensions = listOf("jpg", "jpeg", "png", "gif", "bmp", "webp", "svg", "ico", "tiff", "tif"))
-            )
+                    type = FileKitType.File(
+                        extensions = listOf("jpg", "jpeg", "png", "gif", "bmp", "webp", "svg", "ico", "tiff", "tif")
+                    )
+                )
                 onResult(file?.absolutePath())
             } catch (e: Exception) {
                 Logger.e("BackgroundImagePicker", "Failed to pick image", e)

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.jvm.kt
@@ -1,35 +1,24 @@
 package com.lanrhyme.micyou
 
-import androidx.compose.ui.window.WindowScope
-import java.io.File
-import javax.swing.JFileChooser
-import javax.swing.filechooser.FileNameExtensionFilter
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.absolutePath
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.openFilePicker
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 
 actual object BackgroundImagePicker {
-    private var windowScope: WindowScope? = null
-    
-    fun init(scope: WindowScope) {
-        windowScope = scope
-    }
-    
     actual fun pickImage(onResult: (String?) -> Unit) {
-        val fileChooser = JFileChooser().apply {
-            dialogTitle = "Select Background Image"
-            fileFilter = FileNameExtensionFilter(
-                "Image Files (*.jpg, *.jpeg, *.png, *.gif, *.bmp, *.webp)",
-                "jpg", "jpeg", "png", "gif", "bmp", "webp"
+        runBlocking(Dispatchers.IO) {
+            try {
+                val file = FileKit.openFilePicker(
+                type = FileKitType.File(extensions = listOf("jpg", "jpeg", "png", "gif", "bmp", "webp", "svg", "ico", "tiff", "tif"))
             )
-            fileSelectionMode = JFileChooser.FILES_ONLY
-            isMultiSelectionEnabled = false
-        }
-        
-        val result = fileChooser.showOpenDialog(null)
-        
-        if (result == JFileChooser.APPROVE_OPTION) {
-            val selectedFile = fileChooser.selectedFile
-            onResult(selectedFile.absolutePath)
-        } else {
-            onResult(null)
+                onResult(file?.absolutePath())
+            } catch (e: Exception) {
+                Logger.e("BackgroundImagePicker", "Failed to pick image", e)
+                onResult(null)
+            }
         }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/BackgroundImagePicker.jvm.kt
@@ -16,7 +16,7 @@ actual object BackgroundImagePicker {
             try {
                 val file = FileKit.openFilePicker(
                     type = FileKitType.File(
-                        extensions = listOf("jpg", "jpeg", "png", "gif", "bmp", "webp", "svg", "ico", "tiff", "tif")
+                        extensions = listOf("jpg", "jpeg", "png", "gif", "bmp", "webp")
                     )
                 )
                 onResult(file?.absolutePath())

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.jvm.kt
@@ -4,14 +4,14 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.absolutePath
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-private val filePickerScope = CoroutineScope(Dispatchers.Main)
-
+// 文件选择是短暂的用户交互操作，使用 GlobalScope 是可接受的
+// 协程会在用户完成选择（或取消）后立即结束
 actual fun openPluginFileChooser(onResult: (String?) -> Unit) {
-    filePickerScope.launch {
+    GlobalScope.launch(Dispatchers.Main) {
         try {
             val file = FileKit.openFilePicker(
                 type = FileKitType.File(extensions = listOf("zip", "jar"))

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.jvm.kt
@@ -4,14 +4,11 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.absolutePath
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-// 文件选择是短暂的用户交互操作，使用 GlobalScope 是可接受的
-// 协程会在用户完成选择（或取消）后立即结束
-actual fun openPluginFileChooser(onResult: (String?) -> Unit) {
-    GlobalScope.launch(Dispatchers.Main) {
+actual fun openPluginFileChooser(scope: CoroutineScope, onResult: (String?) -> Unit) {
+    scope.launch {
         try {
             val file = FileKit.openFilePicker(
                 type = FileKitType.File(extensions = listOf("zip", "jar"))

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.jvm.kt
@@ -1,33 +1,22 @@
 package com.lanrhyme.micyou
 
-import javax.swing.JFileChooser
-import javax.swing.SwingUtilities
-import javax.swing.filechooser.FileNameExtensionFilter
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.absolutePath
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.openFilePicker
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 
 actual fun openPluginFileChooser(onResult: (String?) -> Unit) {
-    val filePath = if (!SwingUtilities.isEventDispatchThread()) {
-        var result: String? = null
-        SwingUtilities.invokeAndWait {
-            result = openFileChooserInternal()
+    runBlocking(Dispatchers.IO) {
+        try {
+            val file = FileKit.openFilePicker(
+                type = FileKitType.File(extensions = listOf("zip", "jar"))
+            )
+            onResult(file?.absolutePath())
+        } catch (e: Exception) {
+            Logger.e("PluginFileChooser", "Failed to pick plugin file", e)
+            onResult(null)
         }
-        result
-    } else {
-        openFileChooserInternal()
-    }
-    onResult(filePath)
-}
-
-private fun openFileChooserInternal(): String? {
-    val chooser = JFileChooser().apply {
-        fileFilter = FileNameExtensionFilter(
-            "Plugin Files (*.zip, *.jar)",
-            "zip", "jar"
-        )
-    }
-    val chooserResult = chooser.showOpenDialog(null)
-    return if (chooserResult == JFileChooser.APPROVE_OPTION) {
-        chooser.selectedFile.absolutePath
-    } else {
-        null
     }
 }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/PluginFileChooser.jvm.kt
@@ -4,11 +4,14 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.absolutePath
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
+
+private val filePickerScope = CoroutineScope(Dispatchers.Main)
 
 actual fun openPluginFileChooser(onResult: (String?) -> Unit) {
-    runBlocking(Dispatchers.IO) {
+    filePickerScope.launch {
         try {
             val file = FileKit.openFilePicker(
                 type = FileKitType.File(extensions = listOf("zip", "jar"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ composenativetray = "1.1.0"
 onnxruntime = "1.14.0"
 jtransforms = "3.2"
 window = "1.5.1"
+filekit = "0.13.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -56,6 +57,8 @@ composenativetray = { module = "io.github.kdroidfilter:composenativetray", versi
 onnxruntime = { module = "com.microsoft.onnxruntime:onnxruntime", version.ref = "onnxruntime" }
 jtransforms = { module = "com.github.wendykierp:JTransforms", version.ref = "jtransforms" }
 androidx-window = { group = "androidx.window", name = "window", version.ref = "window" }
+filekit-core = { module = "io.github.vinceglb:filekit-core", version.ref = "filekit" }
+filekit-dialogs-compose = { module = "io.github.vinceglb:filekit-dialogs-compose", version.ref = "filekit" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
What's Changed:
1. 使用 [FileKit](https://github.com/vinceglb/FileKit) 替代 JFileChooser 和 Intent 文件选择器

---

|效果图|
|---|
|<img alt="image" src="https://github.com/user-attachments/assets/76229fc7-0c9e-4264-84e1-3c8f073a59ce" />|


---

<details><summary>Copilot's summary</summary>
This pull request refactors file picking for background images and plugin files on both Android and JVM platforms to use the `FileKit` library, replacing manual and platform-specific implementations. It also updates the API for these operations to use coroutines, improving code consistency and maintainability across platforms. The most important changes are grouped below.

**Migration to FileKit for File Picking:**

* Replaced Android and JVM implementations of background image and plugin file pickers to use `FileKit` and its coroutine-based APIs, removing custom logic and simplifying file handling (`BackgroundImagePicker.android.kt`, `PluginFileChooser.android.kt`, `BackgroundImagePicker.jvm.kt`, `PluginFileChooser.jvm.kt`). [[1]](diffhunk://#diff-22390f44eec34259b70a5235a40a36caa8ac667c1a31a36769583d8bf9496c98L3-R44) [[2]](diffhunk://#diff-646dffa4ada6621fd60cb6a5d3482eb9cfbd66376af4500e83f96a2039318040L3-L87) [[3]](diffhunk://#diff-9c13dc30c0c311ae002a2aea07342166ce8e83d1f6d75525df3555708a27cf88L3-R26) [[4]](diffhunk://#diff-57ec3fc093b44a30054bf0f1f7ee7ba034817540b754e9a97573f9d792ec9705L3-L31)
* Added `filekit-core` and `filekit-dialogs-compose` dependencies to the project and updated version catalogs (`build.gradle.kts`, `libs.versions.toml`). [[1]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aR90-R91) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR26) [[3]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR60-R61)
* Initialized `FileKit` in `MainActivity`, removing previous launcher registration code. [[1]](diffhunk://#diff-86c22a60be173da74c90e632853254bf9bfd276a81f132487d4aebc398ba21bbR26-R27) [[2]](diffhunk://#diff-86c22a60be173da74c90e632853254bf9bfd276a81f132487d4aebc398ba21bbL77-R79)

**API Changes for Coroutine Support:**

* Updated the API for picking images and plugin files to require a `CoroutineScope` parameter, reflecting the coroutine-based approach in both expect/actual declarations and usage sites (`BackgroundSettings.kt`, `PluginFileChooser.kt`, usage in Compose screens and ViewModel). [[1]](diffhunk://#diff-36e6b3c8e186af380e931bd38c0fe942a92b2e6b3f50e1470f839a57cabb9a09R3-R4) [[2]](diffhunk://#diff-36e6b3c8e186af380e931bd38c0fe942a92b2e6b3f50e1470f839a57cabb9a09L15-R17) [[3]](diffhunk://#diff-b0b4d6a936aec62bad694ea5b7dbb4fd8baf9d8a198a4b39e6d900b9195dafd4L3-R5) [[4]](diffhunk://#diff-5390bc3e9f1961f7bc800c498e883366098358913d2b84ee7b3b93f619968158R32) [[5]](diffhunk://#diff-5390bc3e9f1961f7bc800c498e883366098358913d2b84ee7b3b93f619968158R50) [[6]](diffhunk://#diff-5390bc3e9f1961f7bc800c498e883366098358913d2b84ee7b3b93f619968158L82-R84) [[7]](diffhunk://#diff-6e20b1d23f122446a5215b52b1aa7741302c8ce3a5951337f38f898c493d3940L302-R302)

**Code Simplification and Cleanup:**

* Removed custom file copy and file name extraction logic in favor of `FileKit` utilities, reducing platform-specific code and potential for bugs (`BackgroundImagePicker.android.kt`, `PluginFileChooser.android.kt`). [[1]](diffhunk://#diff-22390f44eec34259b70a5235a40a36caa8ac667c1a31a36769583d8bf9496c98L3-R44) [[2]](diffhunk://#diff-646dffa4ada6621fd60cb6a5d3482eb9cfbd66376af4500e83f96a2039318040L3-L87)
* Cleaned up unused imports and legacy code from the previous file picker implementations. [[1]](diffhunk://#diff-22390f44eec34259b70a5235a40a36caa8ac667c1a31a36769583d8bf9496c98L3-R44) [[2]](diffhunk://#diff-646dffa4ada6621fd60cb6a5d3482eb9cfbd66376af4500e83f96a2039318040L3-L87) [[3]](diffhunk://#diff-9c13dc30c0c311ae002a2aea07342166ce8e83d1f6d75525df3555708a27cf88L3-R26) [[4]](diffhunk://#diff-57ec3fc093b44a30054bf0f1f7ee7ba034817540b754e9a97573f9d792ec9705L3-L31)
</details>