### PR TITLE
fix(ui): 修复若干 UI 问题

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/Platform.android.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
@@ -52,12 +53,15 @@ actual fun getDynamicColorScheme(isDark: Boolean, paletteStyle: PaletteStyle): C
         // 先获取 Android 原生动态颜色方案
         val nativeScheme = if (isDark) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
 
-        // 从原生方案中提取 primary 作为 seed color
-        val seedColor = nativeScheme.primary
-        Logger.d("Platform", "Using Android dynamic primary as seed: ${seedColor.toArgb()}")
+        // 使用 remember 缓存生成的配色方案，仅在参数变化时重新计算
+        return remember(nativeScheme, isDark, paletteStyle) {
+            // 从原生方案中提取 primary 作为 seed color
+            val seedColor = nativeScheme.primary
+            Logger.d("Platform", "Using Android dynamic primary as seed: ${seedColor.toArgb()}")
 
-        // 使用用户选择的 paletteStyle 重新生成配色方案
-        return dynamicColorScheme(seedColor, isDark, paletteStyle)
+            // 使用用户选择的 paletteStyle 重新生成配色方案
+            dynamicColorScheme(seedColor, isDark, paletteStyle)
+        }
     }
     return null
 }

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/Platform.android.kt
@@ -7,7 +7,11 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import com.lanrhyme.micyou.theme.PaletteStyle
+import com.lanrhyme.micyou.theme.dynamicColorScheme
 
 class AndroidPlatform : Platform {
     override val name: String = "Android ${Build.VERSION.SDK_INT}"
@@ -42,10 +46,18 @@ actual suspend fun isPortAllowed(port: Int, protocol: String): Boolean = true
 actual suspend fun addFirewallRule(port: Int, protocol: String): Result<Unit> = Result.success(Unit)
 
 @Composable
-actual fun getDynamicColorScheme(isDark: Boolean): ColorScheme? {
+actual fun getDynamicColorScheme(isDark: Boolean, paletteStyle: PaletteStyle): ColorScheme? {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         val context = LocalContext.current
-        return if (isDark) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        // 先获取 Android 原生动态颜色方案
+        val nativeScheme = if (isDark) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+
+        // 从原生方案中提取 primary 作为 seed color
+        val seedColor = nativeScheme.primary
+        Logger.d("Platform", "Using Android dynamic primary as seed: ${seedColor.toArgb()}")
+
+        // 使用用户选择的 paletteStyle 重新生成配色方案
+        return dynamicColorScheme(seedColor, isDark, paletteStyle)
     }
     return null
 }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
@@ -507,7 +507,7 @@ private fun NetworkConfigCard(
                         value = state.port,
                         onValueChange = { viewModel.setPort(it) },
                         label = { Text(strings.portLabel) },
-                        modifier = Modifier.fillMaxWidth().height(60.dp),
+                        modifier = Modifier.fillMaxWidth().heightIn(min = 60.dp),
                         textStyle = MaterialTheme.typography.bodySmall,
                         singleLine = true,
                         shape = MaterialTheme.shapes.medium

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
@@ -371,7 +371,7 @@ private fun NetworkConfigCard(
 
     Column(
         modifier = Modifier.padding(10.dp).fillMaxSize(),
-        verticalArrangement = Arrangement.SpaceBetween
+        verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             AnimatedVisibility(
@@ -388,7 +388,7 @@ private fun NetworkConfigCard(
                     color = MaterialTheme.colorScheme.primary
                 )
             }
-            
+
             AnimatedVisibility(
                 visible = titleVisible,
                 enter = fadeIn(tween(300, 100)) + slideInVertically(
@@ -433,8 +433,6 @@ private fun NetworkConfigCard(
                 }
             }
         }
-
-        Spacer(modifier = Modifier.height(6.dp))
 
         AnimatedVisibility(
             visible = fieldsVisible,
@@ -505,13 +503,14 @@ private fun NetworkConfigCard(
                     enter = fadeIn(tween(200)) + scaleIn(initialScale = 0.9f),
                     exit = fadeOut(tween(150)) + scaleOut(targetScale = 0.9f)
                 ) {
-                    ShardTextField(
+                    OutlinedTextField(
                         value = state.port,
                         onValueChange = { viewModel.setPort(it) },
-                        label = strings.portLabel,
-                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text(strings.portLabel) },
+                        modifier = Modifier.fillMaxWidth().height(60.dp),
                         textStyle = MaterialTheme.typography.bodySmall,
-                        singleLine = true
+                        singleLine = true,
+                        shape = MaterialTheme.shapes.medium
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MobileSettingsContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MobileSettingsContent.kt
@@ -487,7 +487,27 @@ private fun ExpressiveAppearanceSettings(viewModel: MainViewModel, hazeState: Ha
             isLast = isLast,
             containerColor = containerColor,
             hazeState = hazeState,
-            enableHaze = enableHaze
+            enableHaze = enableHaze,
+            overlay = {
+                // 开启动态取色时，显示遮罩覆盖整个卡片
+                if (state.useDynamicColor) {
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
+                            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.85f))
+                            .clickable(enabled = false) { },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = strings.dynamicColorEnabledHint,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(horizontal = 16.dp)
+                        )
+                    }
+                }
+            }
         ) {
             Text(strings.themeColorLabel, style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.primary)
             Spacer(Modifier.height(8.dp))
@@ -505,22 +525,6 @@ private fun ExpressiveAppearanceSettings(viewModel: MainViewModel, hazeState: Ha
                 disabledHint = strings.dynamicColorEnabledHint,
                 modifier = Modifier.fillMaxWidth()
             )
-            if (state.useDynamicColor) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.85f))
-                        .padding(8.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = strings.dynamicColorEnabledHint,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        textAlign = TextAlign.Center
-                    )
-                }
-            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Platform.kt
@@ -2,6 +2,7 @@ package com.lanrhyme.micyou
 
 import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
+import com.lanrhyme.micyou.theme.PaletteStyle
 
 enum class PlatformType {
     Android, Desktop
@@ -66,7 +67,7 @@ interface LoggerImpl {
 }
 
 @Composable
-expect fun getDynamicColorScheme(isDark: Boolean): ColorScheme?
+expect fun getDynamicColorScheme(isDark: Boolean, paletteStyle: PaletteStyle): ColorScheme?
 
 // 检查当前平台是否支持动态取色
 expect fun isDynamicColorSupported(): Boolean

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Theme.kt
@@ -147,8 +147,8 @@ fun AppTheme(
 ) {
     val isDark = isDarkThemeActive(themeMode)
 
-    // 动态颜色（如果启用）
-    val dynamicScheme = if (useDynamicColor) getDynamicColorScheme(isDark) else null
+    // 动态颜色（如果启用）- 使用用户选择的 paletteStyle
+    val dynamicScheme = if (useDynamicColor) getDynamicColorScheme(isDark, paletteStyle) else null
 
     // 使用 materialkolor 生成配色方案 - 不做任何手动调整
     val baseColorScheme = dynamicScheme ?: remember(seedColor, isDark, paletteStyle) {

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/theme/ExpressiveComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/theme/ExpressiveComponents.kt
@@ -613,7 +613,7 @@ fun ExpressiveSettingsBoxItem(
                 color = containerColor,
                 onClick = onClick
             ) {
-                Box {
+                Box(modifier = Modifier.fillMaxWidth()) {
                     Column(
                         modifier = Modifier.padding(contentPadding),
                         content = content
@@ -627,7 +627,7 @@ fun ExpressiveSettingsBoxItem(
                 shape = shape,
                 color = containerColor
             ) {
-                Box {
+                Box(modifier = Modifier.fillMaxWidth()) {
                     Column(
                         modifier = Modifier.padding(contentPadding),
                         content = content

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/theme/ExpressiveComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/theme/ExpressiveComponents.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.RowScope
@@ -550,6 +551,7 @@ fun ExpressiveListItem(
 
 /**
  * Expressive Settings Box Item - 用于复杂内容的设置项容器（带内边距）
+ * @param overlay 可选的覆盖层内容，放置在最外层可覆盖整个卡片（如遮罩）
  */
 @Composable
 fun ExpressiveSettingsBoxItem(
@@ -561,6 +563,7 @@ fun ExpressiveSettingsBoxItem(
     contentPadding: Dp = 20.dp,
     hazeState: HazeState? = null,
     enableHaze: Boolean = false,
+    overlay: @Composable BoxScope.() -> Unit = {},
     content: @Composable ColumnScope.() -> Unit
 ) {
     val shape = when {
@@ -600,6 +603,7 @@ fun ExpressiveSettingsBoxItem(
                     content = content
                 )
             }
+            overlay()
         }
     } else {
         if (onClick != null) {
@@ -609,10 +613,13 @@ fun ExpressiveSettingsBoxItem(
                 color = containerColor,
                 onClick = onClick
             ) {
-                Column(
-                    modifier = Modifier.padding(contentPadding),
-                    content = content
-                )
+                Box {
+                    Column(
+                        modifier = Modifier.padding(contentPadding),
+                        content = content
+                    )
+                    overlay()
+                }
             }
         } else {
             Surface(
@@ -620,10 +627,13 @@ fun ExpressiveSettingsBoxItem(
                 shape = shape,
                 color = containerColor
             ) {
-                Column(
-                    modifier = Modifier.padding(contentPadding),
-                    content = content
-                )
+                Box {
+                    Column(
+                        modifier = Modifier.padding(contentPadding),
+                        content = content
+                    )
+                    overlay()
+                }
             }
         }
     }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
@@ -2,6 +2,8 @@ package com.lanrhyme.micyou
 
 import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
 import com.lanrhyme.micyou.platform.FirewallManager
 import com.lanrhyme.micyou.platform.PlatformInfo
 import com.lanrhyme.micyou.platform.WindowsAccentColorExtractor
@@ -128,16 +130,19 @@ actual fun getDynamicColorScheme(isDark: Boolean, paletteStyle: PaletteStyle): C
         return null
     }
 
-    // 每次都重新获取颜色，确保启动时能获取最新的系统主题色
-    val seedColor = WindowsAccentColorExtractor.getAccentColor()
+    // 使用 remember 缓存生成的配色方案，避免每次重组时重复获取系统颜色
+    return remember(isDark, paletteStyle) {
+        // 获取 Windows 系统主题色
+        val seedColor = WindowsAccentColorExtractor.getAccentColor()
 
-    // 如果无法获取系统主题色，返回 null 使用默认主题
-    val color = seedColor ?: return null
+        // 如果无法获取系统主题色，返回 null 使用默认主题
+        val color = seedColor ?: return@remember null
 
-    Logger.d("Platform", "Using Windows accent color: $color")
+        Logger.d("Platform", "Using Windows accent color: $color")
 
-    // 使用用户选择的 paletteStyle 生成配色方案
-    return dynamicColorScheme(color, isDark, paletteStyle)
+        // 使用用户选择的 paletteStyle 生成配色方案
+        dynamicColorScheme(color, isDark, paletteStyle)
+    }
 }
 
 actual fun getAudioSourceOptions(): List<AudioSourceOption> = emptyList()

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
@@ -5,7 +5,8 @@ import androidx.compose.runtime.Composable
 import com.lanrhyme.micyou.platform.FirewallManager
 import com.lanrhyme.micyou.platform.PlatformInfo
 import com.lanrhyme.micyou.platform.WindowsAccentColorExtractor
-import com.lanrhyme.micyou.theme.generateColorScheme
+import com.lanrhyme.micyou.theme.PaletteStyle
+import com.lanrhyme.micyou.theme.dynamicColorScheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.net.InetAddress
@@ -121,7 +122,7 @@ actual fun getDynamicSeedColor(): Long? {
 }
 
 @Composable
-actual fun getDynamicColorScheme(isDark: Boolean): ColorScheme? {
+actual fun getDynamicColorScheme(isDark: Boolean, paletteStyle: PaletteStyle): ColorScheme? {
     // 目前只为 Windows 提供莫奈取色
     if (!PlatformInfo.isWindows) {
         return null
@@ -135,8 +136,8 @@ actual fun getDynamicColorScheme(isDark: Boolean): ColorScheme? {
 
     Logger.d("Platform", "Using Windows accent color: $color")
 
-    // 使用现有的颜色方案生成器
-    return generateColorScheme(color, isDark)
+    // 使用用户选择的 paletteStyle 生成配色方案
+    return dynamicColorScheme(color, isDark, paletteStyle)
 }
 
 actual fun getAudioSourceOptions(): List<AudioSourceOption> = emptyList()

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/main.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/main.kt
@@ -129,15 +129,15 @@ fun main() {
         }
 
         val windowState = rememberWindowState(
-            width = if (uiState.pocketMode) 600.dp else 850.dp,
-            height = if (uiState.pocketMode) 250.dp else 650.dp,
+            width = if (uiState.pocketMode) 650.dp else 850.dp,
+            height = if (uiState.pocketMode) 300.dp else 650.dp,
             position = WindowPosition(Alignment.Center)
         )
 
         LaunchedEffect(uiState.pocketMode) {
             windowState.size = androidx.compose.ui.unit.DpSize(
-                if (uiState.pocketMode) 600.dp else 850.dp,
-                if (uiState.pocketMode) 250.dp else 650.dp
+                if (uiState.pocketMode) 650.dp else 850.dp,
+                if (uiState.pocketMode) 300.dp else 650.dp
             )
         }
 

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/main.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/main.kt
@@ -196,6 +196,7 @@ fun main() {
                     AppTheme(
                     themeMode = uiState.themeMode,
                     seedColor = seedColorObj,
+                    useDynamicColor = uiState.useDynamicColor,
                     oledPureBlack = uiState.oledPureBlack,
                     paletteStyle = uiState.paletteStyle,
                     useExpressiveShapes = uiState.useExpressiveShapes

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/main.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/main.kt
@@ -128,17 +128,16 @@ fun main() {
             }
         }
 
+        val windowWidth = if (uiState.pocketMode) 650.dp else 850.dp
+        val windowHeight = if (uiState.pocketMode) 300.dp else 650.dp
         val windowState = rememberWindowState(
-            width = if (uiState.pocketMode) 650.dp else 850.dp,
-            height = if (uiState.pocketMode) 300.dp else 650.dp,
+            width = windowWidth,
+            height = windowHeight,
             position = WindowPosition(Alignment.Center)
         )
 
         LaunchedEffect(uiState.pocketMode) {
-            windowState.size = androidx.compose.ui.unit.DpSize(
-                if (uiState.pocketMode) 650.dp else 850.dp,
-                if (uiState.pocketMode) 300.dp else 650.dp
-            )
+            windowState.size = androidx.compose.ui.unit.DpSize(windowWidth, windowHeight)
         }
 
         if (isVisible) {


### PR DESCRIPTION
What Changed:
1. 修复袖珍模式下`端口`字样下沉问题，并调整窗口尺寸
2. 修复退出窗口不遵循主题
3. 修复`动态取色已开启`覆盖层
4. 修复开启动态取色后色彩风格不生效问题

---

<details><summary>Copilot's summary</summary>
This pull request introduces improvements to the dynamic color scheme system across Android and Desktop platforms, enhances the settings UI for dynamic color feedback, and makes minor UI adjustments for consistency and usability. The main focus is on allowing user-selected palette styles to influence dynamic color generation, and on providing clear visual feedback when dynamic color is active.

**Dynamic Color System Enhancements:**

* The dynamic color scheme generation functions (`getDynamicColorScheme`) on both Android and Desktop/JVM now accept a `paletteStyle` parameter, allowing the color palette to be customized based on user selection. The color scheme is regenerated using the selected palette style, improving theme flexibility. [[1]](diffhunk://#diff-1da24d3cf21182fd359b6a50d6a5e1d5de2d05d4c644760f0cdd2d128b28eb49L45-R60) [[2]](diffhunk://#diff-1862d406259cbe711997491fc28e1ae3bd2d46e3997acd34440b381404f25455L69-R70) [[3]](diffhunk://#diff-ac441efab36628a4b53732824d4711d23520ddc2270aee42eefc72d20fa9645cL150-R151) [[4]](diffhunk://#diff-49f02419a91c0f90f329ea5b0f3f0eb9eacfd17be8f616bf9f5dd6f5087a5a74L124-R125) [[5]](diffhunk://#diff-49f02419a91c0f90f329ea5b0f3f0eb9eacfd17be8f616bf9f5dd6f5087a5a74L138-R140)
* Imports and type signatures updated to support the new `PaletteStyle` parameter throughout the codebase. [[1]](diffhunk://#diff-1da24d3cf21182fd359b6a50d6a5e1d5de2d05d4c644760f0cdd2d128b28eb49R10-R14) [[2]](diffhunk://#diff-1862d406259cbe711997491fc28e1ae3bd2d46e3997acd34440b381404f25455R5) [[3]](diffhunk://#diff-49f02419a91c0f90f329ea5b0f3f0eb9eacfd17be8f616bf9f5dd6f5087a5a74L8-R9)

**Settings UI Improvements:**

* The `ExpressiveSettingsBoxItem` component now supports an `overlay` parameter, allowing overlays such as a semi-transparent mask to be shown when dynamic color is enabled. This provides clear feedback to users in the settings screen. [[1]](diffhunk://#diff-a4c78c3bae7d2e2431f677ab865f51157c4f1a267f1e051b68f36abf1baa8dfeR554) [[2]](diffhunk://#diff-a4c78c3bae7d2e2431f677ab865f51157c4f1a267f1e051b68f36abf1baa8dfeR566) [[3]](diffhunk://#diff-a4c78c3bae7d2e2431f677ab865f51157c4f1a267f1e051b68f36abf1baa8dfeR606) [[4]](diffhunk://#diff-a4c78c3bae7d2e2431f677ab865f51157c4f1a267f1e051b68f36abf1baa8dfeR616-R636)
* The mobile settings screen uses this overlay to display a hint when dynamic color is active, and removes the previous, less flexible implementation. [[1]](diffhunk://#diff-58ca327e861ecc2ecf2a0eec6d5cde58f4f3c53be5fe4954a3f7a5e64029ebaeL490-R510) [[2]](diffhunk://#diff-58ca327e861ecc2ecf2a0eec6d5cde58f4f3c53be5fe4954a3f7a5e64029ebaeL508-L523)

**UI Consistency and Usability:**

* The network configuration card's layout is refined for better spacing and replaces the custom `ShardTextField` with a standard `OutlinedTextField` for improved consistency and accessibility. [[1]](diffhunk://#diff-f82f88f0880a7336194cd7469b5d41d2dd41813ed543d0b69a1e63df5e9ee904L374-R374) [[2]](diffhunk://#diff-f82f88f0880a7336194cd7469b5d41d2dd41813ed543d0b69a1e63df5e9ee904L437-L438) [[3]](diffhunk://#diff-f82f88f0880a7336194cd7469b5d41d2dd41813ed543d0b69a1e63df5e9ee904L508-R513)
* The desktop window's minimum size in pocket mode is increased for better usability.

**Other Minor Changes:**

* Ensured `useDynamicColor` is correctly passed to the `AppTheme` component in the desktop entry point.

These changes collectively improve theming flexibility, user feedback, and interface consistency across platforms.
</details>