### PR TITLE
feat(desktop): 添加网页模式 (Web Mode)，手机无需安装 App 即可使用

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -106,6 +106,10 @@ kotlin {
             implementation(libs.onnxruntime)
             implementation(libs.jtransforms)
             implementation(libs.jmdns)
+            implementation("io.ktor:ktor-server-cio:${libs.versions.ktor.get()}")
+            implementation("io.ktor:ktor-server-websockets:${libs.versions.ktor.get()}")
+            implementation(libs.zxing.core)
+            implementation(libs.zxing.javase)
         }
     }
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -110,6 +110,7 @@ kotlin {
             implementation(libs.ktor.server.cio)
             implementation(libs.ktor.server.content.negotiation)
             implementation(libs.ktor.server.websockets)
+            implementation(libs.bouncycastle.pkix)
             implementation(libs.zxing.core)
             implementation(libs.zxing.javase)
         }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -106,8 +106,10 @@ kotlin {
             implementation(libs.onnxruntime)
             implementation(libs.jtransforms)
             implementation(libs.jmdns)
-            implementation("io.ktor:ktor-server-cio:${libs.versions.ktor.get()}")
-            implementation("io.ktor:ktor-server-websockets:${libs.versions.ktor.get()}")
+            implementation(libs.ktor.server.core)
+            implementation(libs.ktor.server.cio)
+            implementation(libs.ktor.server.content.negotiation)
+            implementation(libs.ktor.server.websockets)
             implementation(libs.zxing.core)
             implementation(libs.zxing.javase)
         }

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/AudioEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/AudioEngine.android.kt
@@ -124,6 +124,7 @@ actual class AudioEngine actual constructor() {
 
     private val _isMuted = MutableStateFlow(false)
     actual val isMuted: Flow<Boolean> = _isMuted
+    actual val webServerUrl: Flow<String?> = MutableStateFlow(null)
 
     private var job: Job? = null
     private val startStopMutex = Mutex()

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/Platform.android.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import com.lanrhyme.micyou.theme.PaletteStyle
@@ -88,4 +89,6 @@ actual fun getVBCableInstallProgress(): kotlinx.coroutines.flow.Flow<String?> = 
 actual fun isWindowsPlatform(): Boolean = false
 
 actual fun isMacOSPlatform(): Boolean = false
+
+actual fun generateQrCodeImageBitmap(text: String, size: Int): ImageBitmap? = null
 

--- a/composeApp/src/commonMain/composeResources/values-ca/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ca/strings.xml
@@ -197,6 +197,10 @@
     <string name="missingOn">缺少于喵~</string>
     <string name="modeUsb">USB 喵~</string>
     <string name="modeWifi">Wi-Fi 喵~</string>
+    <string name="modeWeb">Web 喵~</string>
+    <string name="webModeLabel">网页模式喵~</string>
+    <string name="webScanHint">用手机浏览器扫二维码喵~ (ΦωΦ)</string>
+    <string name="webNotStartedHint">开始串流显示二维码喵~ (=^・ω・^=)</string>
     <string name="monitoringLabel">监听喵~</string>
     <string name="muteLabel">静音喵 (´-ω-`)</string>
     <string name="newVersionReleased">发现新版本喵~ ✨</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rHK/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rHK/strings.xml
@@ -197,6 +197,10 @@
     <string name="missingOn">缺少於</string>
     <string name="modeUsb">USB</string>
     <string name="modeWifi">Wi-Fi</string>
+    <string name="modeWeb">Web</string>
+    <string name="webModeLabel">網頁模式</string>
+    <string name="webScanHint">用手機瀏覽器掃描二維碼</string>
+    <string name="webNotStartedHint">開始串流以顯示二維碼</string>
     <string name="monitoringLabel">監聽</string>
     <string name="muteLabel">靜音</string>
     <string name="newVersionReleased">發現新版本</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rSS/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rSS/strings.xml
@@ -197,6 +197,10 @@
     <string name="missingOn">缺少于</string>
     <string name="modeUsb">通用串行总线式</string>
     <string name="modeWifi">无线保真度</string>
+    <string name="modeWeb">国际网络式</string>
+    <string name="webModeLabel">国际网络模式</string>
+    <string name="webScanHint">使用移动电话浏览器扫描二维条码</string>
+    <string name="webNotStartedHint">开始传输数据以显示二维条码</string>
     <string name="monitoringLabel">监视之中</string>
     <string name="muteLabel">静默化</string>
     <string name="newVersionReleased">新版本发布了</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -197,6 +197,10 @@
     <string name="missingOn">缺少於</string>
     <string name="modeUsb">USB</string>
     <string name="modeWifi">Wi-Fi</string>
+    <string name="modeWeb">Web</string>
+    <string name="webModeLabel">網頁模式</string>
+    <string name="webScanHint">用手機瀏覽器掃描二維碼</string>
+    <string name="webNotStartedHint">開始串流以顯示二維碼</string>
     <string name="monitoringLabel">監聽</string>
     <string name="muteLabel">靜音</string>
     <string name="newVersionReleased">發現新版本</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -197,6 +197,10 @@
     <string name="missingOn">缺少于</string>
     <string name="modeUsb">USB</string>
     <string name="modeWifi">Wi-Fi</string>
+    <string name="modeWeb">Web</string>
+    <string name="webModeLabel">网页模式</string>
+    <string name="webScanHint">用手机浏览器扫描二维码</string>
+    <string name="webNotStartedHint">开始串流以显示二维码</string>
     <string name="monitoringLabel">监听</string>
     <string name="muteLabel">静音</string>
     <string name="newVersionReleased">发现新版本</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -234,6 +234,10 @@
     <string name="missingOn">Missing on</string>
     <string name="modeUsb">USB</string>
     <string name="modeWifi">Wi-Fi</string>
+    <string name="modeWeb">Web</string>
+    <string name="webModeLabel">Web Mode</string>
+    <string name="webScanHint">Scan QR code with your phone browser</string>
+    <string name="webNotStartedHint">Start streaming to show QR code</string>
     <string name="monitoringLabel">Monitoring</string>
     <string name="muteLabel">Mute</string>
     <string name="newVersionReleased">New version released</string>

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioEngine.kt
@@ -16,6 +16,8 @@ expect class AudioEngine() {
     val lastError: Flow<String?>
     // 静音状态流
     val isMuted: Flow<Boolean>
+    // Web 服务器 URL 流（仅桌面端有效）
+    val webServerUrl: Flow<String?>
 
     // 启动音频引擎
     suspend fun start(

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
@@ -26,6 +26,10 @@ data class AudioStreamUiState(
     val showFirewallDialog: Boolean = false,
     val pendingFirewallPort: Int? = null,
 
+    // Web Mode State
+    val webUrl: String? = null,
+    val webServerRunning: Boolean = false,
+
     // Error Dialog State
     val showErrorDialog: Boolean = false,
     val errorDetails: ConnectionErrorDetails? = null,
@@ -179,6 +183,12 @@ class AudioStreamViewModel : ViewModel() {
             }
         }
 
+        viewModelScope.launch {
+            _audioEngine.webServerUrl.collect { url ->
+                _uiState.update { it.copy(webUrl = url, webServerRunning = url != null) }
+            }
+        }
+
         // 监听音频电平数据并更新历史记录
         viewModelScope.launch {
             _audioEngine.audioLevelData.collect { levelData ->
@@ -250,32 +260,36 @@ class AudioStreamViewModel : ViewModel() {
     val rawPort = _uiState.value.port.toIntOrNull()
     val port = when {
             rawPort == null -> {
-                Logger.w("AudioStreamViewModel", "Invalid port format: ${_uiState.value.port}, using default 6000")
-                6000
+                val defaultPort = if (mode == ConnectionMode.Web) 8765 else 6000
+                Logger.w("AudioStreamViewModel", "Invalid port format: ${_uiState.value.port}, using default $defaultPort")
+                defaultPort
             }
             rawPort <= 0 || rawPort > 65535 -> {
-                Logger.w("AudioStreamViewModel", "Port out of range: $rawPort, using default 6000")
-                6000
+                val defaultPort = if (mode == ConnectionMode.Web) 8765 else 6000
+                Logger.w("AudioStreamViewModel", "Port out of range: $rawPort, using default $defaultPort")
+                defaultPort
             }
             else -> rawPort
         }
 
-        // IP 地址验证
-        if (ip.isBlank()) {
-            Logger.e("AudioStreamViewModel", "IP address is empty")
-            _uiState.update {
-                it.copy(
-                    streamState = StreamState.Error,
-                    errorMessage = "IP 地址不能为空",
-                    showErrorDialog = true
-                )
+        // IP 地址验证 (Web 模式不需要 IP)
+        if (mode != ConnectionMode.Web) {
+            if (ip.isBlank()) {
+                Logger.e("AudioStreamViewModel", "IP address is empty")
+                _uiState.update {
+                    it.copy(
+                        streamState = StreamState.Error,
+                        errorMessage = "IP 地址不能为空",
+                        showErrorDialog = true
+                    )
+                }
+                return
             }
-            return
-        }
-        // 基本的 IP 格式验证
-        val ipRegex = Regex("^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")
-        if (!ipRegex.matches(ip) && !ip.startsWith("127.")) {
-            Logger.w("AudioStreamViewModel", "IP address format may be invalid: $ip")
+            // 基本的 IP 格式验证
+            val ipRegex = Regex("^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")
+            if (!ipRegex.matches(ip) && !ip.startsWith("127.")) {
+                Logger.w("AudioStreamViewModel", "IP address format may be invalid: $ip")
+            }
         }
     val isClient = getPlatform().type == PlatformType.Android
         val sampleRate = _uiState.value.sampleRate

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
@@ -17,6 +17,7 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
@@ -440,6 +441,7 @@ private fun NetworkConfigCard(
                         value = when (state.mode) {
                             ConnectionMode.Wifi -> stringResource(Res.string.modeWifi)
                             ConnectionMode.Usb -> stringResource(Res.string.modeUsb)
+                            ConnectionMode.Web -> stringResource(Res.string.modeWeb)
                             else -> stringResource(Res.string.modeWifi)
                         },
                         onValueChange = {},
@@ -471,25 +473,100 @@ private fun NetworkConfigCard(
                                 expanded = false
                             }
                         )
+                        DropdownMenuItem(
+                            text = { Text(stringResource(Res.string.modeWeb)) },
+                            onClick = {
+                                viewModel.setMode(ConnectionMode.Web)
+                                expanded = false
+                            }
+                        )
                     }
                 }
 
-                AnimatedVisibility(
-                    visible = true,
-                    enter = fadeIn(tween(200)) + scaleIn(initialScale = 0.9f),
-                    exit = fadeOut(tween(150)) + scaleOut(targetScale = 0.9f)
-                ) {
-                    OutlinedTextField(
-                        value = state.port,
-                        onValueChange = { viewModel.setPort(it) },
-                        label = { Text(stringResource(Res.string.portLabel)) },
-                        modifier = Modifier.fillMaxWidth().heightIn(min = 60.dp),
-                        textStyle = MaterialTheme.typography.bodySmall,
-                        singleLine = true,
-                        shape = MaterialTheme.shapes.medium
-                    )
+                if (state.mode == ConnectionMode.Web) {
+                    AnimatedVisibility(
+                        visible = true,
+                        enter = fadeIn(tween(200)) + scaleIn(initialScale = 0.9f),
+                        exit = fadeOut(tween(150)) + scaleOut(targetScale = 0.9f)
+                    ) {
+                        PocketWebQrCard(
+                            webUrl = state.webUrl,
+                            streamState = state.streamState
+                        )
+                    }
+                } else {
+                    AnimatedVisibility(
+                        visible = true,
+                        enter = fadeIn(tween(200)) + scaleIn(initialScale = 0.9f),
+                        exit = fadeOut(tween(150)) + scaleOut(targetScale = 0.9f)
+                    ) {
+                        OutlinedTextField(
+                            value = state.port,
+                            onValueChange = { viewModel.setPort(it) },
+                            label = { Text(stringResource(Res.string.portLabel)) },
+                            modifier = Modifier.fillMaxWidth().heightIn(min = 60.dp),
+                            textStyle = MaterialTheme.typography.bodySmall,
+                            singleLine = true,
+                            shape = MaterialTheme.shapes.medium
+                        )
+                    }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun PocketWebQrCard(
+    webUrl: String?,
+    streamState: StreamState
+) {
+    val isLoading = streamState == StreamState.Connecting
+    val isRunning = streamState == StreamState.Streaming
+
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        if (isRunning && webUrl != null) {
+            val qrBitmap = remember(webUrl) {
+                generateQrCodeImageBitmap(webUrl, 140)
+            }
+
+            if (qrBitmap != null) {
+                androidx.compose.foundation.Image(
+                    bitmap = qrBitmap,
+                    contentDescription = "QR Code",
+                    modifier = Modifier.size(140.dp)
+                )
+
+                Text(
+                    text = webUrl,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    textAlign = TextAlign.Center,
+                    maxLines = 1
+                )
+
+                Text(
+                    text = stringResource(Res.string.webScanHint),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else if (isLoading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(32.dp),
+                strokeWidth = 2.dp
+            )
+        } else {
+            Text(
+                stringResource(Res.string.webNotStartedHint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
@@ -20,6 +20,7 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.scrollBy
@@ -121,6 +122,7 @@ import micyou.composeapp.generated.resources.firewallTitle
 import micyou.composeapp.generated.resources.icon_pip
 import micyou.composeapp.generated.resources.minimize
 import micyou.composeapp.generated.resources.modeUsb
+import micyou.composeapp.generated.resources.modeWeb
 import micyou.composeapp.generated.resources.modeWifi
 import micyou.composeapp.generated.resources.monitoringLabel
 import micyou.composeapp.generated.resources.monitoringTitle
@@ -134,6 +136,9 @@ import micyou.composeapp.generated.resources.statusIdle
 import micyou.composeapp.generated.resources.statusStreaming
 import micyou.composeapp.generated.resources.systemConfigTitle
 import micyou.composeapp.generated.resources.unmuteLabel
+import micyou.composeapp.generated.resources.webModeLabel
+import micyou.composeapp.generated.resources.webNotStartedHint
+import micyou.composeapp.generated.resources.webScanHint
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import kotlin.math.abs
@@ -598,14 +603,24 @@ private fun LeftPanel(
             hazeState = hazeState,
             enableHaze = state.backgroundSettings.enableHazeEffect
         )
-        
-        PortCard(
-            port = state.port,
-            onPortChange = { viewModel.setPort(it) },
-            cardOpacity = cardOpacity,
-            hazeState = hazeState,
-            enableHaze = state.backgroundSettings.enableHazeEffect
-        )
+
+        if (state.mode == ConnectionMode.Web) {
+            WebQrCard(
+                webUrl = state.webUrl,
+                streamState = state.streamState,
+                cardOpacity = cardOpacity,
+                hazeState = hazeState,
+                enableHaze = state.backgroundSettings.enableHazeEffect
+            )
+        } else {
+            PortCard(
+                port = state.port,
+                onPortChange = { viewModel.setPort(it) },
+                cardOpacity = cardOpacity,
+                hazeState = hazeState,
+                enableHaze = state.backgroundSettings.enableHazeEffect
+            )
+        }
         
         StatusCard(
             streamState = state.streamState,
@@ -638,7 +653,8 @@ private fun ModeCard(
             Text(stringResource(Res.string.connectionModeLabel), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
     val modes = listOf(
                 ConnectionMode.Wifi to (stringResource(Res.string.modeWifi) to Icons.Rounded.Wifi),
-                ConnectionMode.Usb to (stringResource(Res.string.modeUsb) to Icons.Rounded.Usb)
+                ConnectionMode.Usb to (stringResource(Res.string.modeUsb) to Icons.Rounded.Usb),
+                ConnectionMode.Web to (stringResource(Res.string.modeWeb) to Icons.Rounded.Language)
             )
             
             Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
@@ -705,6 +721,91 @@ private fun PortCard(
                 singleLine = true,
                 textStyle = MaterialTheme.typography.bodySmall
             )
+        }
+    }
+}
+
+@Composable
+private fun WebQrCard(
+    webUrl: String?,
+    streamState: StreamState,
+    cardOpacity: Float = 1f,
+    hazeState: HazeState? = null,
+    enableHaze: Boolean = false
+) {
+    val isLoading = streamState == StreamState.Connecting
+    val isRunning = streamState == StreamState.Streaming
+
+    HazeSurface(
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceBright.copy(alpha = cardOpacity),
+        hazeColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha = cardOpacity * 0.7f),
+        modifier = Modifier.fillMaxWidth(),
+        hazeState = hazeState,
+        enabled = enableHaze
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                stringResource(Res.string.webModeLabel),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            if (isRunning && webUrl != null) {
+                val qrBitmap = remember(webUrl) {
+                    generateQrCodeImageBitmap(webUrl, 180)
+                }
+
+                if (qrBitmap != null) {
+                    androidx.compose.foundation.Image(
+                        bitmap = qrBitmap,
+                        contentDescription = "QR Code",
+                        modifier = Modifier.size(180.dp)
+                    )
+
+                    Spacer(Modifier.height(4.dp))
+
+                    Text(
+                        text = webUrl,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        textAlign = TextAlign.Center,
+                        maxLines = 2,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    Spacer(Modifier.height(4.dp))
+
+                    Text(
+                        text = stringResource(Res.string.webScanHint),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            } else if (isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(48.dp),
+                    strokeWidth = 3.dp
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    stringResource(Res.string.statusConnecting),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.tertiary
+                )
+            } else {
+                Text(
+                    stringResource(Res.string.webNotStartedHint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
@@ -16,7 +16,8 @@ import org.jetbrains.compose.resources.getString
 
 enum class ConnectionMode(val label: String) {
     Wifi("Wi-Fi"),
-    Usb("USB (ADB)")
+    Usb("USB (ADB)"),
+    Web("Web")
 }
 
 enum class StreamState {
@@ -75,6 +76,10 @@ data class AppUiState(
     val amplification: Float = 15.0f,
     val androidAudioSourceName: String = "Unprocessed",
     val audioConfigRevision: Int = 0,
+
+    // Web Mode State
+    val webUrl: String? = null,
+    val webServerRunning: Boolean = false,
     
     // Settings State
     val themeMode: ThemeMode = ThemeMode.System,
@@ -296,6 +301,8 @@ class MainViewModel : ViewModel() {
                         amplification = audioState.amplification,
                         androidAudioSourceName = audioState.androidAudioSourceName,
                         audioConfigRevision = audioState.audioConfigRevision,
+                        webUrl = audioState.webUrl,
+                        webServerRunning = audioState.webServerRunning,
                         themeMode = settingsState.themeMode,
                         seedColor = settingsState.seedColor,
                         useDynamicColor = settingsState.useDynamicColor,

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Platform.kt
@@ -2,6 +2,7 @@ package com.lanrhyme.micyou
 
 import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.ImageBitmap
 import com.lanrhyme.micyou.theme.PaletteStyle
 
 enum class PlatformType {
@@ -104,4 +105,10 @@ expect fun isWindowsPlatform(): Boolean
  * Check if running on macOS platform.
  */
 expect fun isMacOSPlatform(): Boolean
+
+/**
+ * Generate a QR code ImageBitmap for the given text.
+ * Returns null if generation fails.
+ */
+expect fun generateQrCodeImageBitmap(text: String, size: Int): ImageBitmap?
 

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
@@ -9,7 +9,7 @@ import com.lanrhyme.micyou.network.MdnsAdvertiser
 import com.lanrhyme.micyou.network.NetworkServer
 import com.lanrhyme.micyou.platform.AdbManager
 import com.lanrhyme.micyou.platform.PlatformInfo
-import com.lanrhyme.micyou.web.WebAudioServer
+import com.lanrhyme.micyou.web.WebModeService
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -33,7 +33,8 @@ actual class AudioEngine actual constructor() {
 
     private val _isMuted = MutableStateFlow(false)
     actual val isMuted: Flow<Boolean> = _isMuted
-    actual val webServerUrl: Flow<String?> = WebAudioServer.webUrl
+    private val webModeService = WebModeService()
+    actual val webServerUrl: Flow<String?> = webModeService.webUrl
     
     private val _pluginSyncReceived = MutableStateFlow<PluginSyncMessage?>(null)
     val pluginSyncReceived: Flow<PluginSyncMessage?> = _pluginSyncReceived
@@ -106,7 +107,7 @@ actual class AudioEngine actual constructor() {
         }
 
         scope.launch {
-            WebAudioServer.state.collect { newState ->
+            webModeService.state.collect { newState ->
                 if (newState == StreamState.Streaming) {
                     audioPipeline.reset()
                     startAudioProcessing()
@@ -121,7 +122,7 @@ actual class AudioEngine actual constructor() {
             }
         }
         scope.launch {
-            WebAudioServer.lastError.collect { error ->
+            webModeService.lastError.collect { error ->
                 if (error != null) {
                     _lastError.value = error
                 }
@@ -249,8 +250,8 @@ actual class AudioEngine actual constructor() {
                 if (mode == ConnectionMode.Web) {
                     val webPort = if (port in 1..65535) port else 0
                     Logger.i("AudioEngine", "启动 Web 服务器，端口: $webPort")
-                    WebAudioServer.start(webPort)
-                    Logger.i("AudioEngine", "WebAudioServer started successfully")
+                    webModeService.start(webPort)
+                    Logger.i("AudioEngine", "WebModeService started successfully")
                 } else {
                     // 直接调用 networkServer.start()，不 launch 新协程
                     // NetworkServer 内部会管理自己的协程
@@ -307,10 +308,10 @@ actual class AudioEngine actual constructor() {
                      }
 
                      try {
-                         WebAudioServer.stop()
-                     } catch (e: Exception) {
-                         Logger.e("AudioEngine", "Error stopping WebAudioServer: ${e.message}", e)
-                     }
+                        webModeService.stop()
+                    } catch (e: Exception) {
+                        Logger.e("AudioEngine", "Error stopping WebModeService: ${e.message}", e)
+                    }
                  }
              } else {
                  Logger.d("AudioEngine", "Stop operation already in progress, skipping duplicate stop request")
@@ -334,7 +335,7 @@ actual class AudioEngine actual constructor() {
             Logger.d("AudioEngine", "Web 音频馈送协程已启动")
             while (isActive) {
                 try {
-                    val audioPacket = WebAudioServer.receiveAudioPacket() ?: continue
+                    val audioPacket = webModeService.receiveAudioPacket() ?: continue
                     processReceivedPacket(audioPacket)
                 } catch (e: CancellationException) {
                     throw e

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
@@ -9,6 +9,8 @@ import com.lanrhyme.micyou.network.MdnsAdvertiser
 import com.lanrhyme.micyou.network.NetworkServer
 import com.lanrhyme.micyou.platform.AdbManager
 import com.lanrhyme.micyou.platform.PlatformInfo
+import com.lanrhyme.micyou.web.SslCertificateManager
+import com.lanrhyme.micyou.web.SslConfig
 import com.lanrhyme.micyou.web.WebModeService
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
@@ -249,8 +251,9 @@ actual class AudioEngine actual constructor() {
             } else {
                 if (mode == ConnectionMode.Web) {
                     val webPort = if (port in 1..65535) port else 0
-                    Logger.i("AudioEngine", "启动 Web 服务器，端口: $webPort")
-                    webModeService.start(webPort)
+                    Logger.i("AudioEngine", "启动 Web 服务器 (HTTPS)，端口: $webPort")
+                    val sslConfig = buildSslConfig()
+                    webModeService.start(webPort, sslConfig)
                     Logger.i("AudioEngine", "WebModeService started successfully")
                 } else {
                     // 直接调用 networkServer.start()，不 launch 新协程
@@ -275,6 +278,18 @@ actual class AudioEngine actual constructor() {
         networkServer.sendMuteState(muted)
     }
     
+    private fun buildSslConfig(): SslConfig {
+        val password = "micyou_ssl".toCharArray()
+        val keyStore = SslCertificateManager.generateSelfSignedKeyStore(password)
+
+        return SslConfig(
+            keyStore = keyStore,
+            keyAlias = "micyou",
+            keyStorePassword = { password },
+            privateKeyPassword = { password }
+        )
+    }
+
     suspend fun sendPluginSync(plugins: List<PluginInfoMessage>, platform: String) {
         networkServer.sendPluginSync(plugins, platform)
     }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
@@ -118,9 +118,7 @@ actual class AudioEngine actual constructor() {
                     stopAudioProcessing()
                     stopWebAudioFeeding()
                 }
-                if (_state.value != StreamState.Streaming) {
-                    _state.value = newState
-                }
+                _state.value = newState
             }
         }
         scope.launch {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
@@ -9,6 +9,7 @@ import com.lanrhyme.micyou.network.MdnsAdvertiser
 import com.lanrhyme.micyou.network.NetworkServer
 import com.lanrhyme.micyou.platform.AdbManager
 import com.lanrhyme.micyou.platform.PlatformInfo
+import com.lanrhyme.micyou.web.WebAudioServer
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -32,6 +33,7 @@ actual class AudioEngine actual constructor() {
 
     private val _isMuted = MutableStateFlow(false)
     actual val isMuted: Flow<Boolean> = _isMuted
+    actual val webServerUrl: Flow<String?> = WebAudioServer.webUrl
     
     private val _pluginSyncReceived = MutableStateFlow<PluginSyncMessage?>(null)
     val pluginSyncReceived: Flow<PluginSyncMessage?> = _pluginSyncReceived
@@ -40,6 +42,7 @@ actual class AudioEngine actual constructor() {
     private var job: Job? = null
     private var audioProcessingJob: Job? = null
     private var stopJob: Job? = null // 用于跟踪停止操作，防止竞态条件
+    private var webAudioFeedingJob: Job? = null
     private val startStopMutex = Mutex()
 
     private val audioOutputManager = AudioOutputManager()
@@ -96,6 +99,29 @@ actual class AudioEngine actual constructor() {
         }
         scope.launch {
             networkServer.lastError.collect { error ->
+                if (error != null) {
+                    _lastError.value = error
+                }
+            }
+        }
+
+        scope.launch {
+            WebAudioServer.state.collect { newState ->
+                if (newState == StreamState.Streaming) {
+                    audioPipeline.reset()
+                    startAudioProcessing()
+                    startWebAudioFeeding()
+                } else if (newState == StreamState.Idle || newState == StreamState.Error) {
+                    stopAudioProcessing()
+                    stopWebAudioFeeding()
+                }
+                if (_state.value != StreamState.Streaming) {
+                    _state.value = newState
+                }
+            }
+        }
+        scope.launch {
+            WebAudioServer.lastError.collect { error ->
                 if (error != null) {
                     _lastError.value = error
                 }
@@ -220,10 +246,17 @@ actual class AudioEngine actual constructor() {
             if (currentJob != null && !currentJob.isCompleted) {
                 Logger.w("AudioEngine", "AudioEngine 已在运行，忽略启动请求")
             } else {
-                // 直接调用 networkServer.start()，不 launch 新协程
-                // NetworkServer 内部会管理自己的协程
-                networkServer.start(port)
-                Logger.i("AudioEngine", "NetworkServer started successfully")
+                if (mode == ConnectionMode.Web) {
+                    val webPort = if (port in 1..65535) port else 0
+                    Logger.i("AudioEngine", "启动 Web 服务器，端口: $webPort")
+                    WebAudioServer.start(webPort)
+                    Logger.i("AudioEngine", "WebAudioServer started successfully")
+                } else {
+                    // 直接调用 networkServer.start()，不 launch 新协程
+                    // NetworkServer 内部会管理自己的协程
+                    networkServer.start(port)
+                    Logger.i("AudioEngine", "NetworkServer started successfully")
+                }
             }
         }
     }
@@ -272,10 +305,17 @@ actual class AudioEngine actual constructor() {
                      } catch (e: Exception) {
                          Logger.e("AudioEngine", "Error in async stop: ${e.message}", e)
                      }
+
+                     try {
+                         WebAudioServer.stop()
+                     } catch (e: Exception) {
+                         Logger.e("AudioEngine", "Error stopping WebAudioServer: ${e.message}", e)
+                     }
                  }
              } else {
                  Logger.d("AudioEngine", "Stop operation already in progress, skipping duplicate stop request")
              }
+             stopWebAudioFeeding()
              _lastError.value = null
              _state.value = StreamState.Idle
          } catch (e: Exception) {
@@ -285,6 +325,30 @@ actual class AudioEngine actual constructor() {
              audioPipeline.release()
              mdnsAdvertiser.close()
          }
+    }
+
+    private fun startWebAudioFeeding() {
+        if (webAudioFeedingJob?.isActive == true) return
+
+        webAudioFeedingJob = scope.launch(Dispatchers.Default) {
+            Logger.d("AudioEngine", "Web 音频馈送协程已启动")
+            while (isActive) {
+                try {
+                    val audioPacket = WebAudioServer.receiveAudioPacket() ?: continue
+                    processReceivedPacket(audioPacket)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.e("AudioEngine", "Web 音频馈送错误", e)
+                }
+            }
+            Logger.d("AudioEngine", "Web 音频馈送协程已停止")
+        }
+    }
+
+    private fun stopWebAudioFeeding() {
+        webAudioFeedingJob?.cancel()
+        webAudioFeedingJob = null
     }
     
     /**

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
@@ -4,14 +4,20 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
 import com.lanrhyme.micyou.platform.FirewallManager
 import com.lanrhyme.micyou.platform.PlatformInfo
 import com.lanrhyme.micyou.platform.WindowsAccentColorExtractor
 import com.lanrhyme.micyou.theme.PaletteStyle
 import com.lanrhyme.micyou.theme.dynamicColorScheme
+import com.lanrhyme.micyou.web.QrCodeGenerator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.jetbrains.skia.Image
+import java.io.ByteArrayOutputStream
 import java.net.InetAddress
+import javax.imageio.ImageIO
 
 class JVMPlatform: Platform {
     override val name: String = "Java ${System.getProperty("java.version")}"
@@ -156,3 +162,17 @@ actual fun getVBCableInstallProgress(): kotlinx.coroutines.flow.Flow<String?> = 
 actual fun isWindowsPlatform(): Boolean = PlatformInfo.isWindows
 
 actual fun isMacOSPlatform(): Boolean = PlatformInfo.isMacOS
+
+actual fun generateQrCodeImageBitmap(text: String, size: Int): ImageBitmap? {
+    return try {
+        val bufferedImage = QrCodeGenerator.generateQrCodeImage(text, size)
+        val baos = ByteArrayOutputStream()
+        ImageIO.write(bufferedImage, "PNG", baos)
+        val bytes = baos.toByteArray()
+        val skiaImage = Image.makeFromEncoded(bytes)
+        skiaImage.toComposeImageBitmap()
+    } catch (e: Exception) {
+        Logger.e("Platform", "Failed to generate QR code: ${e.message}", e)
+        null
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/QrCodeGenerator.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/QrCodeGenerator.kt
@@ -1,0 +1,32 @@
+package com.lanrhyme.micyou.web
+
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
+import com.google.zxing.qrcode.QRCodeWriter
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
+import java.awt.image.BufferedImage
+
+object QrCodeGenerator {
+    private const val DEFAULT_SIZE = 256
+    private const val MARGIN = 2
+
+    fun generateQrCodeImage(text: String, size: Int = DEFAULT_SIZE): BufferedImage {
+        val hints = mapOf(
+            EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.M,
+            EncodeHintType.MARGIN to MARGIN,
+            EncodeHintType.CHARACTER_SET to "UTF-8"
+        )
+
+        val bitMatrix = QRCodeWriter().encode(text, BarcodeFormat.QR_CODE, size, size, hints)
+        val image = BufferedImage(size, size, BufferedImage.TYPE_INT_RGB)
+
+        for (x in 0 until size) {
+            for (y in 0 until size) {
+                val color = if (bitMatrix.get(x, y)) 0xFF000000.toInt() else 0xFFFFFFFF.toInt()
+                image.setRGB(x, y, color)
+            }
+        }
+
+        return image
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/SslCertificateManager.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/SslCertificateManager.kt
@@ -1,0 +1,60 @@
+package com.lanrhyme.micyou.web
+
+import com.lanrhyme.micyou.Logger
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.cert.X509v3CertificateBuilder
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import java.math.BigInteger
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.SecureRandom
+import java.security.Security
+import java.util.Date
+
+object SslCertificateManager {
+    private const val TAG = "SslCertificateManager"
+
+    init {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(BouncyCastleProvider())
+        }
+    }
+
+    fun generateSelfSignedKeyStore(
+        password: CharArray,
+        commonName: String = "MicYou Web Server"
+    ): KeyStore {
+        val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
+        keyPairGenerator.initialize(2048, SecureRandom())
+        val keyPair = keyPairGenerator.generateKeyPair()
+
+        val notBefore = Date()
+        val notAfter = Date(notBefore.time + 365L * 24 * 60 * 60 * 1000)
+
+        val issuer = X500Name("CN=$commonName, O=MicYou, C=CN")
+        val subject = issuer
+        val serial = BigInteger.valueOf(System.currentTimeMillis())
+
+        val certBuilder: X509v3CertificateBuilder = JcaX509v3CertificateBuilder(
+            issuer, serial, notBefore, notAfter, subject, keyPair.public
+        )
+
+        val signer = JcaContentSignerBuilder("SHA256WithRSA").build(keyPair.private)
+
+        val certHolder: X509CertificateHolder = certBuilder.build(signer)
+        val cert = JcaX509CertificateConverter()
+            .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+            .getCertificate(certHolder)
+
+        val keyStore = KeyStore.getInstance("PKCS12")
+        keyStore.load(null, password)
+        keyStore.setKeyEntry("micyou", keyPair.private, password, arrayOf(cert))
+
+        Logger.i(TAG, "Generated self-signed certificate for: $commonName")
+        return keyStore
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/WebAudioServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/WebAudioServer.kt
@@ -1,0 +1,416 @@
+package com.lanrhyme.micyou.web
+
+import com.lanrhyme.micyou.AudioPacketMessage
+import com.lanrhyme.micyou.Logger
+import com.lanrhyme.micyou.StreamState
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.cio.*
+import io.ktor.server.engine.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.websocket.*
+import io.ktor.websocket.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.net.Inet4Address
+import java.net.NetworkInterface
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+object WebAudioServer {
+    private const val SAMPLE_RATE = 48000
+    private const val HOP_LENGTH = 256
+
+    private val audioPacketChannel = Channel<AudioPacketMessage>(
+        capacity = 200,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    private val _state = MutableStateFlow(StreamState.Idle)
+    val state = _state.asStateFlow()
+
+    private val _lastError = MutableStateFlow<String?>(null)
+    val lastError = _lastError.asStateFlow()
+
+    private val _webUrl = MutableStateFlow<String?>(null)
+    val webUrl = _webUrl.asStateFlow()
+
+    private val _clientCount = MutableStateFlow(0)
+    val clientCount = _clientCount.asStateFlow()
+
+    private var server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
+    private var serverPort: Int = 0
+
+    fun getLocalIps(): List<String> {
+        val ips = mutableListOf<String>()
+        try {
+            val interfaces = NetworkInterface.getNetworkInterfaces()
+            while (interfaces.hasMoreElements()) {
+                val iface = interfaces.nextElement()
+                if (iface.isLoopback || !iface.isUp) continue
+                val addresses = iface.inetAddresses
+                while (addresses.hasMoreElements()) {
+                    val addr = addresses.nextElement()
+                    if (addr is Inet4Address && !addr.isLoopbackAddress) {
+                        ips.add(addr.hostAddress ?: continue)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Logger.w("WebAudioServer", "Failed to get local IPs: ${e.message}")
+        }
+
+        ips.sortBy { ip ->
+            when {
+                ip.startsWith("192.168.1.") -> 0
+                ip.startsWith("192.168.0.") -> 1
+                ip.startsWith("192.168.") -> 2
+                ip.startsWith("192.") -> 3
+                ip.startsWith("10.") -> 4
+                ip.startsWith("172.") -> 5
+                else -> 10
+            }
+        }
+        return ips
+    }
+
+    fun getBestUrl(): String? {
+        val protocol = "http"
+        val ips = getLocalIps()
+        if (ips.isNotEmpty()) {
+            return "$protocol://${ips.first()}:$serverPort"
+        }
+        return "$protocol://127.0.0.1:$serverPort"
+    }
+
+    fun getAllUrls(): List<String> {
+        val protocol = "http"
+        return getLocalIps().map { "$protocol://$it:$serverPort" }
+    }
+
+    fun getPort(): Int = serverPort
+
+    suspend fun start(port: Int = 0) {
+        if (server != null) {
+            Logger.w("WebAudioServer", "Server already running")
+            return
+        }
+
+        _state.value = StreamState.Connecting
+        _lastError.value = null
+
+        try {
+            val actualPort = if (port > 0) port else findFreePort()
+            serverPort = actualPort
+
+            val urls = getAllUrls()
+            val primaryUrl = urls.firstOrNull() ?: "http://127.0.0.1:$actualPort"
+            _webUrl.value = primaryUrl
+            Logger.i("WebAudioServer", "Available URLs: $urls")
+
+            server = embeddedServer(CIO, port = actualPort, host = "0.0.0.0") {
+                install(WebSockets)
+
+                routing {
+                    get("/") {
+                        call.respondText(
+                            text = buildHtmlPage(),
+                            contentType = ContentType.Text.Html.withCharset(Charsets.UTF_8)
+                        )
+                    }
+
+                    webSocket("/") {
+                        _clientCount.value++
+                        Logger.i("WebAudioServer", "WebSocket client connected (total: ${_clientCount.value})")
+                        _state.value = StreamState.Streaming
+
+                        try {
+                            for (frame in incoming) {
+                                if (frame is Frame.Binary) {
+                                    processAudioFrame(frame.data)
+                                }
+                            }
+                        } catch (e: Exception) {
+                            Logger.w("WebAudioServer", "WebSocket error: ${e.message}")
+                        } finally {
+                            _clientCount.value--
+                            Logger.i("WebAudioServer", "WebSocket client disconnected (total: ${_clientCount.value})")
+                            if (_clientCount.value == 0) {
+                                _state.value = StreamState.Connecting
+                            }
+                        }
+                    }
+                }
+            }
+
+            server?.start(wait = false)
+            _state.value = StreamState.Connecting
+            Logger.i("WebAudioServer", "Server started on port $actualPort")
+        } catch (e: Exception) {
+            Logger.e("WebAudioServer", "Failed to start server: ${e.message}", e)
+            _state.value = StreamState.Error
+            _lastError.value = e.message
+            throw e
+        }
+    }
+
+    suspend fun stop() {
+        try {
+            server?.stop(1000, 2000)
+            server = null
+            _state.value = StreamState.Idle
+            _webUrl.value = null
+            _clientCount.value = 0
+            Logger.i("WebAudioServer", "Server stopped")
+        } catch (e: Exception) {
+            Logger.e("WebAudioServer", "Error stopping server: ${e.message}", e)
+        }
+    }
+
+    suspend fun receiveAudioPacket(): AudioPacketMessage? {
+        return try {
+            audioPacketChannel.receiveCatching().getOrNull()
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun processAudioFrame(data: ByteArray) {
+        if (data.size < 4) return
+
+        val numFloats = data.size / 4
+        val floatBuffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer()
+        val floatArray = FloatArray(numFloats)
+        floatBuffer.get(floatArray)
+
+        val shortArray = ShortArray(numFloats) { i ->
+            val clamped = floatArray[i].coerceIn(-1f, 1f)
+            (clamped * 32767f).toInt().toShort()
+        }
+
+        val byteBuffer = ByteBuffer.allocate(shortArray.size * 2).order(ByteOrder.LITTLE_ENDIAN)
+        shortArray.forEach { byteBuffer.putShort(it) }
+        val pcmBytes = byteBuffer.array()
+
+        val audioPacket = AudioPacketMessage(
+            buffer = pcmBytes,
+            sampleRate = SAMPLE_RATE,
+            channelCount = 1,
+            audioFormat = 3
+        )
+
+        try {
+            audioPacketChannel.trySend(audioPacket)
+        } catch (e: Exception) {
+            Logger.w("WebAudioServer", "Audio packet channel full, dropping packet")
+        }
+    }
+
+    private fun findFreePort(): Int {
+        return try {
+            val socket = java.net.ServerSocket(0)
+            val port = socket.localPort
+            socket.close()
+            port
+        } catch (e: Exception) {
+            8765
+        }
+    }
+
+    private fun buildHtmlPage(): String {
+        return HTML_PAGE.replace("{HOP_LENGTH}", HOP_LENGTH.toString())
+    }
+
+    private val HTML_PAGE = """<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MicYou Web</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { 
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+            min-height: 100vh; display: flex; flex-direction: column;
+            align-items: center; justify-content: center; color: #fff; padding: 20px;
+        }
+        .container { text-align: center; max-width: 400px; width: 100%; }
+        h1 { font-size: 1.5em; margin-bottom: 10px; color: #4fc3f7; }
+        .status { 
+            padding: 15px 25px; border-radius: 10px; margin: 20px 0;
+            font-size: 1.1em; font-weight: 500;
+        }
+        .status.connected { background: #2e7d32; }
+        .status.disconnected { background: #c62828; }
+        .status.connecting { background: #f57c00; }
+        button {
+            padding: 15px 40px; font-size: 1.2em; border: none;
+            border-radius: 30px; cursor: pointer; margin: 10px;
+            transition: all 0.3s ease; font-weight: 600;
+        }
+        .start-btn { background: #4fc3f7; color: #1a1a2e; }
+        .start-btn:hover { background: #29b6f6; transform: scale(1.05); }
+        .stop-btn { background: #ef5350; color: #fff; }
+        .stop-btn:hover { background: #e53935; transform: scale(1.05); }
+        .audio-level {
+            width: 100%; height: 20px; background: #333;
+            border-radius: 10px; margin: 15px 0; overflow: hidden;
+        }
+        .audio-level-bar {
+            height: 100%; background: linear-gradient(90deg, #4fc3f7, #29b6f6);
+            width: 0%; transition: width 0.1s ease;
+        }
+        .help-box {
+            background: #1e3a5f; padding: 15px; border-radius: 10px;
+            margin: 15px 0; font-size: 0.85em; line-height: 1.8;
+            text-align: left;
+        }
+        .help-box h3 { color: #4fc3f7; margin-bottom: 10px; text-align: center; }
+        .lang-switch { position: absolute; top: 10px; right: 10px; }
+        .lang-switch button {
+            padding: 5px 10px; font-size: 0.8em; margin: 2px;
+            background: #333; color: #fff;
+        }
+        .lang-switch button.active { background: #4fc3f7; color: #1a1a2e; }
+    </style>
+</head>
+<body>
+    <div class="lang-switch">
+        <button id="btnZh" onclick="setLang('zh')" class="active">中文</button>
+        <button id="btnEn" onclick="setLang('en')">EN</button>
+    </div>
+    <div class="container">
+        <h1>MicYou Web</h1>
+        <p id="subtitle" style="color: #aaa;">网络音频输入</p>
+        <div id="status" class="status disconnected" data-zh="未连接" data-en="Disconnected">未连接</div>
+        <div class="audio-level"><div id="levelBar" class="audio-level-bar"></div></div>
+        <button id="startBtn" class="start-btn" onclick="startStreaming()" data-zh="开始麦克风" data-en="Start Microphone">开始麦克风</button>
+        <button id="stopBtn" class="stop-btn" onclick="stopStreaming()" style="display:none;" data-zh="停止" data-en="Stop">停止</button>
+        
+        <div class="help-box">
+            <h3 id="helpTitle" data-zh="使用说明" data-en="Instructions">使用说明</h3>
+            <div id="helpContent">
+                <p data-zh="1. 点击上方按钮开始传输音频" data-en="1. Click the button above to start audio streaming">1. 点击上方按钮开始传输音频</p>
+                <p data-zh="2. 浏览器会请求麦克风权限，请点击允许" data-en="2. Browser will request microphone permission, please allow it">2. 浏览器会请求麦克风权限，请点击允许</p>
+                <p data-zh="3. 如果没有弹出权限请求，请检查浏览器设置：" data-en="3. If no permission prompt appears, check browser settings:">3. 如果没有弹出权限请求，请检查浏览器设置：</p>
+                <p style="color:#4fc3f7;margin-left:15px;" data-zh="Chrome: 设置 → 隐私和安全 → 网站设置 → 麦克风" data-en="Chrome: Settings → Privacy → Site Settings → Microphone">Chrome: 设置 → 隐私和安全 → 网站设置 → 麦克风</p>
+                <p style="color:#4fc3f7;margin-left:15px;" data-zh="Safari: 设置 → 网站 → 麦克风" data-en="Safari: Settings → Websites → Microphone">Safari: 设置 → 网站 → 麦克风</p>
+                <p style="margin-top:10px;" data-zh="首次访问可能需要信任证书，点击"继续"即可" data-en="First visit may require trusting the certificate, click 'Continue'">首次访问可能需要信任证书，点击"继续"即可</p>
+            </div>
+        </div>
+    </div>
+    <script>
+        const HOP_LENGTH = {HOP_LENGTH};
+        let ws = null;
+        let audioContext = null;
+        let processor = null;
+        let stream = null;
+        let currentLang = 'zh';
+        
+        const statusEl = document.getElementById('status');
+        const levelBar = document.getElementById('levelBar');
+        const startBtn = document.getElementById('startBtn');
+        const stopBtn = document.getElementById('stopBtn');
+        
+        function setLang(lang) {
+            currentLang = lang;
+            document.getElementById('btnZh').className = lang === 'zh' ? 'active' : '';
+            document.getElementById('btnEn').className = lang === 'en' ? 'active' : '';
+            document.querySelectorAll('[data-zh]').forEach(function(el) {
+                el.textContent = el.getAttribute('data-' + lang);
+            });
+        }
+        
+        function setStatus(textZh, textEn, cls) {
+            statusEl.setAttribute('data-zh', textZh);
+            statusEl.setAttribute('data-en', textEn);
+            statusEl.textContent = currentLang === 'zh' ? textZh : textEn;
+            statusEl.className = 'status ' + cls;
+        }
+        
+        async function startStreaming() {
+            setStatus('正在请求麦克风...', 'Requesting microphone...', 'connecting');
+            
+            try {
+                stream = await navigator.mediaDevices.getUserMedia({
+                    audio: { sampleRate: 48000, channelCount: 1, echoCancellation: false, noiseSuppression: false }
+                });
+                
+                audioContext = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 48000 });
+                const source = audioContext.createMediaStreamSource(stream);
+                
+                processor = audioContext.createScriptProcessor(HOP_LENGTH, 1, 1);
+                
+                let wsUrl = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/';
+                ws = new WebSocket(wsUrl);
+                ws.binaryType = 'arraybuffer';
+                
+                ws.onopen = function() {
+                    setStatus('已连接 - 传输中', 'Connected - Streaming', 'connected');
+                    startBtn.style.display = 'none';
+                    stopBtn.style.display = 'inline-block';
+                };
+                
+                ws.onmessage = function(e) {
+                    if (e.data === 'SERVER_STOP') {
+                        setStatus('服务已停止', 'Server Stopped', 'disconnected');
+                        stopStreaming();
+                    }
+                };
+                
+                ws.onclose = function() {
+                    setStatus('未连接', 'Disconnected', 'disconnected');
+                    startBtn.style.display = 'inline-block';
+                    stopBtn.style.display = 'none';
+                };
+                
+                ws.onerror = function(e) {
+                    setStatus('连接失败', 'Connection Error', 'disconnected');
+                    stopStreaming();
+                };
+                
+                processor.onaudioprocess = function(e) {
+                    if (ws && ws.readyState === WebSocket.OPEN) {
+                        const inputData = e.inputBuffer.getChannelData(0);
+                        const float32Data = new Float32Array(inputData);
+                        ws.send(float32Data.buffer);
+                        let sum = 0;
+                        for (let i = 0; i < inputData.length; i++) {
+                            sum += inputData[i] * inputData[i];
+                        }
+                        const rms = Math.sqrt(sum / inputData.length);
+                        const level = Math.min(100, rms * 500);
+                        levelBar.style.width = level + '%';
+                    }
+                };
+                
+                source.connect(processor);
+                processor.connect(audioContext.destination);
+                
+            } catch (err) {
+                let msgZh = '麦克风访问失败，请在浏览器设置中允许麦克风权限';
+                let msgEn = 'Microphone access failed. Please allow microphone permission in browser settings';
+                setStatus(msgZh, msgEn, 'disconnected');
+            }
+        }
+        
+        function stopStreaming() {
+            if (processor) { processor.disconnect(); processor = null; }
+            if (audioContext) { audioContext.close(); audioContext = null; }
+            if (stream) { stream.getTracks().forEach(function(t) { t.stop(); }); stream = null; }
+            if (ws) { ws.close(); ws = null; }
+            setStatus('未连接', 'Disconnected', 'disconnected');
+            startBtn.style.display = 'inline-block';
+            stopBtn.style.display = 'none';
+            levelBar.style.width = '0%';
+        }
+    </script>
+</body>
+</html>
+"""
+}

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/WebModeService.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/WebModeService.kt
@@ -7,23 +7,39 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
+import io.ktor.server.http.content.*
+import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
+import io.ktor.serialization.kotlinx.json.*
 import io.ktor.websocket.*
-import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import java.net.Inet4Address
 import java.net.NetworkInterface
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
-object WebAudioServer {
-    private const val SAMPLE_RATE = 48000
-    private const val HOP_LENGTH = 256
+@Serializable
+data class MicYouStatus(
+    val appName: String = "MicYou",
+    val version: String = "1.0",
+    val streamState: String = "idle",
+    val clientCount: Int = 0,
+    val sampleRate: Int = 48000,
+    val channelCount: Int = 1
+)
+
+class WebModeService {
+    companion object {
+        private const val SAMPLE_RATE = 48000
+        private const val HOP_LENGTH = 256
+    }
 
     private val audioPacketChannel = Channel<AudioPacketMessage>(
         capacity = 200,
@@ -61,7 +77,7 @@ object WebAudioServer {
                 }
             }
         } catch (e: Exception) {
-            Logger.w("WebAudioServer", "Failed to get local IPs: ${e.message}")
+            Logger.w("WebModeService", "Failed to get local IPs: ${e.message}")
         }
 
         ips.sortBy { ip ->
@@ -96,7 +112,7 @@ object WebAudioServer {
 
     suspend fun start(port: Int = 0) {
         if (server != null) {
-            Logger.w("WebAudioServer", "Server already running")
+            Logger.w("WebModeService", "Server already running")
             return
         }
 
@@ -104,18 +120,28 @@ object WebAudioServer {
         _lastError.value = null
 
         try {
-            val actualPort = if (port > 0) port else findFreePort()
+            val actualPort = if (port in 1..65535) port else findFreePort()
             serverPort = actualPort
 
             val urls = getAllUrls()
             val primaryUrl = urls.firstOrNull() ?: "http://127.0.0.1:$actualPort"
             _webUrl.value = primaryUrl
-            Logger.i("WebAudioServer", "Available URLs: $urls")
+            Logger.i("WebModeService", "Available URLs: $urls")
+
+            val serviceRef = this
 
             server = embeddedServer(CIO, port = actualPort, host = "0.0.0.0") {
+                install(ContentNegotiation) {
+                    json(Json {
+                        ignoreUnknownKeys = true
+                        prettyPrint = false
+                    })
+                }
                 install(WebSockets)
 
                 routing {
+                    staticResources("/", "webapp")
+
                     get("/") {
                         call.respondText(
                             text = buildHtmlPage(),
@@ -123,24 +149,36 @@ object WebAudioServer {
                         )
                     }
 
-                    webSocket("/") {
-                        _clientCount.value++
-                        Logger.i("WebAudioServer", "WebSocket client connected (total: ${_clientCount.value})")
-                        _state.value = StreamState.Streaming
+                    get("/api/status") {
+                        val status = MicYouStatus(
+                            appName = "MicYou",
+                            version = System.getProperty("app.version") ?: "1.0",
+                            streamState = serviceRef._state.value.name.lowercase(),
+                            clientCount = serviceRef._clientCount.value,
+                            sampleRate = SAMPLE_RATE,
+                            channelCount = 1
+                        )
+                        call.respond(status)
+                    }
+
+                    webSocket("/ws") {
+                        serviceRef._clientCount.value++
+                        Logger.i("WebModeService", "WebSocket client connected (total: ${serviceRef._clientCount.value})")
+                        serviceRef._state.value = StreamState.Streaming
 
                         try {
                             for (frame in incoming) {
                                 if (frame is Frame.Binary) {
-                                    processAudioFrame(frame.data)
+                                    serviceRef.processAudioFrame(frame.data)
                                 }
                             }
                         } catch (e: Exception) {
-                            Logger.w("WebAudioServer", "WebSocket error: ${e.message}")
+                            Logger.w("WebModeService", "WebSocket error: ${e.message}")
                         } finally {
-                            _clientCount.value--
-                            Logger.i("WebAudioServer", "WebSocket client disconnected (total: ${_clientCount.value})")
-                            if (_clientCount.value == 0) {
-                                _state.value = StreamState.Connecting
+                            serviceRef._clientCount.value--
+                            Logger.i("WebModeService", "WebSocket client disconnected (total: ${serviceRef._clientCount.value})")
+                            if (serviceRef._clientCount.value == 0) {
+                                serviceRef._state.value = StreamState.Connecting
                             }
                         }
                     }
@@ -149,9 +187,9 @@ object WebAudioServer {
 
             server?.start(wait = false)
             _state.value = StreamState.Connecting
-            Logger.i("WebAudioServer", "Server started on port $actualPort")
+            Logger.i("WebModeService", "Server started on port $actualPort")
         } catch (e: Exception) {
-            Logger.e("WebAudioServer", "Failed to start server: ${e.message}", e)
+            Logger.e("WebModeService", "Failed to start server: ${e.message}", e)
             _state.value = StreamState.Error
             _lastError.value = e.message
             throw e
@@ -165,9 +203,9 @@ object WebAudioServer {
             _state.value = StreamState.Idle
             _webUrl.value = null
             _clientCount.value = 0
-            Logger.i("WebAudioServer", "Server stopped")
+            Logger.i("WebModeService", "Server stopped")
         } catch (e: Exception) {
-            Logger.e("WebAudioServer", "Error stopping server: ${e.message}", e)
+            Logger.e("WebModeService", "Error stopping server: ${e.message}", e)
         }
     }
 
@@ -206,7 +244,7 @@ object WebAudioServer {
         try {
             audioPacketChannel.trySend(audioPacket)
         } catch (e: Exception) {
-            Logger.w("WebAudioServer", "Audio packet channel full, dropping packet")
+            Logger.w("WebModeService", "Audio packet channel full, dropping packet")
         }
     }
 
@@ -230,6 +268,8 @@ object WebAudioServer {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#4fc3f7">
+    <link rel="manifest" href="/manifest.json">
     <title>MicYou Web</title>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -346,7 +386,7 @@ object WebAudioServer {
                 
                 processor = audioContext.createScriptProcessor(HOP_LENGTH, 1, 1);
                 
-                let wsUrl = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/';
+                let wsUrl = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/ws';
                 ws = new WebSocket(wsUrl);
                 ws.binaryType = 'arraybuffer';
                 
@@ -408,6 +448,12 @@ object WebAudioServer {
             startBtn.style.display = 'inline-block';
             stopBtn.style.display = 'none';
             levelBar.style.width = '0%';
+        }
+
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('/sw.js')
+                .then(function(reg) { console.log('SW registered:', reg.scope); })
+                .catch(function(err) { console.log('SW failed:', err); });
         }
     </script>
 </body>

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/WebModeService.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/WebModeService.kt
@@ -24,6 +24,7 @@ import java.net.Inet4Address
 import java.net.NetworkInterface
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.security.KeyStore
 
 @Serializable
 data class MicYouStatus(
@@ -33,6 +34,13 @@ data class MicYouStatus(
     val clientCount: Int = 0,
     val sampleRate: Int = 48000,
     val channelCount: Int = 1
+)
+
+data class SslConfig(
+    val keyStore: KeyStore,
+    val keyAlias: String = "micyou",
+    val keyStorePassword: () -> CharArray,
+    val privateKeyPassword: () -> CharArray = keyStorePassword
 )
 
 class WebModeService {
@@ -95,22 +103,20 @@ class WebModeService {
     }
 
     fun getBestUrl(): String? {
-        val protocol = "http"
         val ips = getLocalIps()
         if (ips.isNotEmpty()) {
-            return "$protocol://${ips.first()}:$serverPort"
+            return "https://${ips.first()}:$serverPort"
         }
-        return "$protocol://127.0.0.1:$serverPort"
+        return "https://127.0.0.1:$serverPort"
     }
 
     fun getAllUrls(): List<String> {
-        val protocol = "http"
-        return getLocalIps().map { "$protocol://$it:$serverPort" }
+        return getLocalIps().map { "https://$it:$serverPort" }
     }
 
     fun getPort(): Int = serverPort
 
-    suspend fun start(port: Int = 0) {
+    suspend fun start(port: Int = 0, sslConfig: SslConfig) {
         if (server != null) {
             Logger.w("WebModeService", "Server already running")
             return
@@ -124,13 +130,13 @@ class WebModeService {
             serverPort = actualPort
 
             val urls = getAllUrls()
-            val primaryUrl = urls.firstOrNull() ?: "http://127.0.0.1:$actualPort"
+            val primaryUrl = urls.firstOrNull() ?: "https://127.0.0.1:$actualPort"
             _webUrl.value = primaryUrl
             Logger.i("WebModeService", "Available URLs: $urls")
 
             val serviceRef = this
 
-            server = embeddedServer(CIO, port = actualPort, host = "0.0.0.0") {
+            val module: Application.() -> Unit = {
                 install(ContentNegotiation) {
                     json(Json {
                         ignoreUnknownKeys = true
@@ -185,9 +191,20 @@ class WebModeService {
                 }
             }
 
+            server = embeddedServer(
+                CIO,
+                port = actualPort,
+                host = "0.0.0.0",
+                keyStore = sslConfig.keyStore,
+                keyAlias = sslConfig.keyAlias,
+                keyStorePassword = sslConfig.keyStorePassword,
+                privateKeyPassword = sslConfig.privateKeyPassword,
+                module = module
+            )
+
             server?.start(wait = false)
             _state.value = StreamState.Connecting
-            Logger.i("WebModeService", "Server started on port $actualPort")
+            Logger.i("WebModeService", "Server started on port $actualPort (HTTPS)")
         } catch (e: Exception) {
             Logger.e("WebModeService", "Failed to start server: ${e.message}", e)
             _state.value = StreamState.Error

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/WebModeService.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/WebModeService.kt
@@ -193,12 +193,17 @@ class WebModeService {
 
             server = embeddedServer(
                 CIO,
-                port = actualPort,
-                host = "0.0.0.0",
-                keyStore = sslConfig.keyStore,
-                keyAlias = sslConfig.keyAlias,
-                keyStorePassword = sslConfig.keyStorePassword,
-                privateKeyPassword = sslConfig.privateKeyPassword,
+                configure = {
+                    sslConnector(
+                        keyStore = sslConfig.keyStore,
+                        keyAlias = sslConfig.keyAlias,
+                        keyStorePassword = sslConfig.keyStorePassword,
+                        privateKeyPassword = sslConfig.privateKeyPassword
+                    ) {
+                        port = actualPort
+                        host = "0.0.0.0"
+                    }
+                },
                 module = module
             )
 

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/WebModeService.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/web/WebModeService.kt
@@ -255,7 +255,7 @@ class WebModeService {
             buffer = pcmBytes,
             sampleRate = SAMPLE_RATE,
             channelCount = 1,
-            audioFormat = 3
+            audioFormat = 2
         )
 
         try {

--- a/composeApp/src/jvmMain/resources/webapp/manifest.json
+++ b/composeApp/src/jvmMain/resources/webapp/manifest.json
@@ -1,0 +1,22 @@
+{
+  "name": "MicYou Web",
+  "short_name": "MicYou",
+  "description": "Turn your phone into a PC microphone",
+  "start_url": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#1a1a2e",
+  "theme_color": "#4fc3f7",
+  "icons": [
+    {
+      "src": "/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/composeApp/src/jvmMain/resources/webapp/sw.js
+++ b/composeApp/src/jvmMain/resources/webapp/sw.js
@@ -1,0 +1,55 @@
+const CACHE_NAME = 'micyou-web-v1';
+
+const PRECACHE_URLS = [
+  '/',
+  '/manifest.json'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(PRECACHE_URLS);
+    })
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames
+          .filter((name) => name !== CACHE_NAME)
+          .map((name) => caches.delete(name))
+      );
+    })
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.url.includes('/ws')) {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request).then((response) => {
+        if (!response || response.status !== 200 || response.type !== 'basic') {
+          return response;
+        }
+
+        const responseToCache = response.clone();
+        caches.open(CACHE_NAME).then((cache) => {
+          cache.put(event.request, responseToCache);
+        });
+
+        return response;
+      });
+    })
+  );
+});

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ filekit = "0.13.0"
 materialKolor = "5.0.0-alpha07"
 jmdns = "3.6.3"
 zxing = "3.5.3"
+bouncycastle = "1.80"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -70,6 +71,7 @@ ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
+bouncycastle-pkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,10 @@ materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "ma
 jmdns = { module = "org.jmdns:jmdns", version.ref = "jmdns" }
 zxing-core = { module = "com.google.zxing:core", version.ref = "zxing" }
 zxing-javase = { module = "com.google.zxing:javase", version.ref = "zxing" }
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ window = "1.5.1"
 filekit = "0.13.0"
 materialKolor = "5.0.0-alpha07"
 jmdns = "3.6.3"
+zxing = "3.5.3"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -63,6 +64,8 @@ filekit-core = { module = "io.github.vinceglb:filekit-core", version.ref = "file
 filekit-dialogs-compose = { module = "io.github.vinceglb:filekit-dialogs-compose", version.ref = "filekit" }
 materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
 jmdns = { module = "org.jmdns:jmdns", version.ref = "jmdns" }
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxing" }
+zxing-javase = { module = "com.google.zxing:javase", version.ref = "zxing" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
基于 a2heng 提供的 web.py 的原设计，为桌面端添加 Web 连接模式：
- 电脑启动 Ktor HTTP + WebSocket 服务，提供内置 HTML 页面
- 手机浏览器扫码即可打开网页，通过 Web Audio API 采集麦克风音频
- 音频经 Float32 → 16-bit PCM 转换后送入已有音频处理管线
- UI (增强模式 + 口袋模式) 显示二维码及连接状态

新增文件：
- web/WebAudioServer.kt   Ktor CIO WebSocket 服务器 + HTML 页面
- web/QrCodeGenerator.kt  ZXing 二维码生成工具

修改：
- ConnectionMode 枚举新增 Web
- AudioEngine expect/actual 新增 webServerUrl + Web 服务器生命周期
- Platform expect/actual 新增 generateQrCodeImageBitmap()
- build.gradle.kts 添加 ktor-server-cio / ktor-server-websockets / zxing 依赖
- 6 语言 strings.xml 新增 modeWeb / webModeLabel / webScanHint / webNotStartedHint