### PR TITLE
fix: 改进 IP 地址获取逻辑

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
@@ -28,18 +28,24 @@ class JVMPlatform: Platform {
         get() = getLocalIpAddresses()
 
     private fun getLocalIpAddresses(): List<String> {
+        val virtualKeywords = listOf(
+            "vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker",
+            "tunnel", "teredo", "isatap"
+        )
         try {
             val interfaces = java.net.NetworkInterface.getNetworkInterfaces()
-    val candidates = mutableListOf<java.net.InetAddress>()
+            val candidates = mutableListOf<java.net.InetAddress>()
 
             while (interfaces.hasMoreElements()) {
                 val iface = interfaces.nextElement()
-                if (iface.isLoopback || !iface.isUp) continue
+                if (iface.isLoopback || !iface.isUp || iface.isVirtual) continue
+                val name = iface.displayName?.lowercase() ?: ""
+                if (virtualKeywords.any { name.contains(it) }) continue
 
                 val addresses = iface.inetAddresses
                 while (addresses.hasMoreElements()) {
                     val addr = addresses.nextElement()
-                    if (addr is java.net.Inet4Address) {
+                    if (addr is java.net.Inet4Address && !addr.isLoopbackAddress) {
                         candidates.add(addr)
                     }
                 }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
@@ -27,11 +27,14 @@ class JVMPlatform: Platform {
     override val ipAddresses: List<String>
         get() = getLocalIpAddresses()
 
-    private fun getLocalIpAddresses(): List<String> {
-        val virtualKeywords = listOf(
+    companion object {
+        private val VIRTUAL_KEYWORDS = listOf(
             "vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker",
-            "tunnel", "teredo", "isatap"
+            "tunnel", "teredo", "isatap", "vpn"
         )
+    }
+
+    private fun getLocalIpAddresses(): List<String> {
         try {
             val interfaces = java.net.NetworkInterface.getNetworkInterfaces()
             val candidates = mutableListOf<java.net.InetAddress>()
@@ -39,8 +42,9 @@ class JVMPlatform: Platform {
             while (interfaces.hasMoreElements()) {
                 val iface = interfaces.nextElement()
                 if (iface.isLoopback || !iface.isUp || iface.isVirtual) continue
-                val name = iface.displayName?.lowercase() ?: ""
-                if (virtualKeywords.any { name.contains(it) }) continue
+                val name = iface.name.lowercase()
+                val displayName = iface.displayName?.lowercase() ?: ""
+                if (VIRTUAL_KEYWORDS.any { name.contains(it) || displayName.contains(it) }) continue
 
                 val addresses = iface.inetAddresses
                 while (addresses.hasMoreElements()) {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/MdnsAdvertiser.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/MdnsAdvertiser.kt
@@ -30,16 +30,23 @@ class MdnsAdvertiser {
         }
     }
 
+    companion object {
+        private val VIRTUAL_KEYWORDS = listOf(
+            "vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker",
+            "tunnel", "teredo", "isatap", "vpn"
+        )
+    }
+
     private fun findLanAddress(): InetAddress? {
-        val virtualKeywords = listOf("vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker", "tunnel", "teredo", "isatap")
         try {
             val interfaces = java.net.NetworkInterface.getNetworkInterfaces()
             val candidates = mutableListOf<Pair<java.net.NetworkInterface, java.net.Inet4Address>>()
             while (interfaces.hasMoreElements()) {
                 val networkInterface = interfaces.nextElement()
                 if (networkInterface.isLoopback || !networkInterface.isUp || networkInterface.isVirtual) continue
-                val name = networkInterface.displayName?.lowercase() ?: ""
-                if (virtualKeywords.any { name.contains(it) }) continue
+                val name = networkInterface.name.lowercase()
+                val displayName = networkInterface.displayName?.lowercase() ?: ""
+                if (VIRTUAL_KEYWORDS.any { name.contains(it) || displayName.contains(it) }) continue
                 val addresses = networkInterface.inetAddresses
                 while (addresses.hasMoreElements()) {
                     val address = addresses.nextElement()

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/SelfSignedCertificate.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/SelfSignedCertificate.kt
@@ -15,18 +15,20 @@ object SelfSignedCertificate {
 
     private var cachedKeyStore: KeyStore? = null
 
+    private val virtualKeywords = listOf(
+        "vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker", "tunnel", "teredo", "isatap", "vpn"
+    )
+
     internal fun getLanIpAddresses(): List<String> {
-        val virtualKeywords = listOf(
-            "vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker", "tunnel", "teredo", "isatap"
-        )
         try {
             val interfaces = NetworkInterface.getNetworkInterfaces()
             val candidates = mutableListOf<Pair<NetworkInterface, Inet4Address>>()
             while (interfaces.hasMoreElements()) {
                 val iface = interfaces.nextElement()
                 if (iface.isLoopback || !iface.isUp || iface.isVirtual) continue
-                val name = iface.displayName?.lowercase() ?: ""
-                if (virtualKeywords.any { name.contains(it) }) continue
+                val name = iface.name.lowercase()
+                val displayName = iface.displayName?.lowercase() ?: ""
+                if (virtualKeywords.any { name.contains(it) || displayName.contains(it) }) continue
                 val addresses = iface.inetAddresses
                 while (addresses.hasMoreElements()) {
                     val addr = addresses.nextElement()


### PR DESCRIPTION
This pull request improves the logic for retrieving local IP addresses on the JVM platform by filtering out virtual and non-physical network interfaces. This makes the list of local IP addresses more accurate by excluding addresses associated with virtual machines, containers, and tunnels.

Network interface filtering improvements:

* Added a list of keywords (such as "vmware", "docker", "wsl", etc.) to identify and exclude virtual network interfaces based on their display names.
* Updated the filtering logic to skip interfaces that are virtual, in addition to those that are loopback or not up.
* Ensured that only non-loopback IPv4 addresses are included in the returned list.