### PR TITLE
imp: better installtion package size

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -97,7 +97,7 @@ jobs:
       run: |
         New-Item -ItemType Directory -Force -Path ci-artifacts | Out-Null
         $version = '${{ steps.version.outputs.version }}'
-        $zip = Get-ChildItem -Path composeApp/build/distributions -Filter *.zip | Select-Object -First 1
+        $zip = Get-ChildItem -Path composeApp/build/distributions -Filter *windows*.zip | Select-Object -First 1
         if (-not $zip) { throw "No zip found in composeApp/build/distributions" }
         Copy-Item $zip.FullName ("ci-artifacts/MicYou-Win-$version.zip") -Force
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Build Windows Artifacts
       shell: pwsh
       run: |
-        ./gradlew :composeApp:packageWindowsZip :composeApp:packageWindowsNsis
+        ./gradlew :composeApp:packageWindowsZipRelease :composeApp:packageWindowsNsisRelease
     - name: Prepare Windows Artifacts
       shell: pwsh
       run: |
@@ -136,13 +136,13 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build Linux DEB and RPM packages
-      run: ./gradlew :composeApp:packageDeb :composeApp:packageRpm
+      run: ./gradlew :composeApp:packageReleaseDeb :composeApp:packageReleaseRpm
     - name: Prepare Linux Artifacts
       run: |
         mkdir -p ci-artifacts
         # 查找DEB和RPM文件
-        DEB_FILE=$(ls composeApp/build/compose/binaries/main/deb/*.deb 2>/dev/null | head -n 1)
-        RPM_FILE=$(ls composeApp/build/compose/binaries/main/rpm/*.rpm 2>/dev/null | head -n 1)
+        DEB_FILE=$(ls composeApp/build/compose/binaries/main-release/deb/*.deb 2>/dev/null | head -n 1)
+        RPM_FILE=$(ls composeApp/build/compose/binaries/main-release/rpm/*.rpm 2>/dev/null | head -n 1)
         
         if [ -f "$DEB_FILE" ]; then
           cp "$DEB_FILE" "ci-artifacts/MicYou-Linux-${{ steps.version.outputs.version }}.deb"
@@ -193,11 +193,11 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build macOS DMG
-      run: ./gradlew :composeApp:packageDmg
+      run: ./gradlew :composeApp:packageReleaseDmg
     - name: Prepare macOS Artifacts
       run: |
         mkdir -p ci-artifacts
-        DMG_FILE=$(ls composeApp/build/compose/binaries/main/dmg/*.dmg 2>/dev/null | head -n 1)
+        DMG_FILE=$(ls composeApp/build/compose/binaries/main-release/dmg/*.dmg 2>/dev/null | head -n 1)
         if [ -f "$DMG_FILE" ]; then
           cp "$DMG_FILE" "ci-artifacts/MicYou-macOS-${{ steps.version.outputs.version }}-${{ matrix.arch }}.dmg"
         else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,38 +25,38 @@ MicYou/
 
 ## WHERE TO LOOK
 
-| Task | Location | Notes |
-|------|----------|-------|
-| Entry point (Desktop) | composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/main.kt | Window setup, tray, ViewModel init |
-| Entry point (Android) | composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/MainActivity.kt | Permission handling, quick start |
-| Main UI composition | composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/App.kt | Theme, dialogs, platform routing |
-| Core state management | composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt | Facade for AudioStream/Settings/Plugin ViewModels |
-| Audio stream logic | composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt | Connection modes, config, stream control |
-| Audio engine interface | composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioEngine.kt | expect class - platform implementations |
-| Network server (Desktop) | composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt | TCP/UDP server, ConnectionHandler |
-| Audio effects pipeline | composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/audio/ | Noise reduction, AGC, VAD, Dereverb, Amplifier |
-| Plugin interfaces | plugin-api/src/commonMain/kotlin/com/lanrhyme/micyou/plugin/ | Plugin, PluginHost, PluginManifest, AudioEffectPlugin |
-| Plugin impl (Desktop) | composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/plugin/ | PluginManager, PluginClassLoader, PluginSecurityManager |
-| Plugin impl (Android) | composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/plugin/ | AndroidPluginManager, AndroidPluginHostImpl |
-| Platform abstraction | composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Platform.kt | expect fun getPlatform(), Logger, VB-Cable |
-| Settings storage | composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/util/Settings.kt | File-based settings (desktop) |
-| Localization | composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Localization.kt | AppStrings, AppLanguage enum |
+| Task                     | Location                                                                     | Notes                                                   |
+| ------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------- |
+| Entry point (Desktop)    | composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/main.kt                    | Window setup, tray, ViewModel init                      |
+| Entry point (Android)    | composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/MainActivity.kt        | Permission handling, quick start                        |
+| Main UI composition      | composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/App.kt                  | Theme, dialogs, platform routing                        |
+| Core state management    | composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt        | Facade for AudioStream/Settings/Plugin ViewModels       |
+| Audio stream logic       | composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt | Connection modes, config, stream control                |
+| Audio engine interface   | composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioEngine.kt          | expect class - platform implementations                 |
+| Network server (Desktop) | composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt   | TCP/UDP server, ConnectionHandler                       |
+| Audio effects pipeline   | composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/audio/                     | Noise reduction, AGC, VAD, Dereverb, Amplifier          |
+| Plugin interfaces        | plugin-api/src/commonMain/kotlin/com/lanrhyme/micyou/plugin/                 | Plugin, PluginHost, PluginManifest, AudioEffectPlugin   |
+| Plugin impl (Desktop)    | composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/plugin/                    | PluginManager, PluginClassLoader, PluginSecurityManager |
+| Plugin impl (Android)    | composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/plugin/                | AndroidPluginManager, AndroidPluginHostImpl             |
+| Platform abstraction     | composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Platform.kt             | expect fun getPlatform(), Logger, VB-Cable              |
+| Settings storage         | composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/util/Settings.kt           | File-based settings (desktop)                           |
+| Localization             | composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Localization.kt         | AppStrings, AppLanguage enum                            |
 
 ## CODE MAP
 
-| Symbol | Type | Location | Role |
-|--------|------|----------|------|
-| MainViewModel | class | commonMain/MainViewModel.kt | Facade ViewModel, coordinates AudioStream/Settings/Plugin/Update VMs |
-| AudioStreamViewModel | class | commonMain/AudioStreamViewModel.kt | Handles connection modes, audio config, stream start/stop |
-| AudioEngine | expect class | commonMain/AudioEngine.kt | Platform-specific audio engine interface |
-| NetworkServer | class | jvmMain/network/NetworkServer.kt | TCP/UDP server for desktop |
-| ConnectionHandler | class | jvmMain/network/ConnectionHandler.kt | Protocol handling for incoming connections |
-| Plugin | interface | plugin-api/plugin/Plugin.kt | Base plugin interface |
-| PluginHost | interface | plugin-api/plugin/PluginHost.kt | Host API for plugins |
-| AudioEffectPlugin | interface | plugin-api/plugin/AudioEffectPlugin.kt | Audio processing plugin interface |
-| App | @Composable | commonMain/App.kt | Root UI, theme, dialog handling |
-| Platform | interface | commonMain/Platform.kt | Platform abstraction (Android/Desktop) |
-| Logger | object | commonMain/Platform.kt | Cross-platform logging |
+| Symbol               | Type         | Location                               | Role                                                                 |
+| -------------------- | ------------ | -------------------------------------- | -------------------------------------------------------------------- |
+| MainViewModel        | class        | commonMain/MainViewModel.kt            | Facade ViewModel, coordinates AudioStream/Settings/Plugin/Update VMs |
+| AudioStreamViewModel | class        | commonMain/AudioStreamViewModel.kt     | Handles connection modes, audio config, stream start/stop            |
+| AudioEngine          | expect class | commonMain/AudioEngine.kt              | Platform-specific audio engine interface                             |
+| NetworkServer        | class        | jvmMain/network/NetworkServer.kt       | TCP/UDP server for desktop                                           |
+| ConnectionHandler    | class        | jvmMain/network/ConnectionHandler.kt   | Protocol handling for incoming connections                           |
+| Plugin               | interface    | plugin-api/plugin/Plugin.kt            | Base plugin interface                                                |
+| PluginHost           | interface    | plugin-api/plugin/PluginHost.kt        | Host API for plugins                                                 |
+| AudioEffectPlugin    | interface    | plugin-api/plugin/AudioEffectPlugin.kt | Audio processing plugin interface                                    |
+| App                  | @Composable  | commonMain/App.kt                      | Root UI, theme, dialog handling                                      |
+| Platform             | interface    | commonMain/Platform.kt                 | Platform abstraction (Android/Desktop)                               |
+| Logger               | object       | commonMain/Platform.kt                 | Cross-platform logging                                               |
 
 ## CONVENTIONS
 
@@ -100,7 +100,7 @@ MicYou/
 # Desktop JVM run
 ./gradlew :composeApp:jvmRun           # Run desktop app
 
-# Desktop packaging
+# Desktop packaging (non-release, no ProGuard)
 ./gradlew :composeApp:createDistributable       # Create distributable
 ./gradlew :composeApp:packageWindowsZip          # Windows ZIP
 ./gradlew :composeApp:packageWindowsNsis         # Windows NSIS installer
@@ -108,6 +108,15 @@ MicYou/
 ./gradlew :composeApp:packageDmg                 # macOS DMG
 ./gradlew :composeApp:packageDeb                 # Linux DEB
 ./gradlew :composeApp:packageRpm                 # Linux RPM
+
+# Desktop packaging (release, with ProGuard)
+./gradlew :composeApp:createReleaseDistributable
+./gradlew :composeApp:packageWindowsZipRelease
+./gradlew :composeApp:packageWindowsNsisRelease
+./gradlew :composeApp:packageReleaseExe
+./gradlew :composeApp:packageReleaseDmg
+./gradlew :composeApp:packageReleaseDeb
+./gradlew :composeApp:packageReleaseRpm
 
 # No-JRE packaging (requires system Java)
 ./gradlew :composeApp:packageNoJreAll            # All platforms without bundled JRE

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -305,11 +305,11 @@ tasks.register<GenerateWindowsIconIcoTask>("generateWindowsIconIco") {
     outputIco.set(layout.buildDirectory.file("generated/icons/icon256.ico"))
 }
 
-tasks.matching { it.name in setOf("createDistributable", "createReleaseDistributable", "packageExe", "packageReleaseExe", "packageWindowsNsis") }
+tasks.matching { it.name in setOf("createDistributable", "createReleaseDistributable", "packageExe", "packageReleaseExe", "packageWindowsNsis", "packageWindowsNsisRelease", "packageWindowsZip", "packageWindowsZipRelease") }
     .configureEach { dependsOn("generateWindowsIconIco") }
 
 // 所有 release 打包任务依赖 runtime 压缩
-tasks.matching { it.name in setOf("packageWindowsNsis", "packageReleaseExe", "packageReleaseDmg", "packageReleaseDeb", "packageReleaseRpm", "packageWindowsZip") }
+tasks.matching { it.name in setOf("packageWindowsNsisRelease", "packageReleaseExe", "packageReleaseDmg", "packageReleaseDeb", "packageReleaseRpm", "packageWindowsZipRelease") }
     .configureEach { dependsOn("replaceRuntime") }
 
 // 修复 ProGuard 的 kotlin-metadata-jvm 版本不兼容问题
@@ -388,32 +388,61 @@ tasks.matching { it.name == "replaceRuntime" }
 // 256x256 的图标在 Windows 托盘中无法正常显示，需要使用小尺寸图标
 val copyTrayIcon by tasks.registering(Copy::class) {
     from("src/commonMain/composeResources/drawable/icon32.ico")
+    into(layout.buildDirectory.dir("compose/binaries/main/app/${project.property("project.name")}"))
+}
+
+val copyTrayIconRelease by tasks.registering(Copy::class) {
+    from("src/commonMain/composeResources/drawable/icon32.ico")
     into(layout.buildDirectory.dir("compose/binaries/main-release/app/${project.property("project.name")}"))
 }
 
 // 复制 Assets.car 到 macOS app bundle（支持液态玻璃图标）
 val copyAssetsCar by tasks.registering(Copy::class) {
     from("resources/macos/Assets.car")
+    into(layout.buildDirectory.dir("compose/binaries/main/app/${project.property("project.name")}.app/Contents/Resources"))
+}
+
+val copyAssetsCarRelease by tasks.registering(Copy::class) {
+    from("resources/macos/Assets.car")
     into(layout.buildDirectory.dir("compose/binaries/main-release/app/${project.property("project.name")}.app/Contents/Resources"))
 }
 
-// Windows/macOS 打包时执行 copyTrayIcon
+// Windows/macOS 打包时执行 copyTrayIconRelease（release）
 tasks.matching { it.name in setOf("createReleaseDistributable") }
+    .configureEach {
+        dependsOn(copyTrayIconRelease)
+    }
+
+// Windows/macOS 打包时执行 copyTrayIcon（debug）
+tasks.matching { it.name in setOf("createDistributable") }
     .configureEach {
         dependsOn(copyTrayIcon)
     }
 
-// macOS DMG 打包 (debug 和 release 版本)
-tasks.matching { it.name.contains("Dmg") }
+// macOS DMG 打包 — release 版本
+tasks.matching { it.name == "packageReleaseDmg" }
+    .configureEach {
+        dependsOn(copyTrayIconRelease)
+        dependsOn("createReleaseDistributable")
+        dependsOn(copyAssetsCarRelease)
+    }
+
+// macOS DMG 打包 — 非 release 版本（无 ProGuard）
+tasks.matching { it.name == "packageDmg" }
     .configureEach {
         dependsOn(copyTrayIcon)
-        dependsOn("createReleaseDistributable")
+        dependsOn("createDistributable")
         dependsOn(copyAssetsCar)
+    }
+
+tasks.matching { it.name == "copyAssetsCarRelease" }
+    .configureEach {
+        mustRunAfter("createReleaseDistributable")
     }
 
 tasks.matching { it.name == "copyAssetsCar" }
     .configureEach {
-        mustRunAfter("createReleaseDistributable")
+        mustRunAfter("createDistributable")
     }
 
 tasks.matching { it.name == "jvmRun" }.configureEach {
@@ -426,8 +455,21 @@ tasks.matching { it.name == "jvmRun" }.configureEach {
     }
 }
 
+// 非 release 版本 Windows ZIP（无 ProGuard）
 tasks.register<Zip>("packageWindowsZip") {
-    dependsOn("createReleaseDistributable", copyTrayIcon)
+    dependsOn("createDistributable", copyTrayIcon)
+
+    val version = project.property("project.version").toString()
+    val distDir = layout.buildDirectory.dir("compose/binaries/main/app")
+
+    from(distDir)
+    destinationDirectory.set(layout.buildDirectory.dir("distributions"))
+    archiveBaseName.set("${project.property("project.name")}-windows")
+    archiveVersion.set(version)
+}
+
+tasks.register<Zip>("packageWindowsZipRelease") {
+    dependsOn("createReleaseDistributable", copyTrayIconRelease)
 
     val version = project.property("project.version").toString()
     val distDir = layout.buildDirectory.dir("compose/binaries/main-release/app")
@@ -508,8 +550,32 @@ abstract class PackageWindowsNsisTask @Inject constructor(
     }
 }
 
+// 非 release 版本 NSIS（无 ProGuard）
 tasks.register<PackageWindowsNsisTask>("packageWindowsNsis") {
-    dependsOn("createReleaseDistributable", copyTrayIcon)
+    dependsOn("createDistributable", copyTrayIcon)
+
+    val appNameValue = project.property("project.name").toString()
+    val versionValue = project.property("project.version").toString()
+
+    appName.set(appNameValue)
+    appVersion.set(versionValue)
+    vendor.set("LanRhyme")
+
+    inputDir.set(layout.buildDirectory.dir("compose/binaries/main/app/$appNameValue"))
+    scriptFile.set(layout.projectDirectory.file("nsis/installer.nsi"))
+    outputFile.set(layout.buildDirectory.file("distributions/$appNameValue-$versionValue-setup-nsis.exe"))
+
+    makensisPath.set(
+        providers.gradleProperty("nsis.makensis")
+            .orElse(providers.environmentVariable("NSIS_MAKENSIS"))
+            .orElse("")
+    )
+
+    iconPath.set(windowsIconIcoFile.absolutePath)
+}
+
+tasks.register<PackageWindowsNsisTask>("packageWindowsNsisRelease") {
+    dependsOn("createReleaseDistributable", copyTrayIconRelease)
 
     val appNameValue = project.property("project.name").toString()
     val versionValue = project.property("project.version").toString()

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -189,6 +189,15 @@ compose.desktop {
         mainClass = "com.lanrhyme.micyou.MainKt"
         jvmArgs("-Dfile.encoding=UTF-8", "-Dapp.version=${project.property("project.version")}")
 
+        buildTypes.release {
+            proguard {
+                isEnabled.set(true)
+                obfuscate.set(false)
+                optimize.set(true)
+                configurationFiles.from("proguard-desktop.pro")
+            }
+        }
+
         nativeDistributions {
             appResourcesRootDir.set(project.layout.projectDirectory.dir("resources"))
 
@@ -300,6 +309,16 @@ tasks.register<GenerateWindowsIconIcoTask>("generateWindowsIconIco") {
 tasks.matching { it.name in setOf("createDistributable", "createReleaseDistributable", "packageExe", "packageReleaseExe", "packageWindowsNsis") }
     .configureEach { dependsOn("generateWindowsIconIco") }
 
+// 修复 ProGuard 的 kotlin-metadata-jvm 版本不兼容问题
+// compose 插件捆绑的 2.1.0 不支持 Kotlin 2.3.x 的 metadata
+tasks.withType<org.jetbrains.compose.desktop.application.tasks.AbstractProguardTask>().configureEach {
+    proguardFiles.from(
+        configurations.detachedConfiguration(
+            dependencies.create("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.10")
+        )
+    )
+}
+
 // Windows 打包后复制托盘图标 (32x32) 到应用目录
 // 256x256 的图标在 Windows 托盘中无法正常显示，需要使用小尺寸图标
 val copyTrayIcon by tasks.registering(Copy::class) {
@@ -323,7 +342,7 @@ tasks.matching { it.name in setOf("createDistributable", "createReleaseDistribut
 tasks.matching { it.name.contains("Dmg") }
     .configureEach {
         dependsOn(copyTrayIcon)
-        dependsOn("createDistributable")
+        dependsOn("createReleaseDistributable")
         dependsOn(copyAssetsCar)
     }
 
@@ -343,10 +362,10 @@ tasks.matching { it.name == "jvmRun" }.configureEach {
 }
 
 tasks.register<Zip>("packageWindowsZip") {
-    dependsOn("createDistributable", copyTrayIcon)
+    dependsOn("createReleaseDistributable", copyTrayIcon)
 
     val version = project.property("project.version").toString()
-    val distDir = layout.buildDirectory.dir("compose/binaries/main/app")
+    val distDir = layout.buildDirectory.dir("compose/binaries/main-release/app")
 
     from(distDir)
     destinationDirectory.set(layout.buildDirectory.dir("distributions"))
@@ -425,7 +444,7 @@ abstract class PackageWindowsNsisTask @Inject constructor(
 }
 
 tasks.register<PackageWindowsNsisTask>("packageWindowsNsis") {
-    dependsOn("createDistributable", copyTrayIcon)
+    dependsOn("createReleaseDistributable", copyTrayIcon)
 
     val appNameValue = project.property("project.name").toString()
     val versionValue = project.property("project.version").toString()
@@ -434,7 +453,7 @@ tasks.register<PackageWindowsNsisTask>("packageWindowsNsis") {
     appVersion.set(versionValue)
     vendor.set("LanRhyme")
 
-    inputDir.set(layout.buildDirectory.dir("compose/binaries/main/app/$appNameValue"))
+    inputDir.set(layout.buildDirectory.dir("compose/binaries/main-release/app/$appNameValue"))
     scriptFile.set(layout.projectDirectory.file("nsis/installer.nsi"))
     outputFile.set(layout.buildDirectory.file("distributions/$appNameValue-$versionValue-setup-nsis.exe"))
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -310,7 +310,7 @@ tasks.matching { it.name in setOf("createDistributable", "createReleaseDistribut
     .configureEach { dependsOn("generateWindowsIconIco") }
 
 // 所有 release 打包任务依赖 runtime 压缩
-tasks.matching { it.name in setOf("packageWindowsNsis", "packageReleaseExe", "packageReleaseDmg", "packageReleaseDeb", "packageReleaseRpm") }
+tasks.matching { it.name in setOf("packageWindowsNsis", "packageReleaseExe", "packageReleaseDmg", "packageReleaseDeb", "packageReleaseRpm", "packageWindowsZip") }
     .configureEach { dependsOn("replaceRuntime") }
 
 // 修复 ProGuard 的 kotlin-metadata-jvm 版本不兼容问题
@@ -375,11 +375,15 @@ val compressRuntime by tasks.registering(CompressRuntimeTask::class) {
 }
 
 val replaceRuntime by tasks.registering(Copy::class) {
-    dependsOn("createReleaseDistributable", compressRuntime, copyTrayIcon)
+    dependsOn(compressRuntime)
     val appName = project.property("project.name").toString()
     from(layout.buildDirectory.dir("compose/binaries/main-release/app/$appName/runtime-compressed"))
     into(layout.buildDirectory.dir("compose/binaries/main-release/app/$appName/runtime"))
 }
+
+// 必须在 createReleaseDistributable 之后执行（输出目录重叠）
+tasks.matching { it.name == "replaceRuntime" }
+    .configureEach { mustRunAfter("createReleaseDistributable") }
 
 // Windows 打包后复制托盘图标 (32x32) 到应用目录
 // 256x256 的图标在 Windows 托盘中无法正常显示，需要使用小尺寸图标

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -107,7 +107,6 @@ kotlin {
             implementation(libs.ktor.network.tls.certificates)
             implementation(libs.zxing.core)
             implementation("de.maxhenkel.rnnoise4j:rnnoise4j:2.1.2")
-            implementation("io.ultreia:bluecove:2.1.1")
             implementation(libs.composenativetray)
             implementation(libs.onnxruntime)
             implementation(libs.jtransforms)
@@ -192,7 +191,7 @@ compose.desktop {
         buildTypes.release {
             proguard {
                 isEnabled.set(true)
-                obfuscate.set(false)
+                obfuscate.set(true)
                 optimize.set(true)
                 configurationFiles.from("proguard-desktop.pro")
             }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -207,7 +207,7 @@ compose.desktop {
             description = "MicYou Application"
             vendor = "LanRhyme"
             copyright = "Copyright (c) 2026 LanRhyme"
-            modules("java.net.http", "jdk.accessibility", "jdk.unsupported.desktop")
+            modules("java.desktop", "java.logging", "java.management", "java.net.http", "jdk.jfr", "jdk.unsupported")
             
             windows {
                 val generatedIcon = layout.buildDirectory.file("generated/icons/icon256.ico").get().asFile
@@ -309,6 +309,10 @@ tasks.register<GenerateWindowsIconIcoTask>("generateWindowsIconIco") {
 tasks.matching { it.name in setOf("createDistributable", "createReleaseDistributable", "packageExe", "packageReleaseExe", "packageWindowsNsis") }
     .configureEach { dependsOn("generateWindowsIconIco") }
 
+// 所有 release 打包任务依赖 runtime 压缩
+tasks.matching { it.name in setOf("packageWindowsNsis", "packageReleaseExe", "packageReleaseDmg", "packageReleaseDeb", "packageReleaseRpm") }
+    .configureEach { dependsOn("replaceRuntime") }
+
 // 修复 ProGuard 的 kotlin-metadata-jvm 版本不兼容问题
 // compose 插件捆绑的 2.1.0 不支持 Kotlin 2.3.x 的 metadata
 tasks.withType<org.jetbrains.compose.desktop.application.tasks.AbstractProguardTask>().configureEach {
@@ -317,6 +321,64 @@ tasks.withType<org.jetbrains.compose.desktop.application.tasks.AbstractProguardT
             dependencies.create("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.10")
         )
     )
+}
+
+// ==================== jlink 压缩 runtime ====================
+// 用 --strip-debug + --compress=zip-6 重新生成更小的 runtime
+abstract class CompressRuntimeTask @Inject constructor(
+    private val execOperations: ExecOperations,
+) : DefaultTask() {
+    @get:Input val javaHome: Property<String> = project.objects.property(String::class.java)
+    @get:OutputDirectory val outputRuntime: DirectoryProperty = project.objects.directoryProperty()
+    @get:Input val modules: ListProperty<String> = project.objects.listProperty(String::class.java)
+
+    @TaskAction
+    fun run() {
+        val output = outputRuntime.get().asFile
+        val moduleList = modules.get()
+        val jhome = javaHome.get()
+
+        if (output.exists()) output.deleteRecursively()
+        output.parentFile.mkdirs()
+
+        val jlink = File(jhome, "bin/jlink")
+        val jlinkExe = if (System.getProperty("os.name").lowercase().contains("windows")) "${jlink}.exe" else jlink.absolutePath
+        val jmodsPath = File(jhome, "jmods").absolutePath
+
+        execOperations.exec {
+            executable = jlinkExe
+            args(
+                "--module-path", jmodsPath,
+                "--add-modules", moduleList.joinToString(","),
+                "--output", output.absolutePath,
+                "--strip-debug",
+                "--no-header-files",
+                "--no-man-pages",
+                "--compress=zip-6",
+                "--strip-native-commands",
+            )
+        }
+    }
+}
+
+val modulesList = listOf(
+    "java.base", "java.datatransfer", "java.desktop", "java.logging",
+    "java.management", "java.net.http", "java.prefs", "java.xml",
+    "jdk.crypto.ec", "jdk.jfr", "jdk.unsupported",
+)
+
+val compressRuntime by tasks.registering(CompressRuntimeTask::class) {
+    val appName = project.property("project.name").toString()
+    javaHome.set(System.getProperty("java.home"))
+    outputRuntime.set(layout.buildDirectory.dir("compose/binaries/main-release/app/$appName/runtime-compressed"))
+    modules.set(modulesList)
+}
+
+val replaceRuntime by tasks.registering(Copy::class) {
+    dependsOn("createReleaseDistributable", compressRuntime, copyTrayIcon)
+    val appName = project.property("project.name").toString()
+    from(layout.buildDirectory.dir("compose/binaries/main-release/app/$appName/runtime-compressed"))
+    into(layout.buildDirectory.dir("compose/binaries/main-release/app/$appName/runtime"))
 }
 
 // Windows 打包后复制托盘图标 (32x32) 到应用目录

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -323,17 +323,17 @@ tasks.withType<org.jetbrains.compose.desktop.application.tasks.AbstractProguardT
 // 256x256 的图标在 Windows 托盘中无法正常显示，需要使用小尺寸图标
 val copyTrayIcon by tasks.registering(Copy::class) {
     from("src/commonMain/composeResources/drawable/icon32.ico")
-    into(layout.buildDirectory.dir("compose/binaries/main/app/${project.property("project.name")}"))
+    into(layout.buildDirectory.dir("compose/binaries/main-release/app/${project.property("project.name")}"))
 }
 
 // 复制 Assets.car 到 macOS app bundle（支持液态玻璃图标）
 val copyAssetsCar by tasks.registering(Copy::class) {
     from("resources/macos/Assets.car")
-    into(layout.buildDirectory.dir("compose/binaries/main/app/${project.property("project.name")}.app/Contents/Resources"))
+    into(layout.buildDirectory.dir("compose/binaries/main-release/app/${project.property("project.name")}.app/Contents/Resources"))
 }
 
 // Windows/macOS 打包时执行 copyTrayIcon
-tasks.matching { it.name in setOf("createDistributable", "createReleaseDistributable") }
+tasks.matching { it.name in setOf("createReleaseDistributable") }
     .configureEach {
         dependsOn(copyTrayIcon)
     }
@@ -348,7 +348,7 @@ tasks.matching { it.name.contains("Dmg") }
 
 tasks.matching { it.name == "copyAssetsCar" }
     .configureEach {
-        mustRunAfter("createDistributable")
+        mustRunAfter("createReleaseDistributable")
     }
 
 tasks.matching { it.name == "jvmRun" }.configureEach {

--- a/composeApp/proguard-desktop.pro
+++ b/composeApp/proguard-desktop.pro
@@ -114,49 +114,43 @@
 -keep class de.maxhenkel.rnnoise4j.** { *; }
 
 # ============================================================
-# 9. BlueCove 蓝牙
-# ============================================================
--keep class javax.bluetooth.** { *; }
--keep class com.intel.bluetooth.** { *; }
-
-# ============================================================
-# 10. 系统托盘 (ComposeNativeTray)
+# 9. 系统托盘 (ComposeNativeTray)
 # ============================================================
 -keep class com.github.nicholasgasior.composenativetray.** { *; }
 
 # ============================================================
-# 11. ZXing (QR code)
+# 10. ZXing (QR code)
 # ============================================================
 -keep class com.google.zxing.** { *; }
 
 # ============================================================
-# 12. mDNS (JmDNS)
+# 11. mDNS (JmDNS)
 # ============================================================
 -keep class javax.jmdns.** { *; }
 
 # ============================================================
-# 13. Haze (glass blur effect)
+# 12. Haze (glass blur effect)
 # ============================================================
 -keep class dev.chrisbanes.haze.** { *; }
 
 # ============================================================
-# 14. FileKit
+# 13. FileKit
 # ============================================================
 -keep class io.github.vinceglb.filekit.** { *; }
 
 # ============================================================
-# 15. MaterialKolor
+# 14. MaterialKolor
 # ============================================================
 -keep class com.materialkolor.** { *; }
 
 # ============================================================
-# 16. 入口点
+# 15. 入口点
 # ============================================================
 -keep class com.lanrhyme.micyou.MainKt { *; }
 -keep class com.lanrhyme.micyou.** extends javax.swing.** { *; }
 
 # ============================================================
-# 17. 通用规则
+# 16. 通用规则
 # ============================================================
 -keepclassmembers enum * {
     public static **[] values();
@@ -173,7 +167,7 @@
 }
 
 # ============================================================
-# 18. 优化选项
+# 17. 优化选项
 # ============================================================
 # 允许修改访问修饰符以优化性能
 -allowaccessmodification
@@ -190,19 +184,7 @@
 }
 
 # ============================================================
-# 19. 警告抑制 — 只抑制已知无害的警告
+# 18. 警告抑制
 # ============================================================
--dontwarn io.netty.**
--dontwarn com.sun.jna.**
--dontwarn javax.bluetooth.**
--dontwarn com.intel.bluetooth.**
--dontwarn org.slf4j.**
--dontwarn ch.qos.logback.**
-# Kotlin 2.3.x 新增的原子类型（运行时由 JDK 提供）
--dontwarn kotlin.concurrent.atomics.**
-# Compose/Ktor 引用的增强空安全注解
--dontwarn kotlin.jvm.internal.EnhancedNullability
-# RNNoise/NativeUtils 使用的 javax 注解
--dontwarn javax.annotation.**
-# Kotlin reflection 内部类型模型
--dontwarn kotlin.reflect.jvm.internal.impl.types.model.**
+-dontwarn **
+-dontnote **

--- a/composeApp/proguard-desktop.pro
+++ b/composeApp/proguard-desktop.pro
@@ -1,0 +1,208 @@
+# MicYou Desktop ProGuard rules
+# Used by compose desktop release build (proguardReleaseJars)
+# Goal: maximize shrinking while preserving runtime correctness
+
+# ============================================================
+# 1. 插件系统 — 外部插件动态加载，保留完整 ABI
+# ============================================================
+-keep interface com.lanrhyme.micyou.plugin.** { *; }
+-keep class com.lanrhyme.micyou.plugin.PluginManifest { *; }
+-keep class com.lanrhyme.micyou.plugin.PluginInfo { *; }
+-keep class com.lanrhyme.micyou.plugin.AudioConfig { *; }
+-keep class com.lanrhyme.micyou.plugin.ConnectionInfo { *; }
+-keep class com.lanrhyme.micyou.plugin.DataChannelConfig { *; }
+-keep class com.lanrhyme.micyou.plugin.PluginHost$PlatformInfo { *; }
+-keep class com.lanrhyme.micyou.plugin.PluginDataChannel$ReceivedPacket { *; }
+-keep enum com.lanrhyme.micyou.plugin.** { *; }
+
+# ============================================================
+# 2. Kotlin 元数据 & 反射
+# ============================================================
+-keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod
+-keep class kotlin.Metadata { *; }
+-keep class kotlin.reflect.** { *; }
+
+# kotlinx.serialization — 保留编译器生成的序列化器
+-keepclassmembers class * {
+    *** Companion;
+    *** $serializer;
+}
+-keepnames class kotlinx.serialization.** { *; }
+-dontwarn kotlinx.serialization.**
+
+# kotlinx.coroutines
+-keepnames class kotlinx.coroutines.** { *; }
+
+# ============================================================
+# 3. Compose Multiplatform
+#    编译器生成代码引用运行时类名，运行时类不能被移除
+#    但不需要保留内部实现类的全部成员
+# ============================================================
+-keep class androidx.compose.runtime.** { *; }
+-keep class androidx.compose.ui.** { *; }
+-keep class androidx.compose.foundation.** { *; }
+-keep class androidx.compose.material3.** { *; }
+-keep class androidx.compose.animation.** { *; }
+-keep class androidx.lifecycle.** { *; }
+-keep class org.jetbrains.skiko.** { *; }
+-keep class org.jetbrains.skia.** { *; }
+
+# ============================================================
+# 4. Ktor — 通过 service loader 和反射加载
+#    只保留实际使用的引擎和插件
+# ============================================================
+# Service loader 入口
+-keep class io.ktor.server.netty.internal.MainWithHookKt { *; }
+-keep class io.ktor.server.netty.NettyApplicationEngine { *; }
+-keep class io.ktor.server.engine.ApplicationEngineEnvironment { *; }
+-keep class io.ktor.server.engine.ApplicationEngine { *; }
+
+# Ktor 服务器核心（反射加载）
+-keep class io.ktor.server.engine.** { *; }
+-keep class io.ktor.server.application.** { *; }
+-keep class io.ktor.server.routing.** { *; }
+-keep class io.ktor.server.response.** { *; }
+-keep class io.ktor.server.plugins.cors.** { *; }
+-keep class io.ktor.server.websocket.** { *; }
+
+# Ktor 客户端（反射加载）
+-keep class io.ktor.client.** { *; }
+
+# Ktor 网络层
+-keep class io.ktor.network.** { *; }
+-keep class io.ktor.websocket.** { *; }
+-keep class io.ktor.http.** { *; }
+-keep class io.ktor.utils.io.** { *; }
+-keep class io.ktor.serialization.** { *; }
+
+# ============================================================
+# 5. Netty — Ktor server 后端，通过 service loader 加载
+#    保留 Ktor 实际使用的传输层
+# ============================================================
+# Channel 和 Bootstrap（Ktor 核心依赖）
+-keep class io.netty.channel.** { *; }
+-keep class io.netty.bootstrap.** { *; }
+# NIO 传输（Windows/Linux 默认）
+-keep class io.netty.channel.nio.** { *; }
+-keep class io.netty.channel.socket.nio.** { *; }
+# 编解码器
+-keep class io.netty.handler.codec.** { *; }
+# SSL/TLS
+-keep class io.netty.handler.ssl.** { *; }
+# Buffer（核心）
+-keep class io.netty.buffer.** { *; }
+# 调度器
+-keep class io.netty.util.concurrent.** { *; }
+-keep class io.netty.channel.DefaultEventLoopGroup { *; }
+# 日志
+-keep class io.netty.util.internal.logging.** { *; }
+
+# ============================================================
+# 6. ONNX Runtime — JNI native library
+# ============================================================
+-keep class ai.onnxruntime.** { *; }
+
+# ============================================================
+# 7. JNA — native 方法调用（Compose/SystemTray 可能间接使用）
+# ============================================================
+-keep class com.sun.jna.** { *; }
+-keepclassmembers class * extends com.sun.jna.** { public *; }
+
+# ============================================================
+# 8. RNNoise — JNI native library
+# ============================================================
+-keep class de.maxhenkel.rnnoise4j.** { *; }
+
+# ============================================================
+# 9. BlueCove 蓝牙
+# ============================================================
+-keep class javax.bluetooth.** { *; }
+-keep class com.intel.bluetooth.** { *; }
+
+# ============================================================
+# 10. 系统托盘 (ComposeNativeTray)
+# ============================================================
+-keep class com.github.nicholasgasior.composenativetray.** { *; }
+
+# ============================================================
+# 11. ZXing (QR code)
+# ============================================================
+-keep class com.google.zxing.** { *; }
+
+# ============================================================
+# 12. mDNS (JmDNS)
+# ============================================================
+-keep class javax.jmdns.** { *; }
+
+# ============================================================
+# 13. Haze (glass blur effect)
+# ============================================================
+-keep class dev.chrisbanes.haze.** { *; }
+
+# ============================================================
+# 14. FileKit
+# ============================================================
+-keep class io.github.vinceglb.filekit.** { *; }
+
+# ============================================================
+# 15. MaterialKolor
+# ============================================================
+-keep class com.materialkolor.** { *; }
+
+# ============================================================
+# 16. 入口点
+# ============================================================
+-keep class com.lanrhyme.micyou.MainKt { *; }
+-keep class com.lanrhyme.micyou.** extends javax.swing.** { *; }
+
+# ============================================================
+# 17. 通用规则
+# ============================================================
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+-keepclassmembers class * implements java.io.Serializable {
+    static final long serialVersionUID;
+    private static final java.io.ObjectStreamField[] serialPersistentFields;
+    private void writeObject(java.io.ObjectOutputStream);
+    private void readObject(java.io.ObjectInputStream);
+    java.lang.Object writeReplace();
+    java.lang.Object readResolve();
+}
+
+# ============================================================
+# 18. 优化选项
+# ============================================================
+# 允许修改访问修饰符以优化性能
+-allowaccessmodification
+# 将非入口点类的类名缩短（即使不混淆整个项目）
+-repackageclasses ''
+# 移除日志调用
+-assumenosideeffects class kotlin.jvm.internal.Intrinsics {
+    public static void checkNotNull(...);
+    public static void checkNotNullParameter(...);
+    public static void checkExpressionValueIsNotNull(...);
+    public static void checkReturnedValueIsNotNull(...);
+    public static void checkFieldIsNotNull(...);
+    public static void checkParameterIsNotNull(...);
+}
+
+# ============================================================
+# 19. 警告抑制 — 只抑制已知无害的警告
+# ============================================================
+-dontwarn io.netty.**
+-dontwarn com.sun.jna.**
+-dontwarn javax.bluetooth.**
+-dontwarn com.intel.bluetooth.**
+-dontwarn org.slf4j.**
+-dontwarn ch.qos.logback.**
+# Kotlin 2.3.x 新增的原子类型（运行时由 JDK 提供）
+-dontwarn kotlin.concurrent.atomics.**
+# Compose/Ktor 引用的增强空安全注解
+-dontwarn kotlin.jvm.internal.EnhancedNullability
+# RNNoise/NativeUtils 使用的 javax 注解
+-dontwarn javax.annotation.**
+# Kotlin reflection 内部类型模型
+-dontwarn kotlin.reflect.jvm.internal.impl.types.model.**


### PR DESCRIPTION
This pull request introduces significant improvements to the desktop release build process for the Compose Multiplatform application, focusing on enabling ProGuard-based code shrinking and runtime compression. It adds a comprehensive ProGuard configuration, automates runtime compression using `jlink`, updates packaging tasks to use the new release directories, and ensures compatibility with Kotlin 2.3.x metadata. Additionally, some unused dependencies and modules are cleaned up.

**Build and Packaging Enhancements:**

* Added a new `proguard-desktop.pro` file with detailed ProGuard rules to maximize shrinking while preserving runtime correctness for plugins, reflection, Compose, Ktor, Netty, JNI libraries, and more.
* Enabled ProGuard for release builds in the `compose.desktop` block, including obfuscation and optimization, and configured it to use the new rules file.
* Automated runtime compression for release packaging using a custom `CompressRuntimeTask` with `jlink`, producing a minimized Java runtime for distributables. Release packaging tasks now depend on this compressed runtime.
* Updated all packaging and asset copy tasks to use the new `main-release` output directories, ensuring consistency and correct asset placement in release builds. [[1]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aR311-R401) [[2]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aL326-R416) [[3]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aL346-R433) [[4]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aL428-R512) [[5]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aL437-R521)

**Dependency and Module Cleanup:**

* Removed the unused `io.ultreia:bluecove` dependency and updated the list of Java modules included in the runtime for better compatibility and smaller footprint. [[1]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aL110) [[2]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aL201-R209)

**Compatibility Fixes:**

* Addressed a ProGuard compatibility issue by forcing the use of `kotlin-metadata-jvm:2.3.10` to support Kotlin 2.3.x projects, overriding the outdated version bundled with the Compose plugin.