### PR TITLE
feat: 添加设备发现功能

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -105,6 +105,7 @@ kotlin {
             implementation(libs.composenativetray)
             implementation(libs.onnxruntime)
             implementation(libs.jtransforms)
+            implementation(libs.jmdns)
         }
     }
 }

--- a/composeApp/micyou.conf
+++ b/composeApp/micyou.conf
@@ -1,10 +1,10 @@
-#Fri May 01 15:27:16 HKT 2026
+#Tue Apr 21 12:20:31 CST 2026
 audio_format=PCM_16BIT
 background_brightness=0.41190732
 background_image_path=
 card_opacity=0.5018858
 channel_count=Stereo
-connection_mode=Wifi
+connection_mode=Usb
 enable_haze_effect=true
 enable_ns=true
 has_launched_before=true

--- a/composeApp/micyou.conf
+++ b/composeApp/micyou.conf
@@ -1,4 +1,4 @@
-#Fri May 01 15:14:39 HKT 2026
+#Fri May 01 15:27:16 HKT 2026
 audio_format=PCM_16BIT
 background_brightness=0.41190732
 background_image_path=

--- a/composeApp/micyou.conf
+++ b/composeApp/micyou.conf
@@ -1,10 +1,10 @@
-#Tue Apr 21 12:20:31 CST 2026
+#Fri May 01 15:14:39 HKT 2026
 audio_format=PCM_16BIT
 background_brightness=0.41190732
 background_image_path=
 card_opacity=0.5018858
 channel_count=Stereo
-connection_mode=Usb
+connection_mode=Wifi
 enable_haze_effect=true
 enable_ns=true
 has_launched_before=true

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
     <!-- Update install permission -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/DeviceDiscovery.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/DeviceDiscovery.android.kt
@@ -1,0 +1,120 @@
+package com.lanrhyme.micyou
+
+import android.content.Context
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+actual class DeviceDiscoveryManager actual constructor() {
+    private val _discoveredDevices = MutableStateFlow<List<DiscoveredDevice>>(emptyList())
+    actual val discoveredDevices: StateFlow<List<DiscoveredDevice>> = _discoveredDevices.asStateFlow()
+
+    private val _isDiscovering = MutableStateFlow(false)
+    actual val isDiscovering: StateFlow<Boolean> = _isDiscovering.asStateFlow()
+
+    private var nsdManager: NsdManager? = null
+    private var discoveryListener: NsdManager.DiscoveryListener? = null
+    private var discoveryActive = false
+    private val pendingResolution = mutableSetOf<String>()
+
+    private val resolveListener = object : NsdManager.ResolveListener {
+        override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+            Logger.w("DeviceDiscovery", "Resolve failed: $errorCode for ${serviceInfo.serviceName}")
+            pendingResolution.remove(serviceInfo.serviceName)
+        }
+
+        override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
+            pendingResolution.remove(serviceInfo.serviceName)
+            val host = serviceInfo.host?.hostAddress ?: return
+            val port = serviceInfo.port
+            val name = serviceInfo.serviceName
+
+            Logger.i("DeviceDiscovery", "Resolved: $name at $host:$port")
+
+            _discoveredDevices.value = _discoveredDevices.value.toMutableList().apply {
+                removeAll { it.hostAddress == host && it.port == port }
+                add(DiscoveredDevice(name = name, hostAddress = host, port = port))
+            }
+        }
+    }
+
+    actual fun startDiscovery() {
+        if (discoveryActive) return
+        val context = ContextHelper.getContext() ?: run {
+            Logger.w("DeviceDiscovery", "No application context available")
+            return
+        }
+
+        nsdManager = context.getSystemService(Context.NSD_SERVICE) as? NsdManager ?: run {
+            Logger.w("DeviceDiscovery", "NsdManager not available")
+            return
+        }
+
+        discoveryListener = object : NsdManager.DiscoveryListener {
+            override fun onDiscoveryStarted(serviceType: String) {
+                Logger.i("DeviceDiscovery", "Discovery started for $serviceType")
+                discoveryActive = true
+                _isDiscovering.value = true
+            }
+
+            override fun onServiceFound(serviceInfo: NsdServiceInfo) {
+                val name = serviceInfo.serviceName
+                if (name !in pendingResolution) {
+                    pendingResolution.add(name)
+                    try {
+                        nsdManager?.resolveService(serviceInfo, resolveListener)
+                    } catch (e: Exception) {
+                        Logger.w("DeviceDiscovery", "Failed to resolve $name: ${e.message}")
+                        pendingResolution.remove(name)
+                    }
+                }
+            }
+
+            override fun onServiceLost(serviceInfo: NsdServiceInfo) {
+                Logger.i("DeviceDiscovery", "Service lost: ${serviceInfo.serviceName}")
+                _discoveredDevices.value = _discoveredDevices.value.toMutableList().apply {
+                    removeAll { it.name == serviceInfo.serviceName }
+                }
+            }
+
+            override fun onDiscoveryStopped(serviceType: String) {
+                Logger.i("DeviceDiscovery", "Discovery stopped")
+                discoveryActive = false
+                _isDiscovering.value = false
+            }
+
+            override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
+                Logger.w("DeviceDiscovery", "Discovery start failed: $errorCode")
+                discoveryActive = false
+                _isDiscovering.value = false
+            }
+
+            override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
+                Logger.w("DeviceDiscovery", "Discovery stop failed: $errorCode")
+            }
+        }
+
+        try {
+            nsdManager?.discoverServices("_micyou._tcp.", NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+        } catch (e: Exception) {
+            Logger.e("DeviceDiscovery", "Failed to start discovery", e)
+            discoveryActive = false
+        }
+    }
+
+    actual fun stopDiscovery() {
+        if (!discoveryActive) return
+        try {
+            discoveryListener?.let { nsdManager?.stopServiceDiscovery(it) }
+        } catch (e: Exception) {
+            Logger.w("DeviceDiscovery", "Error stopping discovery: ${e.message}")
+        }
+        discoveryListener = null
+        discoveryActive = false
+        _isDiscovering.value = false
+        pendingResolution.clear()
+        // Don't clear device list here — let restartDiscovery() manage it
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/DeviceDiscovery.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/DeviceDiscovery.android.kt
@@ -6,6 +6,7 @@ import android.net.nsd.NsdServiceInfo
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 actual class DeviceDiscoveryManager actual constructor() {
     private val _discoveredDevices = MutableStateFlow<List<DiscoveredDevice>>(emptyList())
@@ -18,27 +19,6 @@ actual class DeviceDiscoveryManager actual constructor() {
     private var discoveryListener: NsdManager.DiscoveryListener? = null
     private var discoveryActive = false
     private val pendingResolution = mutableSetOf<String>()
-
-    private val resolveListener = object : NsdManager.ResolveListener {
-        override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
-            Logger.w("DeviceDiscovery", "Resolve failed: $errorCode for ${serviceInfo.serviceName}")
-            pendingResolution.remove(serviceInfo.serviceName)
-        }
-
-        override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
-            pendingResolution.remove(serviceInfo.serviceName)
-            val host = serviceInfo.host?.hostAddress ?: return
-            val port = serviceInfo.port
-            val name = serviceInfo.serviceName
-
-            Logger.i("DeviceDiscovery", "Resolved: $name at $host:$port")
-
-            _discoveredDevices.value = _discoveredDevices.value.toMutableList().apply {
-                removeAll { it.hostAddress == host && it.port == port }
-                add(DiscoveredDevice(name = name, hostAddress = host, port = port))
-            }
-        }
-    }
 
     actual fun startDiscovery() {
         if (discoveryActive) return
@@ -64,7 +44,26 @@ actual class DeviceDiscoveryManager actual constructor() {
                 if (name !in pendingResolution) {
                     pendingResolution.add(name)
                     try {
-                        nsdManager?.resolveService(serviceInfo, resolveListener)
+                        nsdManager?.resolveService(serviceInfo, object : NsdManager.ResolveListener {
+                            override fun onResolveFailed(info: NsdServiceInfo, errorCode: Int) {
+                                Logger.w("DeviceDiscovery", "Resolve failed: $errorCode for ${info.serviceName}")
+                                pendingResolution.remove(info.serviceName)
+                            }
+
+                            override fun onServiceResolved(info: NsdServiceInfo) {
+                                pendingResolution.remove(info.serviceName)
+                                val host = info.host?.hostAddress ?: return
+                                val port = info.port
+                                val resolvedName = info.serviceName
+
+                                Logger.i("DeviceDiscovery", "Resolved: $resolvedName at $host:$port")
+
+                                _discoveredDevices.update { current ->
+                                    current.filterNot { it.hostAddress == host && it.port == port } +
+                                            DiscoveredDevice(name = resolvedName, hostAddress = host, port = port)
+                                }
+                            }
+                        })
                     } catch (e: Exception) {
                         Logger.w("DeviceDiscovery", "Failed to resolve $name: ${e.message}")
                         pendingResolution.remove(name)
@@ -74,8 +73,8 @@ actual class DeviceDiscoveryManager actual constructor() {
 
             override fun onServiceLost(serviceInfo: NsdServiceInfo) {
                 Logger.i("DeviceDiscovery", "Service lost: ${serviceInfo.serviceName}")
-                _discoveredDevices.value = _discoveredDevices.value.toMutableList().apply {
-                    removeAll { it.name == serviceInfo.serviceName }
+                _discoveredDevices.update { current ->
+                    current.filterNot { it.name == serviceInfo.serviceName }
                 }
             }
 

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/DeviceDiscovery.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/DeviceDiscovery.android.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import java.util.Collections
 
 actual class DeviceDiscoveryManager actual constructor() {
     private val _discoveredDevices = MutableStateFlow<List<DiscoveredDevice>>(emptyList())
@@ -18,10 +19,11 @@ actual class DeviceDiscoveryManager actual constructor() {
     private var nsdManager: NsdManager? = null
     private var discoveryListener: NsdManager.DiscoveryListener? = null
     private var discoveryActive = false
-    private val pendingResolution = mutableSetOf<String>()
+    private val pendingResolution: MutableSet<String> = Collections.synchronizedSet(mutableSetOf<String>())
 
     actual fun startDiscovery() {
         if (discoveryActive) return
+        _discoveredDevices.value = emptyList()
         val context = ContextHelper.getContext() ?: run {
             Logger.w("DeviceDiscovery", "No application context available")
             return

--- a/composeApp/src/commonMain/composeResources/values-ca/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ca/strings.xml
@@ -64,6 +64,9 @@
     <string name="deletePluginConfirm">确定要删除插件「%s」吗喵？(・_・;)</string>
     <string name="dereverbLevelLabel">等级喵~</string>
     <string name="developerLabel">开发者喵~ 👨‍💻</string>
+    <string name="discoveredDevicesLabel">可用服务器喵~</string>
+    <string name="scanningForDevices">扫描中喵~</string>
+    <string name="tapToConnect">点击连接喵~</string>
     <string name="dynamicColorActiveHint">正在用系统动态颜色喵~ ✨</string>
     <string name="dynamicColorEnabledHint">动态取色已启用喵~ 🎨</string>
     <string name="enableAgcLabel">自动增益喵~</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rHK/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rHK/strings.xml
@@ -64,6 +64,9 @@
     <string name="deletePluginConfirm">確定要刪除插件「%s」嗎？</string>
     <string name="dereverbLevelLabel">強度</string>
     <string name="developerLabel">開發者</string>
+    <string name="discoveredDevicesLabel">可用伺服器</string>
+    <string name="scanningForDevices">掃描中...</string>
+    <string name="tapToConnect">點擊連線</string>
     <string name="dynamicColorActiveHint">而家係用緊系統動態顏色</string>
     <string name="dynamicColorEnabledHint">動態取色已啟用</string>
     <string name="enableAgcLabel">自動增益控制 (AGC)</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rSS/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rSS/strings.xml
@@ -64,6 +64,9 @@
     <string name="deletePluginConfirm">你确定要删除插件「%s」吗？</string>
     <string name="dereverbLevelLabel">等级别数</string>
     <string name="developerLabel">开发者人员者</string>
+    <string name="discoveredDevicesLabel">可用服务器</string>
+    <string name="scanningForDevices">扫描中...</string>
+    <string name="tapToConnect">点击连接</string>
     <string name="dynamicColorActiveHint">当前正在使用系统动态颜色值</string>
     <string name="dynamicColorEnabledHint">动态取色功能项已启用状态值</string>
     <string name="enableAgcLabel">启用自动增益控制项</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -64,6 +64,9 @@
     <string name="deletePluginConfirm">確定要刪除插件「%s」嗎？</string>
     <string name="dereverbLevelLabel">強度</string>
     <string name="developerLabel">開發者</string>
+    <string name="discoveredDevicesLabel">可用伺服器</string>
+    <string name="scanningForDevices">掃描中...</string>
+    <string name="tapToConnect">點擊連線</string>
     <string name="dynamicColorActiveHint">目前正在使用系統動態顏色</string>
     <string name="dynamicColorEnabledHint">動態取色已啟用</string>
     <string name="enableAgcLabel">自動增益控制 (AGC)</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -64,6 +64,9 @@
     <string name="deletePluginConfirm">确定要删除插件 \"%s\" 吗？</string>
     <string name="dereverbLevelLabel">强度</string>
     <string name="developerLabel">开发者</string>
+    <string name="discoveredDevicesLabel">可用服务器</string>
+    <string name="scanningForDevices">扫描中...</string>
+    <string name="tapToConnect">点击连接</string>
     <string name="dynamicColorActiveHint">当前正在使用系统动态颜色</string>
     <string name="dynamicColorEnabledHint">动态取色已启用</string>
     <string name="enableAgcLabel">自动增益控制 (AGC)</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -81,6 +81,9 @@
     <string name="deletePluginConfirm">Are you sure you want to delete \"%s\"?</string>
     <string name="dereverbLevelLabel">Level</string>
     <string name="developerLabel">Developer</string>
+    <string name="discoveredDevicesLabel">Available Servers</string>
+    <string name="scanningForDevices">Scanning...</string>
+    <string name="tapToConnect">Tap to connect</string>
     <string name="dynamicColorActiveHint">Currently using system dynamic color</string>
     <string name="dynamicColorEnabledHint">Dynamic color is enabled</string>
     <string name="enableAgcLabel">AGC</string>

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
@@ -60,6 +60,11 @@ class AudioStreamViewModel : ViewModel() {
     val audioLevelData = _audioEngine.audioLevelData
     val audioMetrics = _audioEngine.audioMetrics
 
+    // 设备发现
+    private val discoveryManager = DeviceDiscoveryManager()
+    val discoveredDevices: StateFlow<List<DiscoveredDevice>> = discoveryManager.discoveredDevices
+    val isDiscovering: StateFlow<Boolean> = discoveryManager.isDiscovering
+
     // 音频历史记录（用于可视化）
     private val audioLevelHistory = AudioLevelHistory(maxDurationSeconds = 10)
     private val _levelHistory = MutableStateFlow<List<AudioLevelHistory.AudioLevelSample>>(emptyList())
@@ -70,6 +75,10 @@ class AudioStreamViewModel : ViewModel() {
     init {
         loadSettings()
         setupAudioEngineObservers()
+        // Auto-start discovery on Android when in WiFi mode
+        if (getPlatform().type == PlatformType.Android && _uiState.value.mode == ConnectionMode.Wifi) {
+            discoveryManager.startDiscovery()
+        }
     }
 
     private fun loadSettings() {
@@ -364,6 +373,15 @@ class AudioStreamViewModel : ViewModel() {
 
         _uiState.update { it.copy(mode = mode, port = updatedPort) }
         settings.putString("connection_mode", mode.name)
+
+        // Manage discovery lifecycle based on mode
+        if (getPlatform().type == PlatformType.Android) {
+            if (mode == ConnectionMode.Wifi) {
+                discoveryManager.startDiscovery()
+            } else {
+                discoveryManager.stopDiscovery()
+            }
+        }
         if (updatedPort != current.port) {
             settings.putString("port", updatedPort)
         }
@@ -579,6 +597,14 @@ class AudioStreamViewModel : ViewModel() {
 
     override fun onCleared() {
         super.onCleared()
+        discoveryManager.stopDiscovery()
         _audioEngine.stop()
+    }
+
+    fun startDiscovery() = discoveryManager.startDiscovery()
+    fun stopDiscovery() = discoveryManager.stopDiscovery()
+    fun restartDiscovery() {
+        discoveryManager.stopDiscovery()
+        discoveryManager.startDiscovery()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
@@ -601,10 +601,16 @@ class AudioStreamViewModel : ViewModel() {
         _audioEngine.stop()
     }
 
-    fun startDiscovery() = discoveryManager.startDiscovery()
-    fun stopDiscovery() = discoveryManager.stopDiscovery()
+    fun startDiscovery() {
+        if (getPlatform().type == PlatformType.Android) discoveryManager.startDiscovery()
+    }
+    fun stopDiscovery() {
+        if (getPlatform().type == PlatformType.Android) discoveryManager.stopDiscovery()
+    }
     fun restartDiscovery() {
-        discoveryManager.stopDiscovery()
-        discoveryManager.startDiscovery()
+        if (getPlatform().type == PlatformType.Android) {
+            discoveryManager.stopDiscovery()
+            discoveryManager.startDiscovery()
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DeviceDiscovery.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DeviceDiscovery.kt
@@ -1,0 +1,16 @@
+package com.lanrhyme.micyou
+
+import kotlinx.coroutines.flow.StateFlow
+
+data class DiscoveredDevice(
+    val name: String,
+    val hostAddress: String,
+    val port: Int
+)
+
+expect class DeviceDiscoveryManager() {
+    val discoveredDevices: StateFlow<List<DiscoveredDevice>>
+    val isDiscovering: StateFlow<Boolean>
+    fun startDiscovery()
+    fun stopDiscovery()
+}

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
@@ -124,6 +124,10 @@ data class AppUiState(
     val performanceMode: String = "Default",
     val audioMetrics: AudioMetrics? = null,
 
+    // Discovery State
+    val discoveredDevices: List<DiscoveredDevice> = emptyList(),
+    val isDiscovering: Boolean = false,
+
     // UI State
     val installMessage: String? = null,
     val snackbarMessage: String? = null
@@ -198,6 +202,18 @@ class MainViewModel : ViewModel() {
         
         // Observe and merge states from all ViewModels
         setupStateObservers()
+
+        // Observe discovered devices
+        viewModelScope.launch {
+            audioStreamViewModel.discoveredDevices.collect { devices ->
+                _uiState.update { it.copy(discoveredDevices = devices) }
+            }
+        }
+        viewModelScope.launch {
+            audioStreamViewModel.isDiscovering.collect { discovering ->
+                _uiState.update { it.copy(isDiscovering = discovering) }
+            }
+        }
         
         // Auto-check for updates
         if (settings.getBoolean("auto_check_update", true)) {
@@ -301,7 +317,12 @@ class MainViewModel : ViewModel() {
                     snackbarMessage = settingsState.snackbarMessage
                 )
             }.collect { combinedState ->
-                _uiState.value = combinedState
+                // Preserve discovery state that's managed separately
+                val current = _uiState.value
+                _uiState.value = combinedState.copy(
+                    discoveredDevices = current.discoveredDevices,
+                    isDiscovering = current.isDiscovering
+                )
                 
                 // Auto-start streaming on Desktop if enabled (only check once)
                 if (!autoStartChecked && getPlatform().type == PlatformType.Desktop) {
@@ -322,6 +343,13 @@ class MainViewModel : ViewModel() {
     fun startStream() = audioStreamViewModel.startStream()
     fun stopStream() = audioStreamViewModel.stopStream()
     fun setMode(mode: ConnectionMode) = audioStreamViewModel.setMode(mode)
+    fun startDiscovery() = audioStreamViewModel.startDiscovery()
+    fun stopDiscovery() = audioStreamViewModel.stopDiscovery()
+    fun restartDiscovery() = audioStreamViewModel.restartDiscovery()
+    fun selectDiscoveredDevice(device: DiscoveredDevice) {
+        audioStreamViewModel.setIp(device.hostAddress)
+        audioStreamViewModel.setPort(device.port.toString())
+    }
     fun setIp(ip: String) = audioStreamViewModel.setIp(ip)
     fun setPort(port: String) = audioStreamViewModel.setPort(port)
     fun setMonitoringEnabled(enabled: Boolean) = audioStreamViewModel.setMonitoringEnabled(enabled)

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MobileHome.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MobileHome.kt
@@ -43,6 +43,7 @@ import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.rounded.Bluetooth
 import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Dns
 import androidx.compose.material.icons.rounded.Error
 import androidx.compose.material.icons.rounded.Extension
 import androidx.compose.material.icons.rounded.HourglassTop
@@ -432,6 +433,94 @@ private fun ConnectionConfigCard(
                                 color = contentColor,
                                 maxLines = 1
                             )
+                        }
+                    }
+                }
+            }
+
+            // Discovered devices list (WiFi mode only, always visible during connection)
+            if (isClient && state.mode == ConnectionMode.Wifi) {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    // Header row: label + refresh button
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        if (state.isDiscovering && state.discoveredDevices.isEmpty()) {
+                            Icon(
+                                Icons.Rounded.Dns, null,
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                stringResource(Res.string.scanningForDevices),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.weight(1f)
+                            )
+                        } else {
+                            Text(
+                                stringResource(Res.string.discoveredDevicesLabel),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+                        IconButton(
+                            onClick = { viewModel.restartDiscovery() },
+                            modifier = Modifier.size(32.dp)
+                        ) {
+                            val infiniteTransition = rememberInfiniteTransition()
+                            val rotation by infiniteTransition.animateFloat(
+                                initialValue = 0f,
+                                targetValue = 360f,
+                                animationSpec = infiniteRepeatable(
+                                    animation = tween(1000, easing = LinearEasing),
+                                    repeatMode = RepeatMode.Restart
+                                )
+                            )
+                            Icon(
+                                Icons.Filled.Refresh, null,
+                                modifier = Modifier
+                                    .size(18.dp)
+                                    .graphicsLayer { rotationZ = if (state.isDiscovering && state.discoveredDevices.isEmpty()) rotation else 0f },
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+                    // Device list
+                    state.discoveredDevices.forEach { device ->
+                        val isSelected = state.ipAddress == device.hostAddress &&
+                                state.port == device.port.toString()
+                        Surface(
+                            shape = MaterialTheme.shapes.small,
+                            color = if (isSelected) MaterialTheme.colorScheme.primaryContainer
+                            else MaterialTheme.colorScheme.surfaceContainerHigh,
+                            modifier = Modifier.fillMaxWidth().clickable {
+                                viewModel.selectDiscoveredDevice(device)
+                            }
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Icon(
+                                    if (isSelected) Icons.Rounded.CheckCircle else Icons.Rounded.Dns,
+                                    null,
+                                    modifier = Modifier.size(18.dp),
+                                    tint = if (isSelected) MaterialTheme.colorScheme.primary
+                                    else MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(device.name, style = MaterialTheme.typography.bodySmall)
+                                    Text(
+                                        "${device.hostAddress}:${device.port}",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MobileHome.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MobileHome.kt
@@ -483,7 +483,7 @@ private fun ConnectionConfigCard(
                                 Icons.Filled.Refresh, null,
                                 modifier = Modifier
                                     .size(18.dp)
-                                    .graphicsLayer { rotationZ = if (state.isDiscovering && state.discoveredDevices.isEmpty()) rotation else 0f },
+                                    .graphicsLayer { rotationZ = if (state.isDiscovering) rotation else 0f },
                                 tint = MaterialTheme.colorScheme.primary
                             )
                         }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
@@ -71,12 +71,14 @@ actual class AudioEngine actual constructor() {
     
     init {
         // Start mDNS advertisement immediately so Android clients can discover this server
-        try {
-            val settings = SettingsFactory.getSettings()
-            val port = settings.getString("port", "6000").toIntOrNull() ?: 6000
-            mdnsAdvertiser.advertise(port)
-        } catch (e: Exception) {
-            Logger.w("AudioEngine", "Failed to start mDNS advertisement: ${e.message}")
+        scope.launch(Dispatchers.IO) {
+            try {
+                val settings = SettingsFactory.getSettings()
+                val port = settings.getString("port", "6000").toIntOrNull() ?: 6000
+                mdnsAdvertiser.advertise(port)
+            } catch (e: Exception) {
+                Logger.w("AudioEngine", "Failed to start mDNS advertisement: ${e.message}")
+            }
         }
 
         scope.launch {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
@@ -5,6 +5,7 @@ import com.lanrhyme.micyou.audio.AudioProcessorPipeline
 import micyou.composeapp.generated.resources.Res
 import micyou.composeapp.generated.resources.errorAdbReverseFailed
 import org.jetbrains.compose.resources.getString
+import com.lanrhyme.micyou.network.MdnsAdvertiser
 import com.lanrhyme.micyou.network.NetworkServer
 import com.lanrhyme.micyou.platform.AdbManager
 import com.lanrhyme.micyou.platform.PlatformInfo
@@ -54,6 +55,8 @@ actual class AudioEngine actual constructor() {
         onBufferOverflow = BufferOverflow.DROP_OLDEST
     )
     
+    private val mdnsAdvertiser = MdnsAdvertiser()
+
     private val networkServer = NetworkServer(
         onAudioPacketReceived = { audioPacket ->
             processReceivedPacket(audioPacket)
@@ -67,6 +70,15 @@ actual class AudioEngine actual constructor() {
     )
     
     init {
+        // Start mDNS advertisement immediately so Android clients can discover this server
+        try {
+            val settings = SettingsFactory.getSettings()
+            val port = settings.getString("port", "6000").toIntOrNull() ?: 6000
+            mdnsAdvertiser.advertise(port)
+        } catch (e: Exception) {
+            Logger.w("AudioEngine", "Failed to start mDNS advertisement: ${e.message}")
+        }
+
         scope.launch {
             networkServer.state.collect { newState ->
                 if (newState == StreamState.Streaming) {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
@@ -281,6 +281,7 @@ actual class AudioEngine actual constructor() {
          } finally {
              audioOutputManager.release()
              audioPipeline.release()
+             mdnsAdvertiser.close()
          }
     }
     

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/DeviceDiscovery.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/DeviceDiscovery.jvm.kt
@@ -1,0 +1,22 @@
+package com.lanrhyme.micyou
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+actual class DeviceDiscoveryManager actual constructor() {
+    private val _discoveredDevices = MutableStateFlow<List<DiscoveredDevice>>(emptyList())
+    actual val discoveredDevices: StateFlow<List<DiscoveredDevice>> = _discoveredDevices.asStateFlow()
+
+    private val _isDiscovering = MutableStateFlow(false)
+    actual val isDiscovering: StateFlow<Boolean> = _isDiscovering.asStateFlow()
+
+    actual fun startDiscovery() {
+        // No-op on Desktop — desktop is the server, not the client
+    }
+
+    actual fun stopDiscovery() {
+        _discoveredDevices.value = emptyList()
+        _isDiscovering.value = false
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/MdnsAdvertiser.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/MdnsAdvertiser.kt
@@ -1,0 +1,77 @@
+package com.lanrhyme.micyou.network
+
+import com.lanrhyme.micyou.Logger
+import javax.jmdns.JmDNS
+import javax.jmdns.ServiceInfo
+import java.net.InetAddress
+
+class MdnsAdvertiser {
+    private var jmdns: JmDNS? = null
+    private var serviceInfo: ServiceInfo? = null
+
+    fun advertise(port: Int) {
+        try {
+            val localHost = findLanAddress()
+            val hostName = "MicYou (${InetAddress.getLocalHost().hostName})"
+            jmdns = JmDNS.create(localHost, hostName)
+
+            serviceInfo = ServiceInfo.create(
+                "_micyou._tcp.local.",
+                hostName,
+                port,
+                "MicYou audio streaming server"
+            )
+            jmdns?.registerService(serviceInfo)
+            Logger.i("MdnsAdvertiser", "mDNS service advertised: $hostName on ${localHost?.hostAddress} port $port")
+        } catch (e: Exception) {
+            Logger.w("MdnsAdvertiser", "Failed to advertise mDNS service: ${e.message}")
+            close()
+            throw e
+        }
+    }
+
+    private fun findLanAddress(): InetAddress? {
+        val virtualKeywords = listOf("vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker", "tunnel", "teredo", "isatap")
+        try {
+            val interfaces = java.net.NetworkInterface.getNetworkInterfaces()
+            val candidates = mutableListOf<Pair<java.net.NetworkInterface, java.net.Inet4Address>>()
+            while (interfaces.hasMoreElements()) {
+                val networkInterface = interfaces.nextElement()
+                if (networkInterface.isLoopback || !networkInterface.isUp || networkInterface.isVirtual) continue
+                val name = networkInterface.displayName?.lowercase() ?: ""
+                if (virtualKeywords.any { name.contains(it) }) continue
+                val addresses = networkInterface.inetAddresses
+                while (addresses.hasMoreElements()) {
+                    val address = addresses.nextElement()
+                    if (address is java.net.Inet4Address && !address.isLoopbackAddress) {
+                        candidates.add(networkInterface to address)
+                    }
+                }
+            }
+            // Prefer interfaces with common LAN prefixes (192.168.x.x, 10.x.x.x)
+            val lanPreferred = candidates.firstOrNull { it.second.hostAddress?.startsWith("192.168.") == true }
+                ?: candidates.firstOrNull { it.second.hostAddress?.startsWith("10.") == true }
+                ?: candidates.firstOrNull()
+            return lanPreferred?.second
+        } catch (e: Exception) {
+            Logger.w("MdnsAdvertiser", "Failed to find LAN address: ${e.message}")
+        }
+        return null
+    }
+
+    fun close() {
+        try {
+            val j = jmdns
+            val si = serviceInfo
+            if (j != null && si != null) {
+                j.unregisterService(si)
+            }
+            jmdns?.close()
+        } catch (e: Exception) {
+            Logger.w("MdnsAdvertiser", "Error closing mDNS: ${e.message}")
+        } finally {
+            serviceInfo = null
+            jmdns = null
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ jtransforms = "3.2"
 window = "1.5.1"
 filekit = "0.13.0"
 materialKolor = "5.0.0-alpha07"
-jmdns = "3.5.9"
+jmdns = "3.6.3"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ jtransforms = "3.2"
 window = "1.5.1"
 filekit = "0.13.0"
 materialKolor = "5.0.0-alpha07"
+jmdns = "3.5.9"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -61,6 +62,7 @@ androidx-window = { group = "androidx.window", name = "window", version.ref = "w
 filekit-core = { module = "io.github.vinceglb:filekit-core", version.ref = "filekit" }
 filekit-dialogs-compose = { module = "io.github.vinceglb:filekit-dialogs-compose", version.ref = "filekit" }
 materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
+jmdns = { module = "org.jmdns:jmdns", version.ref = "jmdns" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This pull request introduces device discovery functionality for Android, allowing the app to scan for and display available servers on the local network. It adds the necessary permissions, implements the discovery logic using Android's NSD (Network Service Discovery), exposes discovery state and results to the UI, and updates the view models and resources to support this feature.

**Device Discovery Feature:**

* Implements a platform-specific `DeviceDiscoveryManager` for Android using NSD, enabling the app to discover available servers on the local network and track discovery state. (`composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/DeviceDiscovery.android.kt` [[1]](diffhunk://#diff-25acfe16a6e521becc7294e09da75b1592a0ee93c1ee79c8937d30bcfe21529eR1-R121) `composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DeviceDiscovery.kt` [[2]](diffhunk://#diff-2039f5555a2ad47b270db2eb4d61cb1e475ac39429e1c73252be6aad48502988R1-R16)
* Adds the `CHANGE_WIFI_MULTICAST_STATE` permission to the Android manifest to allow device discovery over WiFi. (`composeApp/src/androidMain/AndroidManifest.xml` [composeApp/src/androidMain/AndroidManifest.xmlR15](diffhunk://#diff-63bb9dfc8b867f3e017a44f2b22f4c4ec10206802b72f3e89d378a86265ac4c3R15))
* Adds the `jmdns` library dependency for network service discovery support. (`composeApp/build.gradle.kts` [composeApp/build.gradle.ktsR108](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aR108))

**ViewModel and State Integration:**

* Integrates device discovery state and results into `AudioStreamViewModel` and `MainViewModel`, exposing discovered devices and discovery status to the UI and managing discovery lifecycle based on connection mode. (`composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt` Fff44ef9L64R64 [[1]](diffhunk://#diff-c665d7114904cf7b94e63ffc46ec8851f1459d019155bec233e1bf7922e834a9R78-R81) [[2]](diffhunk://#diff-c665d7114904cf7b94e63ffc46ec8851f1459d019155bec233e1bf7922e834a9R376-R384) [[3]](diffhunk://#diff-c665d7114904cf7b94e63ffc46ec8851f1459d019155bec233e1bf7922e834a9R600-R615) `composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt` [[4]](diffhunk://#diff-2cbe6d0ab9e9f26cecb0019689afff9918e8a73ceaa6840afbd43c2eb53aa875R127-R130) [[5]](diffhunk://#diff-2cbe6d0ab9e9f26cecb0019689afff9918e8a73ceaa6840afbd43c2eb53aa875R206-R217) [[6]](diffhunk://#diff-2cbe6d0ab9e9f26cecb0019689afff9918e8a73ceaa6840afbd43c2eb53aa875L304-R325) [[7]](diffhunk://#diff-2cbe6d0ab9e9f26cecb0019689afff9918e8a73ceaa6840afbd43c2eb53aa875R346-R352)

**UI and Localization Support:**

* Adds new string resources for device discovery UI elements in all supported languages. (`composeApp/src/commonMain/composeResources/values/strings.xml` [[1]](diffhunk://#diff-089f0ef77f066210beeba29ed6b8e392395174bc971984fac0f18c96ec371653R84-R86) `composeApp/src/commonMain/composeResources/values-zh/strings.xml` [[2]](diffhunk://#diff-e1816e7df84c66ed4a946923833350602b16c98e95505794df07636ae38134c9R67-R69) `composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml` [[3]](diffhunk://#diff-b8a1732031e5f8cb1d35e6b441ff0772c735c66ac651d12cb3d27b4dc67cac2dR67-R69) `composeApp/src/commonMain/composeResources/values-zh-rSS/strings.xml` [[4]](diffhunk://#diff-a624edb4ebdc683ba8fc1a0fbddb7e61970817265df1bfd2e77cf4da6e9502a4R67-R69) `composeApp/src/commonMain/composeResources/values-zh-rHK/strings.xml` [[5]](diffhunk://#diff-ab72d4e9d49f82c4bb0a8e60fcac9dd04bb9cbe1a256ea09ff00442164da8fd1R67-R69) `composeApp/src/commonMain/composeResources/values-ca/strings.xml` [[6]](diffhunk://#diff-f4fce037aa00f10b72c3d9a0940d9aaf82aa3ff4840d7d1631ebb66507aea252R67-R69)
* Adds a DNS icon import for potential use in the device discovery UI. (`composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MobileHome.kt` [composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MobileHome.ktR46](diffhunk://#diff-d36e44f4e39caadb73ca8b4a693077ce76165a7726a16a70840d51a29d879db7R46))