### PR TITLE
fix: 数据目录迁移至平台标准路径

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/PluginManagerProvider.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/PluginManagerProvider.jvm.kt
@@ -46,6 +46,5 @@ actual fun createPluginManager(
 }
 
 actual fun getPluginsDirPath(): String {
-    val userHome = System.getProperty("user.home")
-    return File(userHome, ".micyou/plugins").absolutePath
+    return File(com.lanrhyme.micyou.platform.PlatformInfo.appDataDir, "plugins").absolutePath
 }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/audio/NoiseReducer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/audio/NoiseReducer.kt
@@ -43,12 +43,8 @@ object UlunasModelLoader {
             return path
         }
 
-        // 使用用户目录下的固定位置
-        val userDir = java.io.File(System.getProperty("user.home"), ".micyou")
-        if (!userDir.exists()) {
-            userDir.mkdirs()
-        }
-    val modelFile = java.io.File(userDir, "ulunas.onnx")
+        val dataDir = com.lanrhyme.micyou.platform.PlatformInfo.appDataDir
+        val modelFile = java.io.File(dataDir, "ulunas.onnx")
 
         // 如果已存在且有效，直接返回
         if (modelFile.exists() && modelFile.length() > 0) {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/platform/PlatformInfo.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/platform/PlatformInfo.kt
@@ -70,13 +70,14 @@ object PlatformInfo {
 
         val targetDir = appDataDir
         if (targetDir.absolutePath == legacyDir.absolutePath) return
-        if (targetDir.listFiles()?.isNotEmpty() == true) return
-
+        // 移除全局 isNotEmpty 检查，改为在循环中判断单个文件是否存在，以支持增量迁移和避免系统文件干扰
         logger("Migrating data from $legacyDir to $targetDir ...")
         var copied = 0
         legacyDir.listFiles()?.forEach { file ->
+            val dest = java.io.File(targetDir, file.name)
+            if (dest.exists()) return@forEach
             try {
-                file.copyRecursively(java.io.File(targetDir, file.name), overwrite = false)
+                file.copyRecursively(dest, overwrite = false)
                 copied++
                 logger("  Migrated: ${file.name}")
             } catch (e: Exception) {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/platform/PlatformInfo.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/platform/PlatformInfo.kt
@@ -36,4 +36,53 @@ object PlatformInfo {
     val osName: String get() = System.getProperty("os.name", "Unknown")
     val osVersion: String get() = System.getProperty("os.version", "Unknown")
     val osArch: String get() = System.getProperty("os.arch", "Unknown")
+
+    /**
+     * 应用数据目录，遵循各平台标准规范。
+     *
+     * Linux:   $XDG_DATA_HOME/micyou/  →  ~/.local/share/micyou/
+     * Windows: %LOCALAPPDATA%/MicYou/
+     * macOS:   ~/Library/Application Support/MicYou/
+     */
+    val appDataDir: java.io.File by lazy {
+        val home = System.getProperty("user.home")
+        val dir = when {
+            isLinux -> {
+                val xdgData = System.getenv("XDG_DATA_HOME")
+                    ?: "$home/.local/share"
+                java.io.File(xdgData, "micyou")
+            }
+            isWindows -> {
+                val localAppData = System.getenv("LOCALAPPDATA")
+                    ?: "$home/AppData/Local"
+                java.io.File(localAppData, "MicYou")
+            }
+            isMacOS -> java.io.File("$home/Library/Application Support", "MicYou")
+            else -> java.io.File(home, ".micyou")
+        }
+        dir.apply { mkdirs() }
+    }
+
+    fun migrateLegacyDataDir(logger: (String) -> Unit = {}) {
+        val home = System.getProperty("user.home")
+        val legacyDir = java.io.File(home, ".micyou")
+        if (!legacyDir.isDirectory) return
+
+        val targetDir = appDataDir
+        if (targetDir.absolutePath == legacyDir.absolutePath) return
+        if (targetDir.listFiles()?.isNotEmpty() == true) return
+
+        logger("Migrating data from $legacyDir to $targetDir ...")
+        var copied = 0
+        legacyDir.listFiles()?.forEach { file ->
+            try {
+                file.copyRecursively(java.io.File(targetDir, file.name), overwrite = false)
+                copied++
+                logger("  Migrated: ${file.name}")
+            } catch (e: Exception) {
+                logger("  Failed: ${file.name} — ${e.message}")
+            }
+        }
+        logger("Migration complete: $copied items copied, old directory preserved at $legacyDir")
+    }
 }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/util/Logger.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/util/Logger.kt
@@ -20,14 +20,14 @@ object JvmLogger : LoggerImpl {
     private const val MAX_ARCHIVED_FILES = 2
     
     private val logDir: File by lazy {
-        val userHome = System.getProperty("user.home")
-        File(userHome, ".micyou").apply {
-            if (!exists()) mkdirs()
-        }
+        com.lanrhyme.micyou.platform.PlatformInfo.appDataDir
     }
     
     fun init() {
         try {
+            com.lanrhyme.micyou.platform.PlatformInfo.migrateLegacyDataDir { msg ->
+                println("[MIGRATE] $msg")
+            }
             logFile = File(logDir, "micyou.log")
             logWriter = PrintWriter(FileWriter(logFile, true), true)
         } catch (e: Exception) {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/util/Settings.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/util/Settings.kt
@@ -12,8 +12,7 @@ import javax.crypto.spec.SecretKeySpec
 import org.jetbrains.compose.resources.getString
 
 object JvmSettings : Settings {
-    private val appDir: File = File(System.getProperty("user.dir"))
-    private val configFile: File = File(appDir, "micyou.conf")
+    private val configFile: File = File(com.lanrhyme.micyou.platform.PlatformInfo.appDataDir, "micyou.conf")
     private val fileSettings: FileSettings = FileSettings(configFile)
 
     private const val MIRROR_CDK_KEY = "mirror_cdk"


### PR DESCRIPTION
将 5 个数据文件写入点统一迁移至 `PlatformInfo.appDataDir`：

| 平台 | 路径 |
|------|------|
| Linux | `$XDG_DATA_HOME/micyou` → `~/.local/share/micyou/` |
| Windows | `%LOCALAPPDATA%/MicYou/` |
| macOS | `~/Library/Application Support/MicYou/` |

同时会在启动时自动执行一次迁移，将~/.micyou中的文件复制到目标目录