### PR TITLE
feat(desktop): 添加 IP 地址选择与自动绑定支持

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/AudioEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/AudioEngine.android.kt
@@ -669,6 +669,12 @@ actual class AudioEngine actual constructor() {
             context.startService(intent)
         }
     }
+
+    actual suspend fun stopAndWait() {
+        val currentJob = job
+        stop()
+        currentJob?.join()
+    }
     
     actual fun setMonitoring(enabled: Boolean) { }
 

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/Platform.android.kt
@@ -23,6 +23,8 @@ class AndroidPlatform : Platform {
 }
 
 actual fun getPlatform(): Platform = AndroidPlatform()
+actual suspend fun getPreferredLocalIpAddress(): String = "Client"
+actual suspend fun refreshLocalIpAddressDetails(): List<IpAddressInfo> = emptyList()
 
 actual fun getAppVersion(): String = BuildConfig.VERSION_NAME
 
@@ -106,4 +108,3 @@ actual fun currentTimeSeconds(): Long = System.currentTimeMillis() / 1000
 actual fun QrCodeImage(content: String, modifier: Modifier, sizeDp: Int) {
     // Web mode not supported on Android
 }
-

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/Platform.android.kt
@@ -19,6 +19,7 @@ class AndroidPlatform : Platform {
     override val type: PlatformType = PlatformType.Android
     override val ipAddress: String = "Client"
     override val ipAddresses: List<String> = listOf("Client")
+    override val ipAddressDetails: List<IpAddressInfo> = emptyList()
 }
 
 actual fun getPlatform(): Platform = AndroidPlatform()

--- a/composeApp/src/commonMain/composeResources/values-ca/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ca/strings.xml
@@ -180,6 +180,12 @@
     <string name="importPlugin">导入插件喵~</string>
     <string name="introText">MicYou 是一个开源麦克风工具喵~可以把你的安卓设备变成电脑的高质量麦克风喵！支持 Wi-Fi (TCP) 和 USB 连接，提供低延迟音频传输喵~ (≧∇≦)/</string>
     <string name="ipLabel">IP 喵: </string>
+    <string name="ipSwitchConfirmTitle">切换 IP 地址喵~</string>
+    <string name="ipSwitchConfirmMessage">切换 IP 地址需要重新连接喵，是否继续喵？(・_・)</string>
+    <string name="ipSwitchContinue">继续喵~</string>
+    <string name="ipSwitchCancel">取消喵~</string>
+    <string name="ipAllInterfaces">全部喵~</string>
+    <string name="ipAllInterfacesDesc">监听所有网络接口喵~</string>
     <string name="isLatestVersion">已是最新版本喵~ ✓</string>
     <string name="keepScreenOnDesc">使用应用时防止屏幕自动熄灭喵~</string>
     <string name="keepScreenOnLabel">保持屏幕常亮喵~</string>
@@ -387,6 +393,7 @@
     <string name="errorRecordingPermissionDenied">录音权限不足喵~</string>
     <string name="errorServerGeneric">服务器错误: %s 喵~</string>
     <string name="errorSocketError">套接字错误: %s 喵~</string>
+    <string name="errorIpChangeRestartFailed">IP 切换后重新连接失败喵: %s (ToT)</string>
     <string name="pluginConfiguration">插件配置喵~</string>
     <string name="pluginNotSupportedAndroid">Android 平台不支持插件喵~</string>
     <string name="pluginSettingsTitle">插件设置喵~</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rHK/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rHK/strings.xml
@@ -458,4 +458,11 @@
     <string name="sponsorsDisclaimer">此處僅顯示愛發電上對項目發起者個人 LanRhyme 嘅贊助。</string>
     <string name="sponsorsEmpty">暫無贊助者</string>
     <string name="sponsorsGoToAifadian">贊助</string>
-    </resources>
+    <string name="ipSwitchConfirmTitle">切換 IP 位址</string>
+    <string name="ipSwitchConfirmMessage">切換 IP 需要重新啟動音訊串流，是否繼續？</string>
+    <string name="ipSwitchRestart">重新啟動</string>
+    <string name="ipSwitchCancel">取消</string>
+    <string name="ipAllInterfaces">全部</string>
+    <string name="ipAllInterfacesDesc">監聽所有網絡介面</string>
+    <string name="errorIpChangeRestartFailed">IP 切換後重新啟動服務失敗: %s</string>
+</resources>

--- a/composeApp/src/commonMain/composeResources/values-zh-rHK/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rHK/strings.xml
@@ -459,10 +459,10 @@
     <string name="sponsorsEmpty">暫無贊助者</string>
     <string name="sponsorsGoToAifadian">贊助</string>
     <string name="ipSwitchConfirmTitle">切換 IP 位址</string>
-    <string name="ipSwitchConfirmMessage">切換 IP 需要重新啟動音訊串流，是否繼續？</string>
-    <string name="ipSwitchRestart">重新啟動</string>
+    <string name="ipSwitchConfirmMessage">切換 IP 位址需要重新連接，是否繼續？</string>
+    <string name="ipSwitchContinue">繼續</string>
     <string name="ipSwitchCancel">取消</string>
     <string name="ipAllInterfaces">全部</string>
     <string name="ipAllInterfacesDesc">監聽所有網絡介面</string>
-    <string name="errorIpChangeRestartFailed">IP 切換後重新啟動服務失敗: %s</string>
+    <string name="errorIpChangeRestartFailed">IP 切換後重新連接失敗: %s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh-rSS/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rSS/strings.xml
@@ -458,4 +458,11 @@
     <string name="sponsorsDisclaimer">此处仅显示爱发电上对项目发起者个人 LanRhyme 的赞助项。</string>
     <string name="sponsorsEmpty">暂无赞助者项</string>
     <string name="sponsorsGoToAifadian">赞助项</string>
+    <string name="ipSwitchConfirmTitle">切换 IP 地址</string>
+    <string name="ipSwitchConfirmMessage">切换 IP 需要重启音频流，是否继续？</string>
+    <string name="ipSwitchRestart">重启</string>
+    <string name="ipSwitchCancel">取消</string>
+    <string name="ipAllInterfaces">全部</string>
+    <string name="ipAllInterfacesDesc">监听所有网络接口</string>
+    <string name="errorIpChangeRestartFailed">IP 切换后重启服务失败: %s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh-rSS/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rSS/strings.xml
@@ -459,10 +459,10 @@
     <string name="sponsorsEmpty">暂无赞助者项</string>
     <string name="sponsorsGoToAifadian">赞助项</string>
     <string name="ipSwitchConfirmTitle">切换 IP 地址</string>
-    <string name="ipSwitchConfirmMessage">切换 IP 需要重启音频流，是否继续？</string>
-    <string name="ipSwitchRestart">重启</string>
+    <string name="ipSwitchConfirmMessage">切换 IP 地址需要重新连接，是否继续？</string>
+    <string name="ipSwitchContinue">继续</string>
     <string name="ipSwitchCancel">取消</string>
     <string name="ipAllInterfaces">全部</string>
     <string name="ipAllInterfacesDesc">监听所有网络接口</string>
-    <string name="errorIpChangeRestartFailed">IP 切换后重启服务失败: %s</string>
+    <string name="errorIpChangeRestartFailed">IP 切换后重新连接失败: %s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -458,4 +458,11 @@
     <string name="sponsorsDisclaimer">此處僅顯示愛發電上對專案發起者個人 LanRhyme 的贊助。</string>
     <string name="sponsorsEmpty">暫無贊助者</string>
     <string name="sponsorsGoToAifadian">贊助</string>
-    </resources>
+    <string name="ipSwitchConfirmTitle">切換 IP 位址</string>
+    <string name="ipSwitchConfirmMessage">切換 IP 需要重新啟動音訊串流，是否繼續？</string>
+    <string name="ipSwitchRestart">重新啟動</string>
+    <string name="ipSwitchCancel">取消</string>
+    <string name="ipAllInterfaces">全部</string>
+    <string name="ipAllInterfacesDesc">監聽所有網路介面</string>
+    <string name="errorIpChangeRestartFailed">IP 切換後重新啟動服務失敗: %s</string>
+</resources>

--- a/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -459,10 +459,10 @@
     <string name="sponsorsEmpty">暫無贊助者</string>
     <string name="sponsorsGoToAifadian">贊助</string>
     <string name="ipSwitchConfirmTitle">切換 IP 位址</string>
-    <string name="ipSwitchConfirmMessage">切換 IP 需要重新啟動音訊串流，是否繼續？</string>
-    <string name="ipSwitchRestart">重新啟動</string>
+    <string name="ipSwitchConfirmMessage">切換 IP 位址需要重新連接，是否繼續？</string>
+    <string name="ipSwitchContinue">繼續</string>
     <string name="ipSwitchCancel">取消</string>
     <string name="ipAllInterfaces">全部</string>
     <string name="ipAllInterfacesDesc">監聽所有網路介面</string>
-    <string name="errorIpChangeRestartFailed">IP 切換後重新啟動服務失敗: %s</string>
+    <string name="errorIpChangeRestartFailed">IP 切換後重新連接失敗: %s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -180,6 +180,12 @@
     <string name="importPlugin">导入插件</string>
     <string name="introText">MicYou 是一款开源的麦克风工具，可以将您的 Android 设备变成电脑的高质量麦克风，支持 Wi-Fi (TCP) 和 USB 连接，提供低延迟的音频传输体验。</string>
     <string name="ipLabel">IP： </string>
+    <string name="ipSwitchConfirmTitle">切换 IP 地址</string>
+    <string name="ipSwitchConfirmMessage">切换 IP 需要重启音频流，是否继续？</string>
+    <string name="ipSwitchRestart">重启</string>
+    <string name="ipSwitchCancel">取消</string>
+    <string name="ipAllInterfaces">全部</string>
+    <string name="ipAllInterfacesDesc">监听所有网络接口</string>
     <string name="isLatestVersion">当前已是最新版本</string>
     <string name="keepScreenOnDesc">使用应用时防止屏幕自动熄灭</string>
     <string name="keepScreenOnLabel">保持屏幕常亮</string>
@@ -388,6 +394,7 @@
     <string name="errorRecordingPermissionDenied">录音权限不足</string>
     <string name="errorServerGeneric">服务器错误: %s</string>
     <string name="errorSocketError">套接字错误: %s</string>
+    <string name="errorIpChangeRestartFailed">IP 切换后重启服务失败: %s</string>
     <string name="pluginConfiguration">插件配置</string>
     <string name="pluginNotSupportedAndroid">Android 平台不支持插件。</string>
     <string name="pluginSettingsTitle">插件设置</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -181,8 +181,8 @@
     <string name="introText">MicYou 是一款开源的麦克风工具，可以将您的 Android 设备变成电脑的高质量麦克风，支持 Wi-Fi (TCP) 和 USB 连接，提供低延迟的音频传输体验。</string>
     <string name="ipLabel">IP： </string>
     <string name="ipSwitchConfirmTitle">切换 IP 地址</string>
-    <string name="ipSwitchConfirmMessage">切换 IP 需要重启音频流，是否继续？</string>
-    <string name="ipSwitchRestart">重启</string>
+    <string name="ipSwitchConfirmMessage">切换 IP 地址需要重新连接，是否继续？</string>
+    <string name="ipSwitchContinue">继续</string>
     <string name="ipSwitchCancel">取消</string>
     <string name="ipAllInterfaces">全部</string>
     <string name="ipAllInterfacesDesc">监听所有网络接口</string>
@@ -394,7 +394,7 @@
     <string name="errorRecordingPermissionDenied">录音权限不足</string>
     <string name="errorServerGeneric">服务器错误: %s</string>
     <string name="errorSocketError">套接字错误: %s</string>
-    <string name="errorIpChangeRestartFailed">IP 切换后重启服务失败: %s</string>
+    <string name="errorIpChangeRestartFailed">IP 切换后重新连接失败: %s</string>
     <string name="pluginConfiguration">插件配置</string>
     <string name="pluginNotSupportedAndroid">Android 平台不支持插件。</string>
     <string name="pluginSettingsTitle">插件设置</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -161,7 +161,7 @@
     <string name="errorSuggestionsTitle">Suggestions:</string>
     <string name="errorServerGeneric">Server error: %s</string>
     <string name="errorSocketError">Socket error: %s</string>
-    <string name="errorIpChangeRestartFailed">Failed to restart service after IP change: %s</string>
+    <string name="errorIpChangeRestartFailed">Failed to reconnect after IP change: %s</string>
     <string name="errorUnknownMessage">An unknown error occurred: %s</string>
     <string name="errorUnknownTitle">Unknown Error</string>
     <string name="errorUsbConnectionFailedMessage">USB connection failed. Please check your USB cable and ensure USB debugging is enabled on your Android device.</string>
@@ -219,10 +219,10 @@
     <string name="introText">MicYou is an open source microphone tool that turns your Android device into a high-quality microphone for your computer. It supports Wi-Fi (TCP) and USB connections, providing low-latency audio transmission.</string>
     <string name="ipLabel">IP: </string>
     <string name="ipSwitchConfirmTitle">Switch IP Address</string>
-    <string name="ipSwitchConfirmMessage">Switching IP requires restarting the audio stream. Continue?</string>
-    <string name="ipSwitchRestart">Restart</string>
+    <string name="ipSwitchConfirmMessage">Switching the IP address requires reconnecting. Continue?</string>
+    <string name="ipSwitchContinue">Continue</string>
     <string name="ipSwitchCancel">Cancel</string>
-    <string name="ipAllInterfaces">ALL</string>
+    <string name="ipAllInterfaces">All Interfaces</string>
     <string name="ipAllInterfacesDesc">Listen on all interfaces</string>
     <string name="isLatestVersion">Already the latest version</string>
     <string name="keepScreenOnDesc">Prevent the screen from turning off while using the app</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -161,6 +161,7 @@
     <string name="errorSuggestionsTitle">Suggestions:</string>
     <string name="errorServerGeneric">Server error: %s</string>
     <string name="errorSocketError">Socket error: %s</string>
+    <string name="errorIpChangeRestartFailed">Failed to restart service after IP change: %s</string>
     <string name="errorUnknownMessage">An unknown error occurred: %s</string>
     <string name="errorUnknownTitle">Unknown Error</string>
     <string name="errorUsbConnectionFailedMessage">USB connection failed. Please check your USB cable and ensure USB debugging is enabled on your Android device.</string>
@@ -217,6 +218,12 @@
     <string name="installOsNotSupported">Current operating system does not support automatic installation</string>
     <string name="introText">MicYou is an open source microphone tool that turns your Android device into a high-quality microphone for your computer. It supports Wi-Fi (TCP) and USB connections, providing low-latency audio transmission.</string>
     <string name="ipLabel">IP: </string>
+    <string name="ipSwitchConfirmTitle">Switch IP Address</string>
+    <string name="ipSwitchConfirmMessage">Switching IP requires restarting the audio stream. Continue?</string>
+    <string name="ipSwitchRestart">Restart</string>
+    <string name="ipSwitchCancel">Cancel</string>
+    <string name="ipAllInterfaces">ALL</string>
+    <string name="ipAllInterfacesDesc">Listen on all interfaces</string>
     <string name="isLatestVersion">Already the latest version</string>
     <string name="keepScreenOnDesc">Prevent the screen from turning off while using the app</string>
     <string name="keepScreenOnLabel">Keep Screen On</string>

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioEngine.kt
@@ -57,6 +57,8 @@ expect class AudioEngine() {
 
     // 停止音频引擎
     fun stop()
+    // 停止并等待完成（用于需要严格顺序的场景，如 IP 切换）
+    suspend fun stopAndWait()
     // 设置是否启用本地监听（仅桌面端有效）
     fun setMonitoring(enabled: Boolean)
 

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
@@ -16,6 +16,8 @@ data class AudioStreamUiState(
     val transportProtocol: TransportProtocol = TransportProtocol.Both,
     val streamState: StreamState = StreamState.Idle,
     val ipAddress: String = "192.168.1.5",
+    val bindAddress: String = "0.0.0.0",
+    val isAutoBindAddress: Boolean = true,
     val port: String = Constants.DEFAULT_TCP_PORT.toString(),
     val errorMessage: String? = null,
     val monitoringEnabled: Boolean = false,
@@ -135,7 +137,24 @@ class AudioStreamViewModel : ViewModel() {
         }
         val savedProtocolName = settings.getString("transport_protocol", TransportProtocol.Both.name)
         val savedProtocol = try { TransportProtocol.valueOf(savedProtocolName) } catch(e: Exception) { TransportProtocol.Both }
+        val platform = getPlatform()
+        val isDesktop = platform.type == PlatformType.Desktop
         val savedIp = settings.getString("ip_address", "192.168.1.5")
+        val savedBindAddress = settings.getString("bind_address", "0.0.0.0")
+        val savedSelectedIp = settings.getString("selected_ip_address", "")
+        val defaultAutoBind = savedSelectedIp == "auto" ||
+            (savedSelectedIp.isBlank() && (savedBindAddress.isBlank() || savedBindAddress == "0.0.0.0"))
+        val savedAutoBindSetting = settings.getBoolean("is_auto_bind_address", defaultAutoBind)
+        val manualDesktopIp = when {
+            !isDesktop -> ""
+            savedSelectedIp == "auto" || savedAutoBindSetting -> ""
+            savedSelectedIp.isNotBlank() -> savedSelectedIp
+            savedBindAddress.isNotBlank() && savedBindAddress != "0.0.0.0" -> savedBindAddress
+            else -> ""
+        }
+        val effectiveIp = if (isDesktop) manualDesktopIp.ifBlank { platform.ipAddress } else savedIp
+        val effectiveBindAddress = if (isDesktop && manualDesktopIp.isNotBlank()) manualDesktopIp else "0.0.0.0"
+        val savedIsAutoBind = isDesktop && manualDesktopIp.isBlank()
     val savedPort = settings.getString("port", Constants.DEFAULT_TCP_PORT.toString())
     val savedMonitoring = false
         settings.putBoolean("monitoring_enabled", false)
@@ -202,7 +221,9 @@ class AudioStreamViewModel : ViewModel() {
             it.copy(
                 mode = effectiveMode,
                 transportProtocol = savedProtocol,
-                ipAddress = savedIp,
+                ipAddress = effectiveIp,
+                bindAddress = effectiveBindAddress,
+                isAutoBindAddress = savedIsAutoBind,
                 port = savedPort,
                 monitoringEnabled = savedMonitoring,
                 sampleRate = savedSampleRate,
@@ -345,12 +366,13 @@ class AudioStreamViewModel : ViewModel() {
 
     fun startStream() {
         Logger.i("AudioStreamViewModel", "Starting stream")
-    val mode = _uiState.value.mode
-        val ip = _uiState.value.ipAddress
+        val mode = _uiState.value.mode
+        val isDesktop = getPlatform().type == PlatformType.Desktop
+        val ip = if (isDesktop && _uiState.value.isAutoBindAddress) "0.0.0.0" else _uiState.value.ipAddress
 
         // 端口验证：确保端口在有效范围内 (1-65535)
-    val rawPort = _uiState.value.port.toIntOrNull()
-    val port = when {
+        val rawPort = _uiState.value.port.toIntOrNull()
+        val port = when {
             rawPort == null -> {
                 Logger.w("AudioStreamViewModel", "Invalid port format: ${_uiState.value.port}, using default ${Constants.DEFAULT_TCP_PORT}")
                 if (mode == ConnectionMode.Web) Constants.DEFAULT_WEB_PORT else Constants.DEFAULT_TCP_PORT
@@ -381,7 +403,7 @@ class AudioStreamViewModel : ViewModel() {
                 Logger.w("AudioStreamViewModel", "IP address format may be invalid: $ip")
             }
         }
-    val isClient = getPlatform().type == PlatformType.Android
+        val isClient = getPlatform().type == PlatformType.Android
         val sampleRate = _uiState.value.sampleRate
         val channelCount = _uiState.value.channelCount
         val audioFormat = _uiState.value.audioFormat
@@ -401,13 +423,13 @@ class AudioStreamViewModel : ViewModel() {
                 
                 // 分析错误并生成详细错误信息
                 val errorType = ConnectionErrorHelper.analyzeError(e, mode)
-    val savedLanguageName = settings.getString("language", AppLanguage.System.name)
-    val language = try {
+                val savedLanguageName = settings.getString("language", AppLanguage.System.name)
+                val language = try {
                     AppLanguage.valueOf(savedLanguageName)
                 } catch (ex: Exception) {
                     AppLanguage.System
                 }
-    val errorDetails = ConnectionErrorHelper.generateErrorDetails(
+                val errorDetails = ConnectionErrorHelper.generateErrorDetails(
                     type = errorType,
                     originalMessage = e.message ?: "Unknown error",
                     mode = mode,
@@ -430,8 +452,8 @@ class AudioStreamViewModel : ViewModel() {
         if (!isClient && mode == ConnectionMode.Wifi) {
             viewModelScope.launch {
                 val tcpAllowed = isPortAllowed(port, "TCP")
-    val udpPort = calculateUdpPort(port)
-    val udpAllowed = isPortAllowed(udpPort, "UDP")
+                    val udpPort = calculateUdpPort(port)
+                    val udpAllowed = isPortAllowed(udpPort, "UDP")
                 if (!tcpAllowed || !udpAllowed) {
                     Logger.w("AudioStreamViewModel", "Port $port (TCP) or $udpPort (UDP) is not allowed by firewall")
                     _uiState.update { it.copy(showFirewallDialog = true, pendingFirewallPort = port) }
@@ -448,7 +470,7 @@ class AudioStreamViewModel : ViewModel() {
 
     fun setMode(mode: ConnectionMode) {
         Logger.i("AudioStreamViewModel", "Setting connection mode to $mode")
-    val platformType = getPlatform().type
+        val platformType = getPlatform().type
 
         if (platformType == PlatformType.Android && mode == ConnectionMode.Web) {
             Logger.w("AudioStreamViewModel", "Web mode is not supported on Android, ignoring")
@@ -501,11 +523,54 @@ class AudioStreamViewModel : ViewModel() {
         _uiState.update { it.copy(transportProtocol = protocol) }
         settings.putString("transport_protocol", protocol.name)
     }
+    
+    fun setIp(ip: String, isAutoSelect: Boolean = false, restartStream: Boolean = false) {
+        Logger.d("AudioStreamViewModel", "Setting IP to $ip, autoSelect=$isAutoSelect, restartStream=$restartStream")
+        val wasRunning = _uiState.value.streamState == StreamState.Streaming || _uiState.value.streamState == StreamState.Connecting
 
-    fun setIp(ip: String) {
-        Logger.d("AudioStreamViewModel", "Setting IP to $ip")
-        _uiState.update { it.copy(ipAddress = ip) }
-        settings.putString("ip_address", ip)
+        val isDesktop = getPlatform().type == PlatformType.Desktop
+
+        if (isDesktop && isAutoSelect) {
+            val autoIp = getPlatform().ipAddress
+            _uiState.update {
+                it.copy(
+                    ipAddress = autoIp,
+                    isAutoBindAddress = true,
+                    bindAddress = "0.0.0.0"
+                )
+            }
+            settings.putString("ip_address", autoIp)
+            settings.putBoolean("is_auto_bind_address", true)
+            settings.putString("bind_address", "0.0.0.0")
+            settings.putString("selected_ip_address", "auto")
+        } else {
+            val selectedIp = ip.ifBlank { _uiState.value.ipAddress }
+            _uiState.update {
+                it.copy(
+                    ipAddress = selectedIp,
+                    isAutoBindAddress = if (isDesktop) false else it.isAutoBindAddress,
+                    bindAddress = if (isDesktop) selectedIp else it.bindAddress
+                )
+            }
+            settings.putString("ip_address", selectedIp)
+            if (isDesktop) {
+                settings.putBoolean("is_auto_bind_address", false)
+                settings.putString("bind_address", selectedIp)
+                settings.putString("selected_ip_address", selectedIp)
+            }
+        }
+
+        // 如果要求重启流（IP 切换时），先停止再启动
+        if (restartStream && wasRunning) {
+            viewModelScope.launch {
+                try {
+                    _audioEngine.stopAndWait()
+                    startStream()
+                } catch (e: Exception) {
+                    Logger.e("AudioStreamViewModel", "Failed to restart stream after IP change", e)
+                }
+            }
+        }
     }
 
     fun setPort(port: String) {
@@ -760,4 +825,5 @@ class AudioStreamViewModel : ViewModel() {
             discoveryManager.startDiscovery()
         }
     }
+
 }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
@@ -2,6 +2,7 @@ package com.lanrhyme.micyou
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -102,9 +103,11 @@ class AudioStreamViewModel : ViewModel() {
     val metricsHistoryFlow: StateFlow<List<AudioMetrics>> = _metricsHistoryFlow.asStateFlow()
 
     private val settings = SettingsFactory.getSettings()
+    private var isStartStreamRequestPending = false
 
     init {
         loadSettings()
+        refreshDesktopIpState()
         setupAudioEngineObservers()
         // Auto-start discovery on Android when in WiFi mode
         if (getPlatform().type == PlatformType.Android && _uiState.value.mode == ConnectionMode.Wifi) {
@@ -152,7 +155,7 @@ class AudioStreamViewModel : ViewModel() {
             savedBindAddress.isNotBlank() && savedBindAddress != "0.0.0.0" -> savedBindAddress
             else -> ""
         }
-        val effectiveIp = if (isDesktop) manualDesktopIp.ifBlank { platform.ipAddress } else savedIp
+        val effectiveIp = if (isDesktop) manualDesktopIp.ifBlank { savedIp } else savedIp
         val effectiveBindAddress = if (isDesktop && manualDesktopIp.isNotBlank()) manualDesktopIp else "0.0.0.0"
         val savedIsAutoBind = isDesktop && manualDesktopIp.isBlank()
     val savedPort = settings.getString("port", Constants.DEFAULT_TCP_PORT.toString())
@@ -257,6 +260,28 @@ class AudioStreamViewModel : ViewModel() {
         
         _audioEngine.setMonitoring(savedMonitoring)
         updateAudioEngineConfig()
+    }
+
+    private fun refreshDesktopIpState() {
+        if (getPlatform().type != PlatformType.Desktop) return
+        viewModelScope.launch {
+            try {
+                val details = refreshLocalIpAddressDetails()
+                val preferredIp = details.firstOrNull()?.ip ?: return@launch
+                _uiState.update { current ->
+                    if (!current.isAutoBindAddress || current.ipAddress == preferredIp) {
+                        current
+                    } else {
+                        current.copy(ipAddress = preferredIp)
+                    }
+                }
+                if (_uiState.value.isAutoBindAddress) {
+                    settings.putString("ip_address", preferredIp)
+                }
+            } catch (e: Exception) {
+                Logger.w("AudioStreamViewModel", "Failed to refresh desktop IP state: ${e.message}")
+            }
+        }
     }
 
     private fun setupAudioEngineObservers() {
@@ -365,6 +390,25 @@ class AudioStreamViewModel : ViewModel() {
     }
 
     fun startStream() {
+        if (isStartStreamRequestPending ||
+            _uiState.value.streamState == StreamState.Streaming ||
+            _uiState.value.streamState == StreamState.Connecting
+        ) {
+            Logger.d("AudioStreamViewModel", "Start stream request ignored: already starting or running")
+            return
+        }
+
+        isStartStreamRequestPending = true
+        viewModelScope.launch {
+            try {
+                startStreamInternal()
+            } finally {
+                isStartStreamRequestPending = false
+            }
+        }
+    }
+
+    private suspend fun startStreamInternal() {
         Logger.i("AudioStreamViewModel", "Starting stream")
         val mode = _uiState.value.mode
         val isDesktop = getPlatform().type == PlatformType.Desktop
@@ -410,45 +454,40 @@ class AudioStreamViewModel : ViewModel() {
 
         _uiState.update { it.copy(streamState = StreamState.Connecting, errorMessage = null, showErrorDialog = false, errorDetails = null) }
 
-        // 启动音频引擎（不阻塞）
-        viewModelScope.launch {
-            updateAudioEngineConfig()
+        updateAudioEngineConfig()
 
-            try {
-                Logger.d("AudioStreamViewModel", "Calling _audioEngine.start()")
-                _audioEngine.start(ip, port, mode, isClient, sampleRate, channelCount, audioFormat, _uiState.value.transportProtocol)
-                Logger.i("AudioStreamViewModel", "Stream started successfully")
-            } catch (e: Exception) {
-                Logger.e("AudioStreamViewModel", "Failed to start stream", e)
-                
-                // 分析错误并生成详细错误信息
-                val errorType = ConnectionErrorHelper.analyzeError(e, mode)
-                val savedLanguageName = settings.getString("language", AppLanguage.System.name)
-                val language = try {
-                    AppLanguage.valueOf(savedLanguageName)
-                } catch (ex: Exception) {
-                    AppLanguage.System
-                }
-                val errorDetails = ConnectionErrorHelper.generateErrorDetails(
-                    type = errorType,
-                    originalMessage = e.message ?: "Unknown error",
-                    mode = mode,
-                    port = port,
-                    ip = ip
-                )
-                
-                _uiState.update { 
-                    it.copy(
-                        streamState = StreamState.Error, 
-                        errorMessage = errorDetails.localizedMessage,
-                        showErrorDialog = true,
-                        errorDetails = errorDetails
-                    ) 
-                }
+        try {
+            Logger.d("AudioStreamViewModel", "Calling _audioEngine.start()")
+            _audioEngine.start(ip, port, mode, isClient, sampleRate, channelCount, audioFormat, _uiState.value.transportProtocol)
+            Logger.i("AudioStreamViewModel", "Stream started successfully")
+        } catch (e: Exception) {
+            Logger.e("AudioStreamViewModel", "Failed to start stream", e)
+
+            val errorType = ConnectionErrorHelper.analyzeError(e, mode)
+            val savedLanguageName = settings.getString("language", AppLanguage.System.name)
+            val language = try {
+                AppLanguage.valueOf(savedLanguageName)
+            } catch (ex: Exception) {
+                AppLanguage.System
             }
-        }
+            val errorDetails = ConnectionErrorHelper.generateErrorDetails(
+                type = errorType,
+                originalMessage = e.message ?: "Unknown error",
+                mode = mode,
+                port = port,
+                ip = ip
+            )
 
-        // 异步检查防火墙（不阻塞启动）
+            _uiState.update {
+                it.copy(
+                    streamState = StreamState.Error,
+                    errorMessage = errorDetails.localizedMessage,
+                    showErrorDialog = true,
+                    errorDetails = errorDetails
+                )
+            }
+            return
+        }
         if (!isClient && mode == ConnectionMode.Wifi) {
             viewModelScope.launch {
                 val tcpAllowed = isPortAllowed(port, "TCP")
@@ -531,18 +570,16 @@ class AudioStreamViewModel : ViewModel() {
         val isDesktop = getPlatform().type == PlatformType.Desktop
 
         if (isDesktop && isAutoSelect) {
-            val autoIp = getPlatform().ipAddress
             _uiState.update {
                 it.copy(
-                    ipAddress = autoIp,
                     isAutoBindAddress = true,
                     bindAddress = "0.0.0.0"
                 )
             }
-            settings.putString("ip_address", autoIp)
             settings.putBoolean("is_auto_bind_address", true)
             settings.putString("bind_address", "0.0.0.0")
             settings.putString("selected_ip_address", "auto")
+            refreshDesktopIpState()
         } else {
             val selectedIp = ip.ifBlank { _uiState.value.ipAddress }
             _uiState.update {
@@ -562,10 +599,10 @@ class AudioStreamViewModel : ViewModel() {
 
         // 如果要求重启流（IP 切换时），先停止再启动
         if (restartStream && wasRunning) {
-            viewModelScope.launch {
+            viewModelScope.launch(Dispatchers.IO) {
                 try {
                     _audioEngine.stopAndWait()
-                    startStream()
+                    startStreamInternal()
                 } catch (e: Exception) {
                     Logger.e("AudioStreamViewModel", "Failed to restart stream after IP change", e)
                 }
@@ -758,7 +795,7 @@ class AudioStreamViewModel : ViewModel() {
             }
             
             // 无论防火墙规则是否添加成功，都尝试启动音频流
-            startStream()
+            startStreamInternal()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
@@ -86,6 +86,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -406,8 +407,11 @@ private fun NetworkConfigCard(
                     var showIpSwitchConfirm by remember { mutableStateOf(false) }
                     var pendingIp by remember { mutableStateOf("") }
                     var pendingAutoSelect by remember { mutableStateOf(false) }
-                    val ipDetails = remember(showIpList) {
-                        if (showIpList) platform.ipAddressDetails else emptyList()
+                    var ipDetails by remember { mutableStateOf(emptyList<IpAddressInfo>()) }
+                    LaunchedEffect(showIpList) {
+                        if (showIpList) {
+                            ipDetails = refreshLocalIpAddressDetails()
+                        }
                     }
                     val currentIp = state.ipAddress
                     val isAutoBind = state.isAutoBindAddress

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
@@ -86,7 +86,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
@@ -17,8 +17,11 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -240,11 +243,17 @@ fun DesktopHome(
                     hazeState = hazeState,
                     enableHaze = state.backgroundSettings.enableHazeEffect
                 ) {
-                    NetworkConfigCard(
-                        state = state,
-                        viewModel = viewModel,
-                        platform = platform
-                    )
+                    Column(
+                        modifier = Modifier.fillMaxSize().padding(10.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        NetworkConfigCard(
+                            state = state,
+                            viewModel = viewModel,
+                            platform = platform,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
                 }
 
                 AnimatedCard(
@@ -352,11 +361,12 @@ private fun AnimatedCard(
 private fun NetworkConfigCard(
     state: AppUiState,
     viewModel: MainViewModel,
-    platform: Platform
+    platform: Platform,
+    modifier: Modifier = Modifier
 ) {
     var titleVisible by remember { mutableStateOf(false) }
     var fieldsVisible by remember { mutableStateOf(false) }
-    
+
     LaunchedEffect(Unit) {
         titleVisible = true
         delay(100)
@@ -364,7 +374,7 @@ private fun NetworkConfigCard(
     }
 
     Column(
-        modifier = Modifier.padding(10.dp).fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -393,16 +403,40 @@ private fun NetworkConfigCard(
             ) {
                 Box {
                     var showIpList by remember { mutableStateOf(false) }
-    val currentIps = remember(showIpList) {
-                        if (showIpList) platform.ipAddresses else emptyList()
+                    var showIpSwitchConfirm by remember { mutableStateOf(false) }
+                    var pendingIp by remember { mutableStateOf("") }
+                    var pendingAutoSelect by remember { mutableStateOf(false) }
+                    val ipDetails = remember(showIpList) {
+                        if (showIpList) platform.ipAddressDetails else emptyList()
                     }
+                    val currentIp = state.ipAddress
+                    val isAutoBind = state.isAutoBindAddress
+                    val ipInteractionSource = remember { MutableInteractionSource() }
+                    val isIpHovered by ipInteractionSource.collectIsHoveredAsState()
+                    val ipBgColor by animateColorAsState(
+                        targetValue = if (isIpHovered)
+                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+                        else
+                            Color.Transparent,
+                        animationSpec = tween(200),
+                        label = "ipBg"
+                    )
 
                     SelectionContainer {
                         Text(
-                            "${stringResource(Res.string.ipLabel)}${platform.ipAddress}",
+                            "${stringResource(Res.string.ipLabel)}${currentIp}",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.clickable { showIpList = true }
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(8.dp))
+                                .hoverable(ipInteractionSource)
+                                .clickable(
+                                    interactionSource = ipInteractionSource,
+                                    indication = null,
+                                    onClick = { showIpList = true }
+                                )
+                                .background(ipBgColor)
+                                .padding(horizontal = 10.dp, vertical = 6.dp)
                         )
                     }
 
@@ -416,13 +450,109 @@ private fun NetworkConfigCard(
                             onDismissRequest = { showIpList = false },
                             shape = MaterialTheme.shapes.medium
                         ) {
-                            currentIps.forEach { ip ->
+                            DropdownMenuItem(
+                                text = {
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                    ) {
+                                        Column {
+                                            Text(stringResource(Res.string.ipAllInterfaces))
+                                            Text(
+                                                stringResource(Res.string.ipAllInterfacesDesc),
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        }
+                                        if (isAutoBind) {
+                                            Icon(
+                                                Icons.Rounded.CheckCircle,
+                                                null,
+                                                tint = MaterialTheme.colorScheme.primary,
+                                                modifier = Modifier.size(16.dp)
+                                            )
+                                        }
+                                    }
+                                },
+                                onClick = {
+                                    if (!isAutoBind) {
+                                        if (state.streamState == StreamState.Streaming || state.streamState == StreamState.Connecting) {
+                                            pendingIp = ""
+                                            pendingAutoSelect = true
+                                            showIpSwitchConfirm = true
+                                        } else {
+                                            viewModel.setIp("", isAutoSelect = true)
+                                        }
+                                    }
+                                    showIpList = false
+                                }
+                            )
+                            ipDetails.forEach { info ->
+                                val isSelected = !isAutoBind && currentIp == info.ip
                                 DropdownMenuItem(
-                                    text = { Text(ip) },
-                                    onClick = { showIpList = false }
+                                    text = {
+                                        Row(
+                                            verticalAlignment = Alignment.CenterVertically,
+                                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                        ) {
+                                            Column {
+                                                Text(info.ip)
+                                                Text(
+                                                    info.interfaceName,
+                                                    style = MaterialTheme.typography.labelSmall,
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                                )
+                                            }
+                                            if (isSelected) {
+                                                Icon(
+                                                    Icons.Rounded.CheckCircle,
+                                                    null,
+                                                    tint = MaterialTheme.colorScheme.primary,
+                                                    modifier = Modifier.size(16.dp)
+                                                )
+                                            }
+                                        }
+                                    },
+                                    onClick = {
+                                        if (!isSelected) {
+                                            if (state.streamState == StreamState.Streaming || state.streamState == StreamState.Connecting) {
+                                                pendingIp = info.ip
+                                                pendingAutoSelect = false
+                                                showIpSwitchConfirm = true
+                                            } else {
+                                                viewModel.setIp(info.ip)
+                                            }
+                                        }
+                                        showIpList = false
+                                    }
                                 )
                             }
                         }
+                    }
+
+                    if (showIpSwitchConfirm) {
+                        AlertDialog(
+                            onDismissRequest = { showIpSwitchConfirm = false },
+                            title = { Text(stringResource(Res.string.ipSwitchConfirmTitle)) },
+                            text = { Text(stringResource(Res.string.ipSwitchConfirmMessage)) },
+                            confirmButton = {
+                                TextButton(onClick = {
+                                    if (pendingAutoSelect) {
+                                        viewModel.setIp("", isAutoSelect = true, restartStream = true)
+                                    } else {
+                                        viewModel.setIp(pendingIp, restartStream = true)
+                                    }
+                                    showIpSwitchConfirm = false
+                                }) {
+                                    Text(stringResource(Res.string.ipSwitchRestart))
+                                }
+                            },
+                            dismissButton = {
+                                TextButton(onClick = { showIpSwitchConfirm = false }) {
+                                    Text(stringResource(Res.string.ipSwitchCancel))
+                                }
+                            }
+                        )
                     }
                 }
             }
@@ -1051,7 +1181,7 @@ private fun AnimatedIconButton(
             stiffness = Spring.StiffnessMedium
         )
     )
-    
+
     IconButton(
         onClick = onClick,
         interactionSource = interactionSource,

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
@@ -548,7 +548,7 @@ private fun NetworkConfigCard(
                                     }
                                     showIpSwitchConfirm = false
                                 }) {
-                                    Text(stringResource(Res.string.ipSwitchRestart))
+                                    Text(stringResource(Res.string.ipSwitchContinue))
                                 }
                             },
                             dismissButton = {

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
@@ -91,7 +91,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
@@ -22,9 +22,9 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -41,8 +41,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
@@ -63,6 +61,7 @@ import androidx.compose.material.icons.rounded.Mic
 import androidx.compose.material.icons.rounded.MicOff
 import androidx.compose.material.icons.rounded.Minimize
 import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.KeyboardArrowDown
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Usb
 import androidx.compose.material.icons.rounded.Wifi
@@ -71,23 +70,27 @@ import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RippleConfiguration
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material.ripple.RippleAlpha
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -95,13 +98,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -229,6 +229,7 @@ fun DesktopHomeEnhanced(
                 HeaderSection(
                     platform = platform,
                     state = state,
+                    viewModel = viewModel,
                     onMinimize = onMinimize,
                     onClose = onClose,
                     cardOpacity = state.backgroundSettings.cardOpacity,
@@ -337,6 +338,7 @@ fun DesktopHomeEnhanced(
 private fun HeaderSection(
     platform: Platform,
     state: AppUiState,
+    viewModel: MainViewModel,
     onMinimize: () -> Unit,
     onClose: () -> Unit,
     cardOpacity: Float = 1f,
@@ -421,120 +423,201 @@ private fun HeaderSection(
                     Text("Server", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
-    val ipList = platform.ipAddresses
-            val lazyListState = rememberLazyListState()
-    val coroutineScope = rememberCoroutineScope()
-            
-            Surface(
-                shape = MaterialTheme.shapes.small,
-                color = MaterialTheme.colorScheme.surfaceContainerHighest
-            ) {
-                Box(
-                    modifier = Modifier.widthIn(max = 200.dp)
-                ) {
-                    LazyRow(
-                        state = lazyListState,
-                        modifier = Modifier
-                            .padding(horizontal = 10.dp, vertical = 6.dp)
-                            .pointerInput(Unit) {
-                                awaitPointerEventScope {
-                                    while (true) {
-                                        val event = awaitPointerEvent()
-                                        if (event.type == PointerEventType.Scroll) {
-                                            val scrollDelta = event.changes.first().scrollDelta.y
-                                            coroutineScope.launch {
-                                                lazyListState.scrollBy(scrollDelta * 2f)
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        items(ipList.size) { index ->
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(4.dp)
-                            ) {
-                                if (index > 0) {
-                                    Text(
-                                        "•",
-                                        style = MaterialTheme.typography.labelMedium,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
-                                    )
-                                }
-                                Icon(
-                                    Icons.Rounded.Language,
-                                    null,
-                                    tint = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.size(14.dp)
-                                )
-                                SelectionContainer {
-                                    Text(
-                                        ipList[index],
-                                        style = MaterialTheme.typography.labelMedium,
-                                        fontWeight = FontWeight.Medium,
-                                        maxLines = 1
-                                    )
-                                }
-                            }
-                        }
-                    }
-    val showLeftFade by remember {
-                        derivedStateOf { lazyListState.firstVisibleItemIndex > 0 || lazyListState.firstVisibleItemScrollOffset > 0 }
-                    }
-    val showRightFade by remember {
-                        derivedStateOf {
-                            val layoutInfo = lazyListState.layoutInfo
-                            if (layoutInfo.totalItemsCount == 0) false
-                            else {
-                                val lastVisibleItem = layoutInfo.visibleItemsInfo.lastOrNull()
-                                lastVisibleItem != null && (lastVisibleItem.index < layoutInfo.totalItemsCount - 1 || 
-                                    lastVisibleItem.offset + lastVisibleItem.size > layoutInfo.viewportEndOffset)
-                            }
-                        }
-                    }
-                    
-                    if (showLeftFade) {
-                        Box(
-                            modifier = Modifier
-                                .align(Alignment.CenterStart)
-                                .width(20.dp)
-                                .height(24.dp)
-                                .background(
-                                    Brush.horizontalGradient(
-                                        colors = listOf(
-                                            MaterialTheme.colorScheme.surfaceContainerHighest,
-                                            Color.Transparent
-                                        )
-                                    )
-                                )
-                        )
-                    }
-                    
-                    if (showRightFade) {
-                        Box(
-                            modifier = Modifier
-                                .align(Alignment.CenterEnd)
-                                .width(20.dp)
-                                .height(24.dp)
-                                .background(
-                                    Brush.horizontalGradient(
-                                        colors = listOf(
-                                            Color.Transparent,
-                                            MaterialTheme.colorScheme.surfaceContainerHighest
-                                        )
-                                    )
-                                )
-                        )
-                    }
-                }
-            }
-            
+            IpSelector(
+                platform = platform,
+                state = state,
+                viewModel = viewModel
+            )
+
             if (!isMacOSPlatform() && !state.useSystemTitleBar) {
                 WindowControls(onMinimize = onMinimize, onClose = onClose, useSystemTitleBar = state.useSystemTitleBar)
             }
+        }
+    }
+}
+
+@Composable
+private fun IpSelector(
+    platform: Platform,
+    state: AppUiState,
+    viewModel: MainViewModel
+) {
+    var showIpMenu by remember { mutableStateOf(false) }
+    var showIpSwitchConfirm by remember { mutableStateOf(false) }
+    var pendingIp by remember { mutableStateOf("") }
+    var pendingAutoSelect by remember { mutableStateOf(false) }
+    val ipDetails = remember(showIpMenu) {
+        if (showIpMenu) platform.ipAddressDetails else emptyList()
+    }
+    val currentIp = state.ipAddress
+    val isAutoBind = state.isAutoBindAddress
+
+    val ipInteractionSource = remember { MutableInteractionSource() }
+    val isIpHovered by ipInteractionSource.collectIsHoveredAsState()
+    val ipBgColor by animateColorAsState(
+        targetValue = if (isIpHovered)
+            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f)
+        else
+            MaterialTheme.colorScheme.surfaceContainerHighest,
+        animationSpec = tween(200),
+        label = "ipBgEnhanced"
+    )
+
+    Box {
+        Surface(
+            shape = MaterialTheme.shapes.small,
+            color = ipBgColor,
+            modifier = Modifier
+                .hoverable(ipInteractionSource)
+                .clickable(
+                    interactionSource = ipInteractionSource,
+                    indication = null,
+                    onClick = { showIpMenu = true }
+                )
+        ) {
+            Row(
+                modifier = Modifier
+                    .padding(horizontal = 10.dp, vertical = 6.dp)
+                    .widthIn(max = 200.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Icon(
+                    Icons.Rounded.Language,
+                    null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(14.dp)
+                )
+                SelectionContainer {
+                    Text(
+                        currentIp,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1
+                    )
+                }
+                Icon(
+                    Icons.Rounded.KeyboardArrowDown,
+                    null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+        }
+
+        CompositionLocalProvider(
+            LocalRippleConfiguration provides RippleConfiguration(
+                rippleAlpha = RippleAlpha(0f, 0f, 0f, 0f)
+            )
+        ) {
+            DropdownMenu(
+                expanded = showIpMenu,
+                onDismissRequest = { showIpMenu = false },
+                shape = MaterialTheme.shapes.medium
+            ) {
+                DropdownMenuItem(
+                    text = {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Column {
+                                Text(stringResource(Res.string.ipAllInterfaces))
+                                Text(
+                                    stringResource(Res.string.ipAllInterfacesDesc),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            if (isAutoBind) {
+                                Icon(
+                                    Icons.Rounded.CheckCircle,
+                                    null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.size(16.dp)
+                                )
+                            }
+                        }
+                    },
+                    onClick = {
+                        if (!isAutoBind) {
+                            if (state.streamState == StreamState.Streaming || state.streamState == StreamState.Connecting) {
+                                pendingIp = ""
+                                pendingAutoSelect = true
+                                showIpSwitchConfirm = true
+                            } else {
+                                viewModel.setIp("", isAutoSelect = true)
+                            }
+                        }
+                        showIpMenu = false
+                    }
+                )
+                ipDetails.forEach { info ->
+                    val isSelected = !isAutoBind && currentIp == info.ip
+                    DropdownMenuItem(
+                        text = {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Column {
+                                    Text(info.ip)
+                                    Text(
+                                        info.interfaceName,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                                if (isSelected) {
+                                    Icon(
+                                        Icons.Rounded.CheckCircle,
+                                        null,
+                                        tint = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.size(16.dp)
+                                    )
+                                }
+                            }
+                        },
+                        onClick = {
+                            if (!isSelected) {
+                                if (state.streamState == StreamState.Streaming || state.streamState == StreamState.Connecting) {
+                                    pendingIp = info.ip
+                                    pendingAutoSelect = false
+                                    showIpSwitchConfirm = true
+                                } else {
+                                    viewModel.setIp(info.ip)
+                                }
+                            }
+                            showIpMenu = false
+                        }
+                    )
+                }
+            }
+        }
+
+        if (showIpSwitchConfirm) {
+            AlertDialog(
+                onDismissRequest = { showIpSwitchConfirm = false },
+                title = { Text(stringResource(Res.string.ipSwitchConfirmTitle)) },
+                text = { Text(stringResource(Res.string.ipSwitchConfirmMessage)) },
+                confirmButton = {
+                    TextButton(onClick = {
+                        if (pendingAutoSelect) {
+                            viewModel.setIp("", isAutoSelect = true, restartStream = true)
+                        } else {
+                            viewModel.setIp(pendingIp, restartStream = true)
+                        }
+                        showIpSwitchConfirm = false
+                    }) {
+                        Text(stringResource(Res.string.ipSwitchRestart))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showIpSwitchConfirm = false }) {
+                        Text(stringResource(Res.string.ipSwitchCancel))
+                    }
+                }
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
@@ -613,7 +613,7 @@ private fun IpSelector(
                         }
                         showIpSwitchConfirm = false
                     }) {
-                        Text(stringResource(Res.string.ipSwitchRestart))
+                        Text(stringResource(Res.string.ipSwitchContinue))
                     }
                 },
                 dismissButton = {

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
@@ -91,6 +91,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -446,8 +447,11 @@ private fun IpSelector(
     var showIpSwitchConfirm by remember { mutableStateOf(false) }
     var pendingIp by remember { mutableStateOf("") }
     var pendingAutoSelect by remember { mutableStateOf(false) }
-    val ipDetails = remember(showIpMenu) {
-        if (showIpMenu) platform.ipAddressDetails else emptyList()
+    var ipDetails by remember { mutableStateOf(emptyList<IpAddressInfo>()) }
+    LaunchedEffect(showIpMenu) {
+        if (showIpMenu) {
+            ipDetails = refreshLocalIpAddressDetails()
+        }
     }
     val currentIp = state.ipAddress
     val isAutoBind = state.isAutoBindAddress

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
@@ -55,6 +55,8 @@ data class AppUiState(
     val transportProtocol: TransportProtocol = TransportProtocol.Both,
     val streamState: StreamState = StreamState.Idle,
     val ipAddress: String = "192.168.1.5",
+    val bindAddress: String = "0.0.0.0",
+    val isAutoBindAddress: Boolean = true,
     val port: String = Constants.DEFAULT_TCP_PORT.toString(),
     val errorMessage: String? = null,
     val monitoringEnabled: Boolean = false,
@@ -302,6 +304,8 @@ class MainViewModel : ViewModel() {
                         transportProtocol = audioState.transportProtocol,
                         streamState = audioState.streamState,
                         ipAddress = audioState.ipAddress,
+                        bindAddress = audioState.bindAddress,
+                        isAutoBindAddress = audioState.isAutoBindAddress,
                         port = audioState.port,
                         errorMessage = audioState.errorMessage,
                         monitoringEnabled = audioState.monitoringEnabled,
@@ -402,7 +406,7 @@ class MainViewModel : ViewModel() {
         audioStreamViewModel.setIp(device.hostAddress)
         audioStreamViewModel.setPort(device.port.toString())
     }
-    fun setIp(ip: String) = audioStreamViewModel.setIp(ip)
+    fun setIp(ip: String, isAutoSelect: Boolean = false, restartStream: Boolean = false) = audioStreamViewModel.setIp(ip, isAutoSelect, restartStream)
     fun setPort(port: String) = audioStreamViewModel.setPort(port)
     fun setMonitoringEnabled(enabled: Boolean) = audioStreamViewModel.setMonitoringEnabled(enabled)
     fun setSampleRate(rate: SampleRate) = audioStreamViewModel.setSampleRate(rate)

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Platform.kt
@@ -23,6 +23,8 @@ interface Platform {
 }
 
 expect fun getPlatform(): Platform
+expect suspend fun getPreferredLocalIpAddress(): String
+expect suspend fun refreshLocalIpAddressDetails(): List<IpAddressInfo>
 
 expect fun getAppVersion(): String
 expect fun openUrl(url: String)
@@ -123,4 +125,3 @@ expect fun currentTimeSeconds(): Long
 
 @Composable
 expect fun QrCodeImage(content: String, modifier: Modifier, sizeDp: Int)
-

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Platform.kt
@@ -9,11 +9,17 @@ enum class PlatformType {
     Android, Desktop
 }
 
+data class IpAddressInfo(
+    val ip: String,
+    val interfaceName: String
+)
+
 interface Platform {
     val name: String
     val type: PlatformType
     val ipAddress: String
     val ipAddresses: List<String>
+    val ipAddressDetails: List<IpAddressInfo>
 }
 
 expect fun getPlatform(): Platform

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
@@ -5,8 +5,12 @@ import com.lanrhyme.micyou.audio.AudioProcessorPipeline
 import com.lanrhyme.micyou.audio.AudioSpectrumAnalyzer
 import micyou.composeapp.generated.resources.Res
 import micyou.composeapp.generated.resources.errorAdbReverseFailed
+import micyou.composeapp.generated.resources.errorIpChangeRestartFailed
 import org.jetbrains.compose.resources.getString
 import com.lanrhyme.micyou.network.MdnsAdvertiser
+import com.lanrhyme.micyou.network.NetworkAddressChangeEvent
+import com.lanrhyme.micyou.network.NetworkAddressChangeListener
+import com.lanrhyme.micyou.network.NetworkAddressMonitor
 import com.lanrhyme.micyou.network.NetworkServer
 import com.lanrhyme.micyou.network.WebServer
 import com.lanrhyme.micyou.platform.AdbManager
@@ -16,7 +20,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -72,6 +75,17 @@ actual class AudioEngine actual constructor() {
     )
     
     private val mdnsAdvertiser = MdnsAdvertiser()
+    private val networkAddressMonitor = NetworkAddressMonitor()
+    private val networkAddressChangeListener = object : NetworkAddressChangeListener {
+        override fun onAddressChanged(event: NetworkAddressChangeEvent) {
+            handleIpAddressChanged(event)
+        }
+    }
+
+    // Track current mode and config for IP change restart
+    private var currentMode: ConnectionMode? = null
+    private var currentPort: Int = -1
+    private var currentBindAddress: String = "0.0.0.0"
 
     private val networkServer = NetworkServer(
         onAudioPacketReceived = { audioPacket ->
@@ -96,7 +110,7 @@ actual class AudioEngine actual constructor() {
     private val _webClientCount = MutableStateFlow(0)
     actual val webUrl: Flow<String> = _webUrl.asStateFlow()
     actual val webClientCount: Flow<Int> = _webClientCount.asStateFlow()
-    
+
     init {
         // Start mDNS advertisement immediately so Android clients can discover this server
         scope.launch(Dispatchers.IO) {
@@ -108,6 +122,9 @@ actual class AudioEngine actual constructor() {
                 Logger.w("AudioEngine", "Failed to start mDNS advertisement: ${e.message}")
             }
         }
+
+        // Register IP change listener. Monitoring is started only while a stream is active.
+        networkAddressMonitor.addListener(networkAddressChangeListener)
 
         scope.launch {
             networkServer.state.collect { newState ->
@@ -155,6 +172,66 @@ actual class AudioEngine actual constructor() {
         scope.launch {
             webServer.clientCountFlow.collect { count ->
                 _webClientCount.value = count
+            }
+        }
+    }
+
+    /**
+     * Handles local IP address changes while using automatic bind mode.
+     */
+    private fun handleIpAddressChanged(event: NetworkAddressChangeEvent) {
+        // Manual bind mode should keep using the selected address.
+        if (currentBindAddress != "0.0.0.0") {
+            Logger.d("AudioEngine", "Manual bind mode (currentBindAddress=$currentBindAddress), skipping auto IP change")
+            return
+        }
+
+        val newPrimaryIp = event.newPrimaryIp ?: return
+        Logger.i("AudioEngine", "Handling IP change: ${event.oldPrimaryIp} -> $newPrimaryIp")
+
+        // Re-advertise mDNS with new IP
+        scope.launch(Dispatchers.IO) {
+            try {
+                mdnsAdvertiser.reAdvertise(currentPort, "0.0.0.0")
+            } catch (e: Exception) {
+                Logger.w("AudioEngine", "Failed to re-advertise mDNS: ${e.message}")
+            }
+        }
+
+        // Restart active servers with new IP if they are running
+        val mode = currentMode ?: return
+        if (_state.value != StreamState.Streaming && _state.value != StreamState.Connecting) {
+            Logger.d("AudioEngine", "No active stream, skipping server restart")
+            return
+        }
+
+        scope.launch {
+            try {
+                startStopMutex.withLock {
+                    stopJob?.join()
+                    stopJob = null
+
+                    when (mode) {
+                        ConnectionMode.Wifi -> {
+                            Logger.i("AudioEngine", "Restarting NetworkServer with new IP: $newPrimaryIp")
+                            networkServer.stop()
+                            networkServer.start(currentPort, "0.0.0.0")
+                        }
+                        ConnectionMode.Web -> {
+                            Logger.i("AudioEngine", "Restarting WebServer with new IP: $newPrimaryIp")
+                            val webUrlStr = "https://$newPrimaryIp:$currentPort"
+                            _webUrl.value = webUrlStr
+                            webServer.stop()
+                            webServer.start(currentPort, "0.0.0.0")
+                        }
+                        else -> {
+                            // USB mode does not depend on IP
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                Logger.e("AudioEngine", "Failed to restart server after IP change", e)
+                _lastError.value = String.format(getString(Res.string.errorIpChangeRestartFailed), e.message ?: "")
             }
         }
     }
@@ -268,20 +345,24 @@ actual class AudioEngine actual constructor() {
     }
 
     actual suspend fun start(
-        ip: String, 
-        port: Int, 
-        mode: ConnectionMode, 
+        ip: String,
+        port: Int,
+        mode: ConnectionMode,
         isClient: Boolean,
         sampleRate: SampleRate,
         channelCount: ChannelCount,
         audioFormat: AudioFormat,
         transportProtocol: TransportProtocol
     ) {
-        if (isClient) return 
+        if (isClient) return
         Logger.i("AudioEngine", "启动 JVM AudioEngine: 模式=$mode, 协议=$transportProtocol, 端口=$port, 采样率=${sampleRate.value}, 声道=${channelCount.label}, 格式=${audioFormat.label}")
-        
+
         _lastError.value = null
-        
+
+        // Save current mode and port for IP change handling
+        currentMode = mode
+        currentPort = port
+
         if (mode == ConnectionMode.Usb) {
             Logger.i("AudioEngine", "正在为 USB 模式执行 ADB reverse，端口 $port")
             if (AdbManager.runAdbReverse(port)) {
@@ -294,15 +375,16 @@ actual class AudioEngine actual constructor() {
                 throw Exception(errorMsg)
             }
         }
-        
+
         if (mode == ConnectionMode.Web) {
             val webPort = port.takeIf { it in 1..65535 } ?: Constants.DEFAULT_WEB_PORT
             Logger.i("AudioEngine", "启动 Web 模式，端口=$webPort")
 
-            val platform = getPlatform()
-            val primaryIp = platform.ipAddress
-            val webUrlStr = "https://$primaryIp:$webPort"
+            val bindAddress = ip.takeIf { it.isNotBlank() } ?: "0.0.0.0"
+            val displayIp = if (bindAddress == "0.0.0.0") getPlatform().ipAddress else bindAddress
+            val webUrlStr = "https://$displayIp:$webPort"
             _webUrl.value = webUrlStr
+            currentBindAddress = bindAddress
 
             startStopMutex.withLock {
                 stopJob?.join()
@@ -311,13 +393,15 @@ actual class AudioEngine actual constructor() {
                 if (webServer.isRunning) {
                     Logger.w("AudioEngine", "WebServer 已在运行，忽略启动请求")
                 } else {
-                    webServer.start(webPort)
+                    webServer.start(webPort, bindAddress)
+                    mdnsAdvertiser.reAdvertise(webPort, bindAddress)
+                    updateNetworkAddressMonitor(bindAddress)
                     Logger.i("AudioEngine", "WebServer started at $webUrlStr")
                 }
             }
             return
         }
-        
+
         startStopMutex.withLock {
             // 等待任何正在进行的停止操作完成，防止竞态条件
             stopJob?.join()
@@ -329,9 +413,21 @@ actual class AudioEngine actual constructor() {
             } else {
                 // 直接调用 networkServer.start()，不 launch 新协程
                 // NetworkServer 内部会管理自己的协程
-                networkServer.start(port, transportProtocol, mode)
-                Logger.i("AudioEngine", "NetworkServer started successfully")
+                val bindAddress = ip.takeIf { it.isNotBlank() } ?: getPlatform().ipAddress
+                currentBindAddress = bindAddress
+                networkServer.start(port, bindAddress, transportProtocol, mode)
+                mdnsAdvertiser.reAdvertise(port, bindAddress)
+                updateNetworkAddressMonitor(bindAddress)
+                Logger.i("AudioEngine", "NetworkServer started successfully on $bindAddress:$port")
             }
+        }
+    }
+
+    private fun updateNetworkAddressMonitor(bindAddress: String) {
+        if (bindAddress == "0.0.0.0") {
+            networkAddressMonitor.start()
+        } else {
+            networkAddressMonitor.stop()
         }
     }
 
@@ -372,6 +468,14 @@ actual class AudioEngine actual constructor() {
          try {
              job?.cancel()
              job = null
+             _lastError.value = null
+             _state.value = StreamState.Idle
+
+             // Reset current mode tracking
+             currentMode = null
+             currentPort = -1
+             currentBindAddress = "0.0.0.0"
+
              // 使用协程异步停止，避免阻塞调用线程
              // 保存停止 Job 以便 start() 可以等待其完成，防止竞态条件
              // 检查是否已有活跃的停止操作，避免协程泄漏
@@ -408,17 +512,32 @@ actual class AudioEngine actual constructor() {
                      } catch (e: Exception) {
                          Logger.w("AudioEngine", "Error closing MdnsAdvertiser: ${e.message}")
                      }
+                     try {
+                         networkAddressMonitor.stop()
+                     } catch (e: Exception) {
+                         Logger.w("AudioEngine", "Error stopping NetworkAddressMonitor: ${e.message}")
+                     }
                  }
              } else {
                  Logger.d("AudioEngine", "Stop operation already in progress, skipping duplicate stop request")
              }
-             _lastError.value = null
-             _state.value = StreamState.Idle
          } catch (e: Exception) {
              Logger.e("AudioEngine", "Error stopping audio engine: ${e.message}", e)
          }
     }
-    
+
+    /**
+     * 挂起函数版本的 stop，确保停止操作完全完成后再返回。
+     * 用于 IP 切换等需要严格顺序的场景。
+     */
+    actual suspend fun stopAndWait() {
+        stop()
+        startStopMutex.withLock {
+            stopJob?.join()
+            stopJob = null
+        }
+    }
+
     /**
      * 计算 16-bit PCM 音频数据的电平数据。
      * 返回 RMS、峰值和分贝值。

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
@@ -54,9 +54,7 @@ actual class AudioEngine actual constructor() {
     val pluginSyncReceived: Flow<PluginSyncMessage?> = _pluginSyncReceived
     
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-    private var job: Job? = null
     private var audioProcessingJob: Job? = null
-    private var stopJob: Job? = null // 用于跟踪停止操作，防止竞态条件
     private val startStopMutex = Mutex()
 
     private val audioOutputManager = AudioOutputManager()
@@ -82,10 +80,11 @@ actual class AudioEngine actual constructor() {
         }
     }
 
-    // Track current mode and config for IP change restart
+    // Track current mode and config for IP change restart. Guard with startStopMutex.
     private var currentMode: ConnectionMode? = null
     private var currentPort: Int = -1
     private var currentBindAddress: String = "0.0.0.0"
+    private var currentTransportProtocol: TransportProtocol = TransportProtocol.Both
 
     private val networkServer = NetworkServer(
         onAudioPacketReceived = { audioPacket ->
@@ -110,6 +109,13 @@ actual class AudioEngine actual constructor() {
     private val _webClientCount = MutableStateFlow(0)
     actual val webUrl: Flow<String> = _webUrl.asStateFlow()
     actual val webClientCount: Flow<Int> = _webClientCount.asStateFlow()
+
+    private data class RestartConfig(
+        val mode: ConnectionMode,
+        val port: Int,
+        val bindAddress: String,
+        val transportProtocol: TransportProtocol
+    )
 
     init {
         // Start mDNS advertisement immediately so Android clients can discover this server
@@ -180,55 +186,28 @@ actual class AudioEngine actual constructor() {
      * Handles local IP address changes while using automatic bind mode.
      */
     private fun handleIpAddressChanged(event: NetworkAddressChangeEvent) {
-        // Manual bind mode should keep using the selected address.
-        if (currentBindAddress != "0.0.0.0") {
-            Logger.d("AudioEngine", "Manual bind mode (currentBindAddress=$currentBindAddress), skipping auto IP change")
-            return
-        }
-
         val newPrimaryIp = event.newPrimaryIp ?: return
         Logger.i("AudioEngine", "Handling IP change: ${event.oldPrimaryIp} -> $newPrimaryIp")
 
-        // Re-advertise mDNS with new IP
         scope.launch(Dispatchers.IO) {
             try {
-                mdnsAdvertiser.reAdvertise(currentPort, "0.0.0.0")
-            } catch (e: Exception) {
-                Logger.w("AudioEngine", "Failed to re-advertise mDNS: ${e.message}")
-            }
-        }
-
-        // Restart active servers with new IP if they are running
-        val mode = currentMode ?: return
-        if (_state.value != StreamState.Streaming && _state.value != StreamState.Connecting) {
-            Logger.d("AudioEngine", "No active stream, skipping server restart")
-            return
-        }
-
-        scope.launch {
-            try {
-                startStopMutex.withLock {
-                    stopJob?.join()
-                    stopJob = null
-
-                    when (mode) {
-                        ConnectionMode.Wifi -> {
-                            Logger.i("AudioEngine", "Restarting NetworkServer with new IP: $newPrimaryIp")
-                            networkServer.stop()
-                            networkServer.start(currentPort, "0.0.0.0")
-                        }
-                        ConnectionMode.Web -> {
-                            Logger.i("AudioEngine", "Restarting WebServer with new IP: $newPrimaryIp")
-                            val webUrlStr = "https://$newPrimaryIp:$currentPort"
-                            _webUrl.value = webUrlStr
-                            webServer.stop()
-                            webServer.start(currentPort, "0.0.0.0")
-                        }
-                        else -> {
-                            // USB mode does not depend on IP
-                        }
+                val restartConfig = startStopMutex.withLock {
+                    if (currentBindAddress != "0.0.0.0") {
+                        Logger.d("AudioEngine", "Manual bind mode (currentBindAddress=$currentBindAddress), skipping auto IP change")
+                        return@withLock null
                     }
+
+                    val mode = currentMode ?: return@withLock null
+                    if (_state.value != StreamState.Streaming && _state.value != StreamState.Connecting) {
+                        Logger.d("AudioEngine", "No active stream, skipping server restart")
+                        return@withLock null
+                    }
+
+                    RestartConfig(mode, currentPort, currentBindAddress, currentTransportProtocol)
                 }
+
+                val config = restartConfig ?: return@launch
+                restartForIpChange(config, newPrimaryIp)
             } catch (e: Exception) {
                 Logger.e("AudioEngine", "Failed to restart server after IP change", e)
                 _lastError.value = String.format(getString(Res.string.errorIpChangeRestartFailed), e.message ?: "")
@@ -357,11 +336,26 @@ actual class AudioEngine actual constructor() {
         if (isClient) return
         Logger.i("AudioEngine", "启动 JVM AudioEngine: 模式=$mode, 协议=$transportProtocol, 端口=$port, 采样率=${sampleRate.value}, 声道=${channelCount.label}, 格式=${audioFormat.label}")
 
-        _lastError.value = null
+        startStopMutex.withLock {
+            startLocked(ip, port, mode, sampleRate, channelCount, audioFormat, transportProtocol)
+        }
+    }
 
-        // Save current mode and port for IP change handling
-        currentMode = mode
-        currentPort = port
+    private suspend fun startLocked(
+        ip: String,
+        port: Int,
+        mode: ConnectionMode,
+        sampleRate: SampleRate,
+        channelCount: ChannelCount,
+        audioFormat: AudioFormat,
+        transportProtocol: TransportProtocol
+    ) {
+        if (_state.value == StreamState.Streaming || _state.value == StreamState.Connecting) {
+            Logger.w("AudioEngine", "AudioEngine 已在运行，忽略启动请求")
+            return
+        }
+
+        _lastError.value = null
 
         if (mode == ConnectionMode.Usb) {
             Logger.i("AudioEngine", "正在为 USB 模式执行 ADB reverse，端口 $port")
@@ -376,51 +370,35 @@ actual class AudioEngine actual constructor() {
             }
         }
 
+        currentMode = mode
+        currentPort = if (mode == ConnectionMode.Web) port.takeIf { it in 1..65535 } ?: Constants.DEFAULT_WEB_PORT else port
+        currentTransportProtocol = transportProtocol
+
         if (mode == ConnectionMode.Web) {
-            val webPort = port.takeIf { it in 1..65535 } ?: Constants.DEFAULT_WEB_PORT
+            val webPort = currentPort
             Logger.i("AudioEngine", "启动 Web 模式，端口=$webPort")
 
             val bindAddress = ip.takeIf { it.isNotBlank() } ?: "0.0.0.0"
-            val displayIp = if (bindAddress == "0.0.0.0") getPlatform().ipAddress else bindAddress
+            val displayIp = if (bindAddress == "0.0.0.0") getPreferredLocalIpAddress() else bindAddress
             val webUrlStr = "https://$displayIp:$webPort"
             _webUrl.value = webUrlStr
             currentBindAddress = bindAddress
 
-            startStopMutex.withLock {
-                stopJob?.join()
-                stopJob = null
-
-                if (webServer.isRunning) {
-                    Logger.w("AudioEngine", "WebServer 已在运行，忽略启动请求")
-                } else {
-                    webServer.start(webPort, bindAddress)
-                    mdnsAdvertiser.reAdvertise(webPort, bindAddress)
-                    updateNetworkAddressMonitor(bindAddress)
-                    Logger.i("AudioEngine", "WebServer started at $webUrlStr")
-                }
-            }
+            webServer.start(webPort, bindAddress)
+            runCatching { mdnsAdvertiser.reAdvertise(webPort, bindAddress) }
+                .onFailure { Logger.w("AudioEngine", "mDNS advertise failed: ${it.message}") }
+            updateNetworkAddressMonitor(bindAddress)
+            Logger.i("AudioEngine", "WebServer started at $webUrlStr")
             return
         }
 
-        startStopMutex.withLock {
-            // 等待任何正在进行的停止操作完成，防止竞态条件
-            stopJob?.join()
-            stopJob = null
-
-            val currentJob = job
-            if (currentJob != null && !currentJob.isCompleted) {
-                Logger.w("AudioEngine", "AudioEngine 已在运行，忽略启动请求")
-            } else {
-                // 直接调用 networkServer.start()，不 launch 新协程
-                // NetworkServer 内部会管理自己的协程
-                val bindAddress = ip.takeIf { it.isNotBlank() } ?: getPlatform().ipAddress
-                currentBindAddress = bindAddress
-                networkServer.start(port, bindAddress, transportProtocol, mode)
-                mdnsAdvertiser.reAdvertise(port, bindAddress)
-                updateNetworkAddressMonitor(bindAddress)
-                Logger.i("AudioEngine", "NetworkServer started successfully on $bindAddress:$port")
-            }
-        }
+        val bindAddress = ip.takeIf { it.isNotBlank() } ?: getPreferredLocalIpAddress()
+        currentBindAddress = bindAddress
+        networkServer.start(port, bindAddress, transportProtocol, mode)
+        runCatching { mdnsAdvertiser.reAdvertise(port, bindAddress) }
+            .onFailure { Logger.w("AudioEngine", "mDNS advertise failed: ${it.message}") }
+        updateNetworkAddressMonitor(bindAddress)
+        Logger.i("AudioEngine", "NetworkServer started successfully on $bindAddress:$port")
     }
 
     private fun updateNetworkAddressMonitor(bindAddress: String) {
@@ -428,6 +406,36 @@ actual class AudioEngine actual constructor() {
             networkAddressMonitor.start()
         } else {
             networkAddressMonitor.stop()
+        }
+    }
+
+    private suspend fun restartForIpChange(config: RestartConfig, newPrimaryIp: String) {
+        startStopMutex.withLock {
+            if (currentMode != config.mode || currentPort != config.port || currentBindAddress != config.bindAddress) {
+                Logger.d("AudioEngine", "Stream config changed during IP restart, skipping stale restart")
+                return
+            }
+
+            when (config.mode) {
+                ConnectionMode.Wifi -> {
+                    Logger.i("AudioEngine", "Restarting NetworkServer with new IP: $newPrimaryIp")
+                    networkServer.stop()
+                    networkServer.start(config.port, config.bindAddress, config.transportProtocol, config.mode)
+                    runCatching { mdnsAdvertiser.reAdvertise(config.port, config.bindAddress) }
+                        .onFailure { Logger.w("AudioEngine", "mDNS re-advertise failed: ${it.message}") }
+                }
+                ConnectionMode.Web -> {
+                    Logger.i("AudioEngine", "Restarting WebServer with new IP: $newPrimaryIp")
+                    _webUrl.value = "https://$newPrimaryIp:${config.port}"
+                    webServer.stop()
+                    webServer.start(config.port, config.bindAddress)
+                    runCatching { mdnsAdvertiser.reAdvertise(config.port, config.bindAddress) }
+                        .onFailure { Logger.w("AudioEngine", "mDNS re-advertise failed: ${it.message}") }
+                }
+                else -> {
+                    Logger.d("AudioEngine", "IP restart skipped for mode ${config.mode}")
+                }
+            }
         }
     }
 
@@ -465,65 +473,10 @@ actual class AudioEngine actual constructor() {
     }
 
     actual fun stop() {
-         try {
-             job?.cancel()
-             job = null
-             _lastError.value = null
-             _state.value = StreamState.Idle
-
-             // Reset current mode tracking
-             currentMode = null
-             currentPort = -1
-             currentBindAddress = "0.0.0.0"
-
-             // 使用协程异步停止，避免阻塞调用线程
-             // 保存停止 Job 以便 start() 可以等待其完成，防止竞态条件
-             // 检查是否已有活跃的停止操作，避免协程泄漏
-             if (stopJob?.isActive != true) {
-                 stopJob = scope.launch {
-                     try {
-                         withTimeoutOrNull(Constants.SERVER_STOP_TIMEOUT_MS) {
-                             networkServer.stop()
-                         } ?: Logger.w("AudioEngine", "NetworkServer stop timeout after ${Constants.SERVER_STOP_TIMEOUT_MS}ms")
-                     } catch (e: Exception) {
-                         Logger.e("AudioEngine", "Error in async stop: ${e.message}", e)
-                     }
-                     // Stop web server as well
-                     try {
-                         webServer.stop()
-                         _webUrl.value = ""
-                         _webClientCount.value = 0
-                     } catch (e: Exception) {
-                         Logger.w("AudioEngine", "Error stopping WebServer: ${e.message}")
-                     }
-                     // Release resources asynchronously to avoid blocking UI
-                     try {
-                         audioOutputManager.release()
-                     } catch (e: Exception) {
-                         Logger.w("AudioEngine", "Error releasing AudioOutputManager: ${e.message}")
-                     }
-                     try {
-                         audioPipeline.release()
-                     } catch (e: Exception) {
-                         Logger.w("AudioEngine", "Error releasing AudioProcessorPipeline: ${e.message}")
-                     }
-                     try {
-                         mdnsAdvertiser.close()
-                     } catch (e: Exception) {
-                         Logger.w("AudioEngine", "Error closing MdnsAdvertiser: ${e.message}")
-                     }
-                     try {
-                         networkAddressMonitor.stop()
-                     } catch (e: Exception) {
-                         Logger.w("AudioEngine", "Error stopping NetworkAddressMonitor: ${e.message}")
-                     }
-                 }
-             } else {
-                 Logger.d("AudioEngine", "Stop operation already in progress, skipping duplicate stop request")
-             }
-         } catch (e: Exception) {
-             Logger.e("AudioEngine", "Error stopping audio engine: ${e.message}", e)
-         }
+        stopAudioProcessing()
+        scope.launch(Dispatchers.IO) {
+            stopAndWait()
+        }
     }
 
     /**
@@ -531,11 +484,55 @@ actual class AudioEngine actual constructor() {
      * 用于 IP 切换等需要严格顺序的场景。
      */
     actual suspend fun stopAndWait() {
-        stop()
         startStopMutex.withLock {
-            stopJob?.join()
-            stopJob = null
+            stopLocked()
         }
+    }
+
+    private suspend fun stopLocked() {
+        _lastError.value = null
+
+        currentMode = null
+        currentPort = -1
+        currentBindAddress = "0.0.0.0"
+        currentTransportProtocol = TransportProtocol.Both
+        stopAudioProcessing()
+
+        try {
+            withTimeoutOrNull(Constants.SERVER_STOP_TIMEOUT_MS) {
+                networkServer.stop()
+            } ?: Logger.w("AudioEngine", "NetworkServer stop timeout after ${Constants.SERVER_STOP_TIMEOUT_MS}ms")
+        } catch (e: Exception) {
+            Logger.e("AudioEngine", "Error stopping NetworkServer: ${e.message}", e)
+        }
+        try {
+            webServer.stop()
+            _webUrl.value = ""
+            _webClientCount.value = 0
+        } catch (e: Exception) {
+            Logger.w("AudioEngine", "Error stopping WebServer: ${e.message}")
+        }
+        try {
+            audioOutputManager.release()
+        } catch (e: Exception) {
+            Logger.w("AudioEngine", "Error releasing AudioOutputManager: ${e.message}")
+        }
+        try {
+            audioPipeline.release()
+        } catch (e: Exception) {
+            Logger.w("AudioEngine", "Error releasing AudioProcessorPipeline: ${e.message}")
+        }
+        try {
+            mdnsAdvertiser.close()
+        } catch (e: Exception) {
+            Logger.w("AudioEngine", "Error closing MdnsAdvertiser: ${e.message}")
+        }
+        try {
+            networkAddressMonitor.stop()
+        } catch (e: Exception) {
+            Logger.w("AudioEngine", "Error stopping NetworkAddressMonitor: ${e.message}")
+        }
+        _state.value = StreamState.Idle
     }
 
     /**

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
@@ -31,6 +31,9 @@ class JVMPlatform: Platform {
     override val ipAddresses: List<String>
         get() = getLocalIpAddresses()
 
+    override val ipAddressDetails: List<IpAddressInfo>
+        get() = getLocalIpAddressDetails()
+
     companion object {
         private val VIRTUAL_KEYWORDS = listOf(
             "vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker",
@@ -39,9 +42,13 @@ class JVMPlatform: Platform {
     }
 
     private fun getLocalIpAddresses(): List<String> {
+        return getLocalIpAddressDetails().map { it.ip }
+    }
+
+    private fun getLocalIpAddressDetails(): List<IpAddressInfo> {
         try {
             val interfaces = java.net.NetworkInterface.getNetworkInterfaces()
-            val candidates = mutableListOf<java.net.InetAddress>()
+            val candidates = mutableListOf<Pair<java.net.InetAddress, String>>()
 
             while (interfaces.hasMoreElements()) {
                 val iface = interfaces.nextElement()
@@ -54,11 +61,11 @@ class JVMPlatform: Platform {
                 while (addresses.hasMoreElements()) {
                     val addr = addresses.nextElement()
                     if (addr is java.net.Inet4Address && !addr.isLoopbackAddress) {
-                        candidates.add(addr)
+                        candidates.add(addr to (iface.displayName ?: iface.name))
                     }
                 }
             }
-    val sortedCandidates = candidates.sortedByDescending { addr ->
+            val sortedCandidates = candidates.sortedByDescending { (addr, _) ->
                 val ip = addr.hostAddress
                 when {
                     ip.startsWith("192.168.") -> 100
@@ -69,12 +76,14 @@ class JVMPlatform: Platform {
                     else -> 0
                 }
             }
-    val result = sortedCandidates.map { it.hostAddress }
+            val result = sortedCandidates.map { (addr, ifaceName) ->
+                IpAddressInfo(addr.hostAddress, ifaceName)
+            }
             if (result.isNotEmpty()) return result
-            
-            return listOf(java.net.InetAddress.getLocalHost().hostAddress)
+
+            return listOf(IpAddressInfo(java.net.InetAddress.getLocalHost().hostAddress, "Default"))
         } catch (e: Exception) {
-            return listOf("Unknown")
+            return listOf(IpAddressInfo("Unknown", "Unknown"))
         }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
@@ -37,10 +37,14 @@ class JVMPlatform: Platform {
 
 actual fun getPlatform(): Platform = JVMPlatform()
 actual suspend fun getPreferredLocalIpAddress(): String = withContext(Dispatchers.IO) {
-    LocalNetworkAddressProvider.refreshNow().firstOrNull()?.ip ?: "Unknown"
+    runCatching { LocalNetworkAddressProvider.refreshNow().firstOrNull()?.ip ?: "Unknown" }
+        .onFailure { Logger.w("Platform", "Failed to refresh preferred IP address: ${it.message}") }
+        .getOrDefault("Unknown")
 }
 actual suspend fun refreshLocalIpAddressDetails(): List<IpAddressInfo> = withContext(Dispatchers.IO) {
-    LocalNetworkAddressProvider.refreshNow()
+    runCatching { LocalNetworkAddressProvider.refreshNow() }
+        .onFailure { Logger.w("Platform", "Failed to refresh IP address details: ${it.message}") }
+        .getOrDefault(emptyList())
 }
 
 actual fun getAppVersion(): String {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
@@ -13,10 +13,10 @@ import com.lanrhyme.micyou.platform.PlatformInfo
 import com.lanrhyme.micyou.platform.WindowsAccentColorExtractor
 import com.lanrhyme.micyou.theme.PaletteStyle
 import com.lanrhyme.micyou.theme.dynamicColorScheme
+import com.lanrhyme.micyou.network.LocalNetworkAddressProvider
 import com.lanrhyme.micyou.util.QrCodeGenerator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.net.InetAddress
 import javax.sound.sampled.AudioSystem
 import javax.sound.sampled.SourceDataLine
 import micyou.composeapp.generated.resources.Res
@@ -26,69 +26,22 @@ class JVMPlatform: Platform {
     override val name: String = "Java ${System.getProperty("java.version")}"
     override val type: PlatformType = PlatformType.Desktop
     override val ipAddress: String
-        get() = ipAddresses.firstOrNull() ?: "Unknown"
+        get() = LocalNetworkAddressProvider.getPreferredIpAddress()
 
     override val ipAddresses: List<String>
-        get() = getLocalIpAddresses()
+        get() = LocalNetworkAddressProvider.getCachedIpAddressDetails().map { it.ip }
 
     override val ipAddressDetails: List<IpAddressInfo>
-        get() = getLocalIpAddressDetails()
-
-    companion object {
-        private val VIRTUAL_KEYWORDS = listOf(
-            "vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker",
-            "tunnel", "teredo", "isatap", "vpn"
-        )
-    }
-
-    private fun getLocalIpAddresses(): List<String> {
-        return getLocalIpAddressDetails().map { it.ip }
-    }
-
-    private fun getLocalIpAddressDetails(): List<IpAddressInfo> {
-        try {
-            val interfaces = java.net.NetworkInterface.getNetworkInterfaces()
-            val candidates = mutableListOf<Pair<java.net.InetAddress, String>>()
-
-            while (interfaces.hasMoreElements()) {
-                val iface = interfaces.nextElement()
-                if (iface.isLoopback || !iface.isUp || iface.isVirtual) continue
-                val name = iface.name.lowercase()
-                val displayName = iface.displayName?.lowercase() ?: ""
-                if (VIRTUAL_KEYWORDS.any { name.contains(it) || displayName.contains(it) }) continue
-
-                val addresses = iface.inetAddresses
-                while (addresses.hasMoreElements()) {
-                    val addr = addresses.nextElement()
-                    if (addr is java.net.Inet4Address && !addr.isLoopbackAddress) {
-                        candidates.add(addr to (iface.displayName ?: iface.name))
-                    }
-                }
-            }
-            val sortedCandidates = candidates.sortedByDescending { (addr, _) ->
-                val ip = addr.hostAddress
-                when {
-                    ip.startsWith("192.168.") -> 100
-                    ip.startsWith("172.") && (ip.split(".")[1].toIntOrNull() in 16..31) -> 80
-                    ip.startsWith("10.") -> 50
-                    ip.startsWith("198.18.") -> -10
-                    ip.startsWith("169.254.") -> -20
-                    else -> 0
-                }
-            }
-            val result = sortedCandidates.map { (addr, ifaceName) ->
-                IpAddressInfo(addr.hostAddress, ifaceName)
-            }
-            if (result.isNotEmpty()) return result
-
-            return listOf(IpAddressInfo(java.net.InetAddress.getLocalHost().hostAddress, "Default"))
-        } catch (e: Exception) {
-            return listOf(IpAddressInfo("Unknown", "Unknown"))
-        }
-    }
+        get() = LocalNetworkAddressProvider.getCachedIpAddressDetails()
 }
 
 actual fun getPlatform(): Platform = JVMPlatform()
+actual suspend fun getPreferredLocalIpAddress(): String = withContext(Dispatchers.IO) {
+    LocalNetworkAddressProvider.refreshNow().firstOrNull()?.ip ?: "Unknown"
+}
+actual suspend fun refreshLocalIpAddressDetails(): List<IpAddressInfo> = withContext(Dispatchers.IO) {
+    LocalNetworkAddressProvider.refreshNow()
+}
 
 actual fun getAppVersion(): String {
     val fromManifest = object {}.javaClass.`package`?.implementationVersion

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/LocalNetworkAddressProvider.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/LocalNetworkAddressProvider.kt
@@ -1,0 +1,106 @@
+package com.lanrhyme.micyou.network
+
+import com.lanrhyme.micyou.IpAddressInfo
+import com.lanrhyme.micyou.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.NetworkInterface
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal object LocalNetworkAddressProvider {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val refreshInProgress = AtomicBoolean(false)
+
+    @Volatile
+    private var cachedDetails: List<IpAddressInfo> = emptyList()
+
+    private val virtualKeywords = listOf(
+        "vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker",
+        "tunnel", "teredo", "isatap", "vpn"
+    )
+
+    init {
+        refreshAsync()
+    }
+
+    fun getCachedIpAddressDetails(): List<IpAddressInfo> {
+        return cachedDetails
+    }
+
+    fun getCachedOrRefreshNow(): List<IpAddressInfo> {
+        val cached = cachedDetails
+        if (cached.isNotEmpty()) {
+            refreshAsync()
+            return cached
+        }
+        return runCatching { refreshNow() }
+            .getOrElse { listOf(IpAddressInfo("Unknown", "Unknown")) }
+    }
+
+    fun refreshAsync() {
+        if (!refreshInProgress.compareAndSet(false, true)) return
+        scope.launch {
+            try {
+                cachedDetails = queryIpAddressDetails()
+            } catch (e: Exception) {
+                Logger.w("LocalNetworkAddressProvider", "Failed to refresh IP addresses: ${e.message}")
+            } finally {
+                refreshInProgress.set(false)
+            }
+        }
+    }
+
+    fun refreshNow(): List<IpAddressInfo> {
+        val details = queryIpAddressDetails()
+        cachedDetails = details
+        return details
+    }
+
+    fun getPreferredIpAddress(): String {
+        return cachedDetails.firstOrNull()?.ip ?: "Unknown"
+    }
+
+    private fun queryIpAddressDetails(): List<IpAddressInfo> {
+        val interfaces = NetworkInterface.getNetworkInterfaces()
+        val candidates = mutableListOf<Pair<InetAddress, String>>()
+
+        while (interfaces?.hasMoreElements() == true) {
+            val iface = interfaces.nextElement()
+            if (iface.isLoopback || !iface.isUp || iface.isVirtual) continue
+            val name = iface.name.lowercase()
+            val displayName = iface.displayName?.lowercase() ?: ""
+            if (virtualKeywords.any { name.contains(it) || displayName.contains(it) }) continue
+
+            val addresses = iface.inetAddresses
+            while (addresses.hasMoreElements()) {
+                val addr = addresses.nextElement()
+                if (addr is Inet4Address && !addr.isLoopbackAddress) {
+                    candidates.add(addr to (iface.displayName ?: iface.name))
+                }
+            }
+        }
+
+        val result = candidates
+            .sortedByDescending { (addr, _) -> scoreIpAddress(addr.hostAddress) }
+            .map { (addr, ifaceName) -> IpAddressInfo(addr.hostAddress, ifaceName) }
+
+        return result.ifEmpty {
+            listOf(IpAddressInfo(InetAddress.getLocalHost().hostAddress, "Default"))
+        }
+    }
+
+    private fun scoreIpAddress(ip: String): Int {
+        return when {
+            ip.startsWith("192.168.") -> 100
+            ip.startsWith("172.") && (ip.split(".")[1].toIntOrNull() in 16..31) -> 80
+            ip.startsWith("10.") -> 50
+            ip.startsWith("198.18.") -> -10
+            ip.startsWith("169.254.") -> -20
+            else -> 0
+        }
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/LocalNetworkAddressProvider.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/LocalNetworkAddressProvider.kt
@@ -85,7 +85,11 @@ internal object LocalNetworkAddressProvider {
         }
 
         val result = candidates
-            .sortedByDescending { (addr, _) -> scoreIpAddress(addr.hostAddress) }
+            .sortedWith(
+                compareByDescending<Pair<InetAddress, String>> { (addr, _) -> scoreIpAddress(addr.hostAddress) }
+                    .thenBy { (addr, _) -> addr.hostAddress }
+                    .thenBy { (_, ifaceName) -> ifaceName }
+            )
             .map { (addr, ifaceName) -> IpAddressInfo(addr.hostAddress, ifaceName) }
 
         return result.ifEmpty {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/MdnsAdvertiser.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/MdnsAdvertiser.kt
@@ -8,10 +8,23 @@ import java.net.InetAddress
 class MdnsAdvertiser {
     private var jmdns: JmDNS? = null
     private var serviceInfo: ServiceInfo? = null
+    private var currentPort: Int = -1
+    private var currentBindAddress: String = "0.0.0.0"
 
-    fun advertise(port: Int) {
+    fun advertise(port: Int, bindAddress: String = "0.0.0.0") {
+        advertiseInternal(port, bindAddress, force = false)
+    }
+
+    private fun advertiseInternal(port: Int, bindAddress: String, force: Boolean) {
+        if (!force && jmdns != null && currentPort == port && currentBindAddress == bindAddress) {
+            Logger.d("MdnsAdvertiser", "mDNS already advertising on $bindAddress:$port")
+            return
+        }
+
+        close(resetPort = false)
+
         try {
-            val localHost = findLanAddress()
+            val localHost = resolveAdvertiseAddress(bindAddress)
             val hostName = "MicYou (${InetAddress.getLocalHost().hostName})"
             jmdns = JmDNS.create(localHost, hostName)
 
@@ -22,12 +35,26 @@ class MdnsAdvertiser {
                 "MicYou audio streaming server"
             )
             jmdns?.registerService(serviceInfo)
+            currentPort = port
+            currentBindAddress = bindAddress
             Logger.i("MdnsAdvertiser", "mDNS service advertised: $hostName on ${localHost?.hostAddress} port $port")
         } catch (e: Exception) {
             Logger.w("MdnsAdvertiser", "Failed to advertise mDNS service: ${e.message}")
-            close()
+            close(resetPort = true)
             throw e
         }
+    }
+
+    /**
+     * 重新广播 mDNS 服务（IP 变化时调用）
+     */
+    fun reAdvertise(port: Int = currentPort, bindAddress: String = currentBindAddress) {
+        if (port <= 0) {
+            Logger.w("MdnsAdvertiser", "Cannot re-advertise: invalid port $port")
+            return
+        }
+        Logger.i("MdnsAdvertiser", "Re-advertising mDNS service due to IP change")
+        advertiseInternal(port, bindAddress, force = true)
     }
 
     companion object {
@@ -35,6 +62,14 @@ class MdnsAdvertiser {
             "vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker",
             "tunnel", "teredo", "isatap", "vpn"
         )
+    }
+
+    private fun resolveAdvertiseAddress(bindAddress: String): InetAddress? {
+        return if (bindAddress == "0.0.0.0") {
+            findLanAddress()
+        } else {
+            InetAddress.getByName(bindAddress)
+        }
     }
 
     private fun findLanAddress(): InetAddress? {
@@ -67,6 +102,10 @@ class MdnsAdvertiser {
     }
 
     fun close() {
+        close(resetPort = true)
+    }
+
+    private fun close(resetPort: Boolean) {
         try {
             val j = jmdns
             val si = serviceInfo
@@ -79,6 +118,10 @@ class MdnsAdvertiser {
         } finally {
             serviceInfo = null
             jmdns = null
+            if (resetPort) {
+                currentPort = -1
+                currentBindAddress = "0.0.0.0"
+            }
         }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/MdnsAdvertiser.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/MdnsAdvertiser.kt
@@ -57,13 +57,6 @@ class MdnsAdvertiser {
         advertiseInternal(port, bindAddress, force = true)
     }
 
-    companion object {
-        private val VIRTUAL_KEYWORDS = listOf(
-            "vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker",
-            "tunnel", "teredo", "isatap", "vpn"
-        )
-    }
-
     private fun resolveAdvertiseAddress(bindAddress: String): InetAddress? {
         return if (bindAddress == "0.0.0.0") {
             findLanAddress()
@@ -73,32 +66,13 @@ class MdnsAdvertiser {
     }
 
     private fun findLanAddress(): InetAddress? {
-        try {
-            val interfaces = java.net.NetworkInterface.getNetworkInterfaces()
-            val candidates = mutableListOf<Pair<java.net.NetworkInterface, java.net.Inet4Address>>()
-            while (interfaces.hasMoreElements()) {
-                val networkInterface = interfaces.nextElement()
-                if (networkInterface.isLoopback || !networkInterface.isUp || networkInterface.isVirtual) continue
-                val name = networkInterface.name.lowercase()
-                val displayName = networkInterface.displayName?.lowercase() ?: ""
-                if (VIRTUAL_KEYWORDS.any { name.contains(it) || displayName.contains(it) }) continue
-                val addresses = networkInterface.inetAddresses
-                while (addresses.hasMoreElements()) {
-                    val address = addresses.nextElement()
-                    if (address is java.net.Inet4Address && !address.isLoopbackAddress) {
-                        candidates.add(networkInterface to address)
-                    }
-                }
-            }
-            // Prefer interfaces with common LAN prefixes (192.168.x.x, 10.x.x.x)
-            val lanPreferred = candidates.firstOrNull { it.second.hostAddress?.startsWith("192.168.") == true }
-                ?: candidates.firstOrNull { it.second.hostAddress?.startsWith("10.") == true }
-                ?: candidates.firstOrNull()
-            return lanPreferred?.second
+        return try {
+            val preferredIp = LocalNetworkAddressProvider.getPreferredIpAddress()
+            if (preferredIp != "Unknown") InetAddress.getByName(preferredIp) else null
         } catch (e: Exception) {
             Logger.w("MdnsAdvertiser", "Failed to find LAN address: ${e.message}")
+            null
         }
-        return null
     }
 
     fun close() {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkAddressMonitor.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkAddressMonitor.kt
@@ -12,9 +12,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import java.net.Inet4Address
-import java.net.InetAddress
-import java.net.NetworkInterface
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -37,10 +34,6 @@ class NetworkAddressMonitor {
     private var isRunning = false
 
     companion object {
-        private val VIRTUAL_KEYWORDS = listOf(
-            "vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker",
-            "tunnel", "teredo", "isatap", "vpn"
-        )
         private const val MONITOR_INTERVAL_MS = 10_000L
     }
 
@@ -48,13 +41,16 @@ class NetworkAddressMonitor {
         if (isRunning) return
         isRunning = true
 
-        val initialAddresses = getCurrentIpAddresses()
-        _currentIpAddresses.value = initialAddresses
-        _primaryIp.value = initialAddresses.firstOrNull()?.ip
+        val initialAddresses = LocalNetworkAddressProvider.getCachedOrRefreshNow()
+        if (initialAddresses.any { it.ip != "Unknown" }) {
+            _currentIpAddresses.value = initialAddresses
+            _primaryIp.value = initialAddresses.firstOrNull()?.ip
+        }
 
         Logger.i("NetworkAddressMonitor", "Started monitoring. Primary IP: ${_primaryIp.value}")
 
         monitorJob = scope.launch {
+            checkForChanges()
             while (isActive) {
                 delay(MONITOR_INTERVAL_MS)
                 checkForChanges()
@@ -110,44 +106,7 @@ class NetworkAddressMonitor {
 
     private fun getCurrentIpAddresses(): List<IpAddressInfo> {
         return try {
-            val interfaces = NetworkInterface.getNetworkInterfaces()
-            val candidates = mutableListOf<Pair<InetAddress, String>>()
-
-            while (interfaces.hasMoreElements()) {
-                val iface = interfaces.nextElement()
-                if (iface.isLoopback || !iface.isUp || iface.isVirtual) continue
-                val name = iface.name.lowercase()
-                val displayName = iface.displayName?.lowercase() ?: ""
-                if (VIRTUAL_KEYWORDS.any { name.contains(it) || displayName.contains(it) }) continue
-
-                val addresses = iface.inetAddresses
-                while (addresses.hasMoreElements()) {
-                    val addr = addresses.nextElement()
-                    if (addr is Inet4Address && !addr.isLoopbackAddress) {
-                        candidates.add(addr to (iface.displayName ?: iface.name))
-                    }
-                }
-            }
-
-            val sortedCandidates = candidates.sortedByDescending { (addr, _) ->
-                val ip = addr.hostAddress
-                when {
-                    ip.startsWith("192.168.") -> 100
-                    ip.startsWith("172.") && (ip.split(".")[1].toIntOrNull() in 16..31) -> 80
-                    ip.startsWith("10.") -> 50
-                    ip.startsWith("198.18.") -> -10
-                    ip.startsWith("169.254.") -> -20
-                    else -> 0
-                }
-            }
-
-            val result = sortedCandidates.map { (addr, ifaceName) ->
-                IpAddressInfo(addr.hostAddress, ifaceName)
-            }
-
-            if (result.isNotEmpty()) return result
-
-            listOf(IpAddressInfo(InetAddress.getLocalHost().hostAddress, "Default"))
+            LocalNetworkAddressProvider.refreshNow()
         } catch (e: Exception) {
             Logger.w("NetworkAddressMonitor", "Failed to get IP addresses: ${e.message}")
             emptyList()

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkAddressMonitor.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkAddressMonitor.kt
@@ -114,7 +114,13 @@ class NetworkAddressMonitor {
     }
 
     private fun areAddressesEqual(old: List<IpAddressInfo>, new: List<IpAddressInfo>): Boolean {
-        return old.map { it.ip to it.interfaceName } == new.map { it.ip to it.interfaceName }
+        return normalizeAddresses(old) == normalizeAddresses(new)
+    }
+
+    private fun normalizeAddresses(addresses: List<IpAddressInfo>): List<Pair<String, String>> {
+        return addresses
+            .map { it.ip to it.interfaceName }
+            .sortedWith(compareBy<Pair<String, String>> { it.first }.thenBy { it.second })
     }
 }
 

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkAddressMonitor.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkAddressMonitor.kt
@@ -1,0 +1,177 @@
+package com.lanrhyme.micyou.network
+
+import com.lanrhyme.micyou.IpAddressInfo
+import com.lanrhyme.micyou.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.NetworkInterface
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Monitors local network address changes and notifies registered listeners.
+ */
+class NetworkAddressMonitor {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var monitorJob: Job? = null
+
+    private val _currentIpAddresses = MutableStateFlow<List<IpAddressInfo>>(emptyList())
+    val currentIpAddresses: StateFlow<List<IpAddressInfo>> = _currentIpAddresses.asStateFlow()
+
+    private val _primaryIp = MutableStateFlow<String?>(null)
+    val primaryIp: StateFlow<String?> = _primaryIp.asStateFlow()
+
+    private val listeners = CopyOnWriteArrayList<NetworkAddressChangeListener>()
+
+    @Volatile
+    private var isRunning = false
+
+    companion object {
+        private val VIRTUAL_KEYWORDS = listOf(
+            "vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker",
+            "tunnel", "teredo", "isatap", "vpn"
+        )
+        private const val MONITOR_INTERVAL_MS = 10_000L
+    }
+
+    fun start() {
+        if (isRunning) return
+        isRunning = true
+
+        val initialAddresses = getCurrentIpAddresses()
+        _currentIpAddresses.value = initialAddresses
+        _primaryIp.value = initialAddresses.firstOrNull()?.ip
+
+        Logger.i("NetworkAddressMonitor", "Started monitoring. Primary IP: ${_primaryIp.value}")
+
+        monitorJob = scope.launch {
+            while (isActive) {
+                delay(MONITOR_INTERVAL_MS)
+                checkForChanges()
+            }
+        }
+    }
+
+    fun stop() {
+        isRunning = false
+        monitorJob?.cancel()
+        monitorJob = null
+        Logger.i("NetworkAddressMonitor", "Stopped monitoring")
+    }
+
+    fun addListener(listener: NetworkAddressChangeListener) {
+        listeners.add(listener)
+    }
+
+    fun removeListener(listener: NetworkAddressChangeListener) {
+        listeners.remove(listener)
+    }
+
+    private fun checkForChanges() {
+        val newAddresses = getCurrentIpAddresses()
+        val currentAddresses = _currentIpAddresses.value
+
+        if (!areAddressesEqual(currentAddresses, newAddresses)) {
+            val oldPrimary = _primaryIp.value
+            val newPrimary = newAddresses.firstOrNull()?.ip
+
+            _currentIpAddresses.value = newAddresses
+            _primaryIp.value = newPrimary
+
+            Logger.i("NetworkAddressMonitor", "IP addresses changed. Old primary: $oldPrimary, New primary: $newPrimary")
+            Logger.d("NetworkAddressMonitor", "New addresses: ${newAddresses.map { "${it.ip}(${it.interfaceName})" }}")
+
+            val changeEvent = NetworkAddressChangeEvent(
+                oldAddresses = currentAddresses,
+                newAddresses = newAddresses,
+                oldPrimaryIp = oldPrimary,
+                newPrimaryIp = newPrimary
+            )
+
+            listeners.forEach { listener ->
+                try {
+                    listener.onAddressChanged(changeEvent)
+                } catch (e: Exception) {
+                    Logger.e("NetworkAddressMonitor", "Listener notification failed", e)
+                }
+            }
+        }
+    }
+
+    private fun getCurrentIpAddresses(): List<IpAddressInfo> {
+        return try {
+            val interfaces = NetworkInterface.getNetworkInterfaces()
+            val candidates = mutableListOf<Pair<InetAddress, String>>()
+
+            while (interfaces.hasMoreElements()) {
+                val iface = interfaces.nextElement()
+                if (iface.isLoopback || !iface.isUp || iface.isVirtual) continue
+                val name = iface.name.lowercase()
+                val displayName = iface.displayName?.lowercase() ?: ""
+                if (VIRTUAL_KEYWORDS.any { name.contains(it) || displayName.contains(it) }) continue
+
+                val addresses = iface.inetAddresses
+                while (addresses.hasMoreElements()) {
+                    val addr = addresses.nextElement()
+                    if (addr is Inet4Address && !addr.isLoopbackAddress) {
+                        candidates.add(addr to (iface.displayName ?: iface.name))
+                    }
+                }
+            }
+
+            val sortedCandidates = candidates.sortedByDescending { (addr, _) ->
+                val ip = addr.hostAddress
+                when {
+                    ip.startsWith("192.168.") -> 100
+                    ip.startsWith("172.") && (ip.split(".")[1].toIntOrNull() in 16..31) -> 80
+                    ip.startsWith("10.") -> 50
+                    ip.startsWith("198.18.") -> -10
+                    ip.startsWith("169.254.") -> -20
+                    else -> 0
+                }
+            }
+
+            val result = sortedCandidates.map { (addr, ifaceName) ->
+                IpAddressInfo(addr.hostAddress, ifaceName)
+            }
+
+            if (result.isNotEmpty()) return result
+
+            listOf(IpAddressInfo(InetAddress.getLocalHost().hostAddress, "Default"))
+        } catch (e: Exception) {
+            Logger.w("NetworkAddressMonitor", "Failed to get IP addresses: ${e.message}")
+            emptyList()
+        }
+    }
+
+    private fun areAddressesEqual(old: List<IpAddressInfo>, new: List<IpAddressInfo>): Boolean {
+        return old.map { it.ip to it.interfaceName } == new.map { it.ip to it.interfaceName }
+    }
+}
+
+/**
+ * Network address change event.
+ */
+data class NetworkAddressChangeEvent(
+    val oldAddresses: List<IpAddressInfo>,
+    val newAddresses: List<IpAddressInfo>,
+    val oldPrimaryIp: String?,
+    val newPrimaryIp: String?
+)
+
+/**
+ * Listener for network address changes.
+ */
+interface NetworkAddressChangeListener {
+    fun onAddressChanged(event: NetworkAddressChangeEvent)
+}

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
@@ -10,7 +10,6 @@ import org.jetbrains.compose.resources.getString
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.utils.io.*
-import io.ktor.utils.io.jvm.javaio.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -41,7 +40,7 @@ class NetworkServer(
     private val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var serverJob: Job? = null
     private var selectorManager: SelectorManager? = null
-    
+
     // TCP 资源
     private var serverSocket: ServerSocket? = null
     private var activeSocket: Socket? = null
@@ -52,20 +51,27 @@ class NetworkServer(
 
     // 当前活动的连接处理器
     private var activeHandler: ConnectionHandler? = null
+    private var currentBindAddress: String = "0.0.0.0"
 
     // 当前连接模式，用于决定是否启动 UDP 监控
     private var currentMode: ConnectionMode = ConnectionMode.Wifi
 
     suspend fun start(
         port: Int,
+        bindAddress: String = "0.0.0.0",
         protocol: TransportProtocol = TransportProtocol.Both,
         mode: ConnectionMode = ConnectionMode.Wifi
     ) {
         serverJob?.takeIf { it.isActive }?.let {
-            Logger.w("NetworkServer", "服务器已在运行")
-            return
+            if (currentBindAddress == bindAddress) {
+                Logger.w("NetworkServer", "Server is already running on $bindAddress")
+                return
+            }
+            Logger.i("NetworkServer", "Bind address changed ($currentBindAddress -> $bindAddress), restarting server")
+            stop()
         }
 
+        currentBindAddress = bindAddress
         _state.value = StreamState.Connecting
         _lastError.value = null
         currentMode = mode
@@ -79,11 +85,11 @@ class NetworkServer(
                 when (protocol) {
                     TransportProtocol.Tcp -> {
                         // 纯 TCP 模式：同时传输音频和控制消息
-                        runTcpOnlyServer(port, startupComplete)
+                        runTcpOnlyServer(port, bindAddress, startupComplete)
                     }
                     TransportProtocol.Both -> {
                         // TCP+UDP 模式：TCP 控制通道 + UDP 音频通道
-                        runDualProtocolServer(port, startupComplete)
+                        runDualProtocolServer(port, bindAddress, startupComplete)
                     }
                 }
             } catch (e: kotlinx.coroutines.CancellationException) {
@@ -100,7 +106,7 @@ class NetworkServer(
                 }
             }
         }
-        
+
         // 等待启动完成，失败时抛出异常
         try {
             startupComplete.await()
@@ -130,7 +136,7 @@ class NetworkServer(
     }
 
     fun getUdpStats(): UdpConnectionHandler.UdpStats? = udpHandler?.getStats()
-    
+
     fun getRtt(): Long = activeHandler?.getRtt() ?: 0L
 
     /**
@@ -138,7 +144,11 @@ class NetworkServer(
      * TCP 负责：握手、控制消息（静音/插件同步）
      * UDP 负责：音频数据传输
      */
-    private suspend fun runDualProtocolServer(port: Int, startupComplete: CompletableDeferred<Unit>? = null) {
+    private suspend fun runDualProtocolServer(
+        port: Int,
+        bindAddress: String = "0.0.0.0",
+        startupComplete: CompletableDeferred<Unit>? = null
+    ) {
         val udpPort = calculateUdpPort(port)
         Logger.i("NetworkServer", "启动双协议服务器: TCP 端口 $port, UDP 端口 $udpPort")
 
@@ -158,44 +168,53 @@ class NetworkServer(
             },
             onAudioPacketOrderedReceived = { packet ->
                 jitterBuffer?.insert(packet)
-            }
+            },
+            bindAddress = bindAddress
         )
         udpHandler?.start()
 
         // 然后启动 TCP 控制通道
-        runTcpServer(port, startupComplete)
+        runTcpServer(port, bindAddress, startupComplete)
     }
 
     /**
      * 运行仅 TCP 服务器：音频和控制消息都通过 TCP 传输
      * 适用于需要简化网络配置的场景
      */
-    private suspend fun runTcpOnlyServer(port: Int, startupComplete: CompletableDeferred<Unit>? = null) {
+    private suspend fun runTcpOnlyServer(
+        port: Int,
+        bindAddress: String = "0.0.0.0",
+        startupComplete: CompletableDeferred<Unit>? = null
+    ) {
         Logger.i("NetworkServer", "启动仅 TCP 服务器: 端口 $port")
         // 仅启动 TCP 服务器，音频和控制消息都通过 TCP 传输
-        runTcpServer(port, startupComplete)
+        runTcpServer(port, bindAddress, startupComplete)
     }
 
-    private suspend fun runTcpServer(port: Int, startupComplete: CompletableDeferred<Unit>? = null) {
+    private suspend fun runTcpServer(
+        port: Int,
+        bindAddress: String = "0.0.0.0",
+        startupComplete: CompletableDeferred<Unit>? = null
+    ) {
         try {
             val manager = SelectorManager(Dispatchers.IO)
             selectorManager = manager
-            serverSocket = aSocket(manager).tcp().bind("0.0.0.0", port = port)
+            serverSocket = aSocket(manager).tcp().bind(bindAddress, port = port)
             Logger.i("NetworkServer", "正在监听 TCP 端口 $port")
-            
+
             // 通知启动成功
             startupComplete?.complete(Unit)
-            
+
             while (currentCoroutineContext().isActive) {
                 val socket = serverSocket?.accept() ?: break
                 activeSocket = socket
                 Logger.i("NetworkServer", "接受来自 ${socket.remoteAddress} 的 TCP 连接")
-                
+
                 handleConnection(
                     input = socket.openReadChannel(),
                     output = socket.openWriteChannel(autoFlush = true),
-                    closeAction = { 
-                        socket.close() 
+                    closeAction = {
+                        socket.close()
                         activeSocket = null
                     }
                 )
@@ -296,8 +315,6 @@ class NetworkServer(
         )
         activeHandler = handler
         
-        // 启动 UDP 连接监控（仅在双协议模式下，且非 USB 模式）
-        // USB 模式下 Android 客户端通过 TCP 发送音频，不会发送 UDP 包，无需监控
         val udpMonitorJob = if (udpHandler != null && currentMode != ConnectionMode.Usb) {
             serverScope.launch {
                 monitorUdpConnection()

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/SelfSignedCertificate.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/SelfSignedCertificate.kt
@@ -12,10 +12,13 @@ object SelfSignedCertificate {
     private const val IPS_FILENAME = "micyou_web.jks.ips"
 
     private var cachedKeyStore: KeyStore? = null
+    private var cachedLanIps: Set<String>? = null
 
     internal fun getLanIpAddresses(): List<String> {
         return try {
-            LocalNetworkAddressProvider.getCachedIpAddressDetails().map { it.ip }
+            val details = LocalNetworkAddressProvider.getCachedIpAddressDetails()
+                .ifEmpty { LocalNetworkAddressProvider.getCachedOrRefreshNow() }
+            details.map { it.ip }.filter { it.isNotBlank() && it != "Unknown" }
         } catch (e: Exception) {
             Logger.w("SelfSignedCertificate", "Failed to get LAN IP addresses: ${e.message}")
             emptyList()
@@ -23,13 +26,16 @@ object SelfSignedCertificate {
     }
 
     fun generate(): KeyStore {
-        cachedKeyStore?.let { return it }
-
         val tmpDir = System.getProperty("java.io.tmpdir")
         val certFile = File(tmpDir, CERT_FILENAME)
         val ipsFile = File(tmpDir, IPS_FILENAME)
 
         val currentLanIps = getLanIpAddresses()
+        val currentIpSet = currentLanIps.toSet()
+        if (cachedLanIps == currentIpSet) {
+            cachedKeyStore?.let { return it }
+        }
+
         val domainList = mutableListOf("localhost", "127.0.0.1")
         domainList.addAll(currentLanIps)
 
@@ -39,12 +45,12 @@ object SelfSignedCertificate {
             } else {
                 emptySet()
             }
-            val currentIpSet = currentLanIps.toSet()
             if (savedIps == currentIpSet) {
                 try {
                     val ks = KeyStore.getInstance("JKS")
                     ks.load(certFile.inputStream(), KEYSTORE_PASSWORD.toCharArray())
                     cachedKeyStore = ks
+                    cachedLanIps = currentIpSet
                     Logger.i("SelfSignedCertificate", "Loaded cached SSL certificate from ${certFile.absolutePath}")
                     return ks
                 } catch (e: Exception) {
@@ -68,6 +74,7 @@ object SelfSignedCertificate {
             ipsFile.writeText(currentLanIps.joinToString("\n"))
 
             cachedKeyStore = keystore
+            cachedLanIps = currentIpSet
             Logger.i("SelfSignedCertificate", "Generated new SSL certificate with domains: $domainList saved to ${certFile.absolutePath}")
             return keystore
         } catch (e: Exception) {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/SelfSignedCertificate.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/SelfSignedCertificate.kt
@@ -3,8 +3,6 @@ package com.lanrhyme.micyou.network
 import com.lanrhyme.micyou.Logger
 import io.ktor.network.tls.certificates.buildKeyStore
 import java.io.File
-import java.net.Inet4Address
-import java.net.NetworkInterface
 import java.security.KeyStore
 
 object SelfSignedCertificate {
@@ -15,45 +13,13 @@ object SelfSignedCertificate {
 
     private var cachedKeyStore: KeyStore? = null
 
-    private val virtualKeywords = listOf(
-        "vmware", "virtualbox", "hyper-v", "vethernet", "wsl", "docker", "tunnel", "teredo", "isatap", "vpn"
-    )
-
     internal fun getLanIpAddresses(): List<String> {
-        try {
-            val interfaces = NetworkInterface.getNetworkInterfaces()
-            val candidates = mutableListOf<Pair<NetworkInterface, Inet4Address>>()
-            while (interfaces.hasMoreElements()) {
-                val iface = interfaces.nextElement()
-                if (iface.isLoopback || !iface.isUp || iface.isVirtual) continue
-                val name = iface.name.lowercase()
-                val displayName = iface.displayName?.lowercase() ?: ""
-                if (virtualKeywords.any { name.contains(it) || displayName.contains(it) }) continue
-                val addresses = iface.inetAddresses
-                while (addresses.hasMoreElements()) {
-                    val addr = addresses.nextElement()
-                    if (addr is Inet4Address && !addr.isLoopbackAddress) {
-                        candidates.add(iface to addr)
-                    }
-                }
-            }
-            return candidates
-                .sortedByDescending { (_, addr) ->
-                    val ip = addr.hostAddress
-                    when {
-                        ip.startsWith("192.168.") -> 100
-                        ip.startsWith("172.") && ip.split(".").getOrNull(1)?.toIntOrNull() in 16..31 -> 80
-                        ip.startsWith("10.") -> 50
-                        ip.startsWith("198.18.") -> -10
-                        ip.startsWith("169.254.") -> -20
-                        else -> 0
-                    }
-                }
-                .map { it.second.hostAddress }
+        return try {
+            LocalNetworkAddressProvider.getCachedIpAddressDetails().map { it.ip }
         } catch (e: Exception) {
             Logger.w("SelfSignedCertificate", "Failed to get LAN IP addresses: ${e.message}")
+            emptyList()
         }
-        return emptyList()
     }
 
     fun generate(): KeyStore {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/UdpConnectionHandler.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/UdpConnectionHandler.kt
@@ -26,7 +26,8 @@ class UdpConnectionHandler(
     private val port: Int,
     private val onAudioPacketReceived: suspend (AudioPacketMessage) -> Unit,
     private val onError: (String) -> Unit,
-    private val onAudioPacketOrderedReceived: ((AudioPacketMessageOrdered) -> Unit)? = null
+    private val onAudioPacketOrderedReceived: ((AudioPacketMessageOrdered) -> Unit)? = null,
+    private val bindAddress: String = "0.0.0.0"
 ) {
     @OptIn(ExperimentalSerializationApi::class)
     private val proto = ProtoBuf { }
@@ -105,9 +106,14 @@ class UdpConnectionHandler(
 
     private suspend fun runUdpReceiver() {
         try {
+            val bindInetAddress = if (bindAddress == "0.0.0.0") {
+                null
+            } else {
+                java.net.InetAddress.getByName(bindAddress)
+            }
             udpSocket = DatagramSocket(null).also { socket ->
                 socket.reuseAddress = true
-                socket.bind(java.net.InetSocketAddress(port))
+                socket.bind(java.net.InetSocketAddress(bindInetAddress, port))
                 // Set receive buffer size for audio stream
                 socket.receiveBufferSize = 2 * 1024 * 1024 // 2MB
                 val actualBufferSize = socket.receiveBufferSize

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/WebServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/WebServer.kt
@@ -37,6 +37,7 @@ class WebServer(
     private val port: Int,
     private val onAudioPacketReceived: (AudioPacketMessage) -> Unit
 ) {
+    private var currentBindAddress: String = "0.0.0.0"
     private var server: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>? = null
 
     private val _state = MutableStateFlow(StreamState.Idle)
@@ -55,18 +56,24 @@ class WebServer(
 
     private val htmlContent: String by lazy { WebHtmlPage.getHtml() }
 
-    fun start(port: Int = this.port) {
+    fun start(port: Int = this.port, bindAddress: String = "0.0.0.0") {
         if (isRunning) {
-            Logger.w("WebServer", "WebServer is already running")
-            return
+            if (currentBindAddress == bindAddress) {
+                Logger.w("WebServer", "WebServer is already running on $bindAddress")
+                return
+            }
+            Logger.i("WebServer", "Bind address changed ($currentBindAddress -> $bindAddress), restarting")
+            stop()
         }
 
+        currentBindAddress = bindAddress
         _state.value = StreamState.Connecting
 
         try {
             val keyStore = SelfSignedCertificate.generate()
             val password = SelfSignedCertificate.getKeyStorePassword()
-            server = embeddedServer(Netty,
+            server = embeddedServer(
+                Netty,
                 environment = applicationEnvironment {},
                 configure = {
                     sslConnector(
@@ -76,7 +83,7 @@ class WebServer(
                         privateKeyPassword = { password.toCharArray() }
                     ) {
                         this.port = port
-                        host = "0.0.0.0"
+                        host = bindAddress
                     }
                 }
             ) {
@@ -116,11 +123,16 @@ class WebServer(
 
             isRunning = true
             _state.value = StreamState.Connecting
-            Logger.i("WebServer", "HTTPS+WebSocket server started on port $port")
+            Logger.i("WebServer", "HTTPS+WebSocket server started on $bindAddress:$port")
         } catch (e: Exception) {
+            isRunning = false
+            server = null
+            clientCount.set(0)
+            _clientCountFlow.value = 0
             _state.value = StreamState.Error
-            _lastError.value = "Failed to start web server: ${e.message}"
+            _lastError.value = "Web server error: ${e.message}"
             Logger.e("WebServer", "Failed to start web server", e)
+            throw e
         }
     }
 
@@ -136,15 +148,9 @@ class WebServer(
             for (frame in incoming) {
                 if (!isActive) break
                 when (frame) {
-                    is Frame.Binary -> {
-                        processAudioData(frame.data)
-                    }
-                    is Frame.Ping -> {
-                        send(Frame.Pong(frame.data))
-                    }
-                    is Frame.Close -> {
-                        break
-                    }
+                    is Frame.Binary -> processAudioData(frame.data)
+                    is Frame.Ping -> send(Frame.Pong(frame.data))
+                    is Frame.Close -> break
                     else -> {}
                 }
             }
@@ -190,6 +196,7 @@ class WebServer(
                 Logger.w("WebServer", "Rejected oversized audio frame: ${float32Bytes.size} bytes (max ${Constants.MAX_PACKET_SIZE})")
                 return
             }
+
             val numFloats = float32Bytes.size / 4
             if (numFloats == 0) return
             val pcmBytes = ByteArray(numFloats * 2)


### PR DESCRIPTION
- 在桌面端 UI（常规与增强模式）中添加 IP 地址选择器
- 支持将服务器绑定到特定 IP 或所有网络接口 (0.0.0.0)
- 添加 NetworkAddressMonitor 以实现自动 IP 变更检测
- 当主 IP 变更时，自动重启服务器并重新发布 mDNS 广播
- 添加包含网卡名称详情的 IpAddressInfo 数据类
- 更新所有网络服务器（TCP/UDP/Web）以支持自定义绑定地址
- 添加串流过程中切换 IP 时的确认对话框
- 添加 IP 选择 UI 的本地化字符串（英文/简中/繁中/香港繁中）

<details><summary>Copilot's Summary</summary>
This pull request introduces support for selecting and switching the IP address (bind address) for the audio streaming service, with a focus on improving the desktop experience. It adds state and logic for managing manual and automatic IP selection, ensures correct persistence and restoration of these settings, and provides the ability to safely restart the audio stream when the IP changes. Additionally, it updates UI strings in multiple languages to support the new IP switching functionality and error handling.

**IP Address Selection and Switching Enhancements:**

* Added `bindAddress` and `isAutoBindAddress` to `AudioStreamUiState`, and logic to persist, restore, and update these settings for both manual and automatic IP selection, especially on desktop. (`AudioStreamViewModel.kt`, `AudioStreamUiState`) [[1]](diffhunk://#diff-c665d7114904cf7b94e63ffc46ec8851f1459d019155bec233e1bf7922e834a9R20-R21) [[2]](diffhunk://#diff-c665d7114904cf7b94e63ffc46ec8851f1459d019155bec233e1bf7922e834a9R143-R160) [[3]](diffhunk://#diff-c665d7114904cf7b94e63ffc46ec8851f1459d019155bec233e1bf7922e834a9L205-R229)
* Implemented `setIp` to handle both manual and auto IP selection, update settings, and optionally restart the audio stream when the IP changes. (`AudioStreamViewModel.kt`)
* Added `refreshDesktopIpState` to fetch and update the preferred desktop IP address, and integrated it into initialization and IP selection flows. (`AudioStreamViewModel.kt`) [[1]](diffhunk://#diff-c665d7114904cf7b94e63ffc46ec8851f1459d019155bec233e1bf7922e834a9R106-R110) [[2]](diffhunk://#diff-c665d7114904cf7b94e63ffc46ec8851f1459d019155bec233e1bf7922e834a9R265-R286)

**Audio Engine Improvements:**

* Introduced a new `stopAndWait` suspend function in `AudioEngine` to ensure the engine is fully stopped before restarting (used during IP changes). (`AudioEngine.kt`, `AudioEngine.android.kt`) [[1]](diffhunk://#diff-a363c0044bc1e54fac4f9d6528883a28961770acc91bcd3fe3e65ef0111446e1R60-R61) [[2]](diffhunk://#diff-8b6b216df743006c87646a9919a29ee9b02dccd6e3f8ae99ff27411494bc0686R673-R678)

**Streaming Logic and State Management:**

* Refactored `startStream` to prevent concurrent start requests and to use the new IP/bind address logic, ensuring correct behavior when switching IPs. (`AudioStreamViewModel.kt`) [[1]](diffhunk://#diff-c665d7114904cf7b94e63ffc46ec8851f1459d019155bec233e1bf7922e834a9R393-R415) [[2]](diffhunk://#diff-c665d7114904cf7b94e63ffc46ec8851f1459d019155bec233e1bf7922e834a9L696-R798)
* Integrated error handling for failed restarts after IP changes, with new error messages and UI string support. (`AudioStreamViewModel.kt`, `strings.xml`) [[1]](diffhunk://#diff-c665d7114904cf7b94e63ffc46ec8851f1459d019155bec233e1bf7922e834a9L505-R610) [[2]](diffhunk://#diff-089f0ef77f066210beeba29ed6b8e392395174bc971984fac0f18c96ec371653R164) [[3]](diffhunk://#diff-e1816e7df84c66ed4a946923833350602b16c98e95505794df07636ae38134c9R397) [[4]](diffhunk://#diff-a624edb4ebdc683ba8fc1a0fbddb7e61970817265df1bfd2e77cf4da6e9502a4R461-R467) [[5]](diffhunk://#diff-b8a1732031e5f8cb1d35e6b441ff0772c735c66ac651d12cb3d27b4dc67cac2dR461-R467) [[6]](diffhunk://#diff-ab72d4e9d49f82c4bb0a8e60fcac9dd04bb9cbe1a256ea09ff00442164da8fd1R461-R467)

**Localization and UI:**

* Added new strings for IP switching dialogs, actions, and error messages in English and multiple Chinese locales. (`strings.xml` in various locales) [[1]](diffhunk://#diff-089f0ef77f066210beeba29ed6b8e392395174bc971984fac0f18c96ec371653R221-R226) [[2]](diffhunk://#diff-e1816e7df84c66ed4a946923833350602b16c98e95505794df07636ae38134c9R183-R188) [[3]](diffhunk://#diff-a624edb4ebdc683ba8fc1a0fbddb7e61970817265df1bfd2e77cf4da6e9502a4R461-R467) [[4]](diffhunk://#diff-b8a1732031e5f8cb1d35e6b441ff0772c735c66ac651d12cb3d27b4dc67cac2dR461-R467) [[5]](diffhunk://#diff-ab72d4e9d49f82c4bb0a8e60fcac9dd04bb9cbe1a256ea09ff00442164da8fd1R461-R467)
* Minor Compose UI improvements for desktop (e.g., import of `background`, `hoverable`). (`DesktopHome.kt`)

**Platform/Android Stubs:**

* Added stubs for new platform functions and properties for IP address details on Android, maintaining cross-platform compatibility. (`Platform.android.kt`)

These changes collectively enable dynamic and user-friendly IP address selection for audio streaming, with robust state handling and localized user feedback.
</details>