### PR TITLE
feat: UDP连接检查

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ca/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ca/strings.xml
@@ -96,6 +96,8 @@
     <string name="errorDialogTitle">连接错误喵~ (ToT)</string>
     <string name="errorFirewallBlockedMessage">端口 %s 被防火墙阻止喵~请添加防火墙规则或以管理员身份运行应用喵~ (・_・;)</string>
     <string name="errorFirewallBlockedTitle">防火墙挡住了喵~</string>
+    <string name="errorUdpPortBlockedMessage">UDP 音频端口 %s 被防火墙阻止了喵~音频传输需要 TCP 和 UDP 端口都可以访问喵~请为 UDP 端口添加防火墙规则，或以管理员身份运行应用喵~ (´・ω・`)</string>
+    <string name="errorUdpPortBlockedTitle">UDP 端口被阻止了喵~</string>
     <string name="errorHandshakeFailedMessage">与目标设备握手失败喵~这可能表示版本不匹配或协议错误喵~</string>
     <string name="errorHandshakeFailedTitle">握手失败喵~</string>
     <string name="errorNetworkTimeoutMessage">连接超时喵~请检查网络连接和目标设备状态喵~ (・_・)</string>
@@ -148,6 +150,9 @@
     <string name="firewallDismiss">忽略喵~</string>
     <string name="firewallMessage">端口 %s 未被 Windows 防火墙允许喵~这可能会阻止安卓设备通过 Wi-Fi 连接喵~\n\n要尝试为此端口添加防火墙规则吗喵？(需要管理员权限) (・_・;)</string>
     <string name="firewallTitle">防火墙检查喵~ 🧱</string>
+    <string name="udpWarningTitle">UDP 音频警告喵~</string>
+    <string name="udpWarningMessage">TCP 连接已建立了喵~，但没有收到任何 UDP 音频包喵~。音频传输需要 TCP 和 UDP 端口都可以访问喵~\n\n请检查喵~：\n• 确保 UDP 端口 %1$d 已在防火墙中放行喵~（TCP 端口 %2$d + 1）\n• 两台设备应在同一网络中喵~\n• 尝试重新连接喵~ (´・ω・`)</string>
+    <string name="udpWarningConfirm">好的喵~</string>
     <string name="firstLaunchGotItButton">猫猫知道怎么使用喵~</string>
     <string name="firstLaunchGuideButton">看看使用指南喵~</string>
     <string name="firstLaunchMessage">猫猫似乎是第一次使用 MicYou 喵~本应用可以把你的安卓设备变成电脑的高质量麦克风喵</string>

--- a/composeApp/src/commonMain/composeResources/values-ca/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ca/strings.xml
@@ -96,7 +96,7 @@
     <string name="errorDialogTitle">连接错误喵~ (ToT)</string>
     <string name="errorFirewallBlockedMessage">端口 %s 被防火墙阻止喵~请添加防火墙规则或以管理员身份运行应用喵~ (・_・;)</string>
     <string name="errorFirewallBlockedTitle">防火墙挡住了喵~</string>
-    <string name="errorUdpPortBlockedMessage">UDP 音频端口 %s 被防火墙阻止了喵~音频传输需要 TCP 和 UDP 端口都可以访问喵~请为 UDP 端口添加防火墙规则，或以管理员身份运行应用喵~ (´・ω・`)</string>
+    <string name="errorUdpPortBlockedMessage">UDP 音频端口 %d 被防火墙阻止了喵~音频传输需要 TCP 和 UDP 端口都可以访问喵~请为 UDP 端口添加防火墙规则，或以管理员身份运行应用喵~ (´・ω・`)</string>
     <string name="errorUdpPortBlockedTitle">UDP 端口被阻止了喵~</string>
     <string name="errorHandshakeFailedMessage">与目标设备握手失败喵~这可能表示版本不匹配或协议错误喵~</string>
     <string name="errorHandshakeFailedTitle">握手失败喵~</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rHK/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rHK/strings.xml
@@ -96,6 +96,8 @@
     <string name="errorDialogTitle">連線錯誤</string>
     <string name="errorFirewallBlockedMessage">埠口 %s 俾 Windows 防火牆擋住。請加防火牆規則或者以管理員身份行應用程式。</string>
     <string name="errorFirewallBlockedTitle">防火牆擋住咗</string>
+    <string name="errorUdpPortBlockedMessage">UDP 音訊埠口 %s 俾防火牆擋住。音訊傳輸需要 TCP 同 UDP 埠口都可以用。請為 UDP 埠口加防火牆規則，或者以管理員身份行應用程式。</string>
+    <string name="errorUdpPortBlockedTitle">UDP 埠口俾擋住咗</string>
     <string name="errorHandshakeFailedMessage">同目標裝置握手失敗。咁可能係版本唔夾或者協定錯誤。</string>
     <string name="errorHandshakeFailedTitle">握手失敗</string>
     <string name="errorNetworkTimeoutMessage">連線超時。請檢查網路連線同目標裝置狀態。</string>
@@ -148,6 +150,9 @@
     <string name="firewallDismiss">是但啦</string>
     <string name="firewallMessage">埠口 %s 似乎未畀 Windows 防火牆放行。咁樣可能搞到 Android 裝置冇辦法經 Wi-Fi 連線。\n\n試唔試吓自動加返條防火牆規則？（要管理員權限）</string>
     <string name="firewallTitle">防火牆檢查</string>
+    <string name="udpWarningTitle">UDP 音訊警告</string>
+    <string name="udpWarningMessage">TCP 連線已建立，但未收到任何 UDP 音訊封包。音訊傳輸需要 TCP 同 UDP 埠口都可以用。\n\n請檢查：\n• 確保 UDP 埠口 %1$d 已在防火牆中放行（TCP 埠口 %2$d + 1）\n• 兩部裝置應在同一網絡中\n• 試吓重新連線</string>
+    <string name="udpWarningConfirm">確定</string>
     <string name="firstLaunchGotItButton">我很清楚點樣使用</string>
     <string name="firstLaunchGuideButton">等我睇下使用指南</string>
     <string name="firstLaunchMessage">您好似係第一次使用 MicYou，呢個 App 可以將你嘅 Android 裝置透過 Wi-Fi 或者 USB 變做電腦嘅高質量咪高峰</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rHK/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rHK/strings.xml
@@ -96,7 +96,7 @@
     <string name="errorDialogTitle">連線錯誤</string>
     <string name="errorFirewallBlockedMessage">埠口 %s 俾 Windows 防火牆擋住。請加防火牆規則或者以管理員身份行應用程式。</string>
     <string name="errorFirewallBlockedTitle">防火牆擋住咗</string>
-    <string name="errorUdpPortBlockedMessage">UDP 音訊埠口 %s 俾防火牆擋住。音訊傳輸需要 TCP 同 UDP 埠口都可以用。請為 UDP 埠口加防火牆規則，或者以管理員身份行應用程式。</string>
+    <string name="errorUdpPortBlockedMessage">UDP 音訊埠口 %d 俾防火牆擋住。音訊傳輸需要 TCP 同 UDP 埠口都可以用。請為 UDP 埠口加防火牆規則，或者以管理員身份行應用程式。</string>
     <string name="errorUdpPortBlockedTitle">UDP 埠口俾擋住咗</string>
     <string name="errorHandshakeFailedMessage">同目標裝置握手失敗。咁可能係版本唔夾或者協定錯誤。</string>
     <string name="errorHandshakeFailedTitle">握手失敗</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rSS/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rSS/strings.xml
@@ -96,7 +96,7 @@
     <string name="errorDialogTitle">连接错误项目标题项</string>
     <string name="errorFirewallBlockedMessage">港口 %s 被窗户防火墙阻挡。请新增防火墙规则或以管理者身份执行应用程式。</string>
     <string name="errorFirewallBlockedTitle">防火墙阻挡项目</string>
-    <string name="errorUdpPortBlockedMessage">UDP 音讯港口 %s 被防火墙阻挡。音讯传输需要 TCP 和 UDP 港口均可存取。请为 UDP 港口新增防火墙规则，或以管理者身份执行应用程式。</string>
+    <string name="errorUdpPortBlockedMessage">UDP 音讯港口 %d 被防火墙阻挡。音讯传输需要 TCP 和 UDP 港口均可存取。请为 UDP 港口新增防火墙规则，或以管理者身份执行应用程式。</string>
     <string name="errorUdpPortBlockedTitle">UDP 港口被阻挡</string>
     <string name="errorHandshakeFailedMessage">与目标装置握手失败。这可能表示版本不匹配或通讯协定错误。</string>
     <string name="errorHandshakeFailedTitle">握手失败项目</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rSS/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rSS/strings.xml
@@ -96,6 +96,8 @@
     <string name="errorDialogTitle">连接错误项目标题项</string>
     <string name="errorFirewallBlockedMessage">港口 %s 被窗户防火墙阻挡。请新增防火墙规则或以管理者身份执行应用程式。</string>
     <string name="errorFirewallBlockedTitle">防火墙阻挡项目</string>
+    <string name="errorUdpPortBlockedMessage">UDP 音讯港口 %s 被防火墙阻挡。音讯传输需要 TCP 和 UDP 港口均可存取。请为 UDP 港口新增防火墙规则，或以管理者身份执行应用程式。</string>
+    <string name="errorUdpPortBlockedTitle">UDP 港口被阻挡</string>
     <string name="errorHandshakeFailedMessage">与目标装置握手失败。这可能表示版本不匹配或通讯协定错误。</string>
     <string name="errorHandshakeFailedTitle">握手失败项目</string>
     <string name="errorNetworkTimeoutMessage">连线超时了啊。请检查网络连线和目标装置状态。</string>
@@ -148,6 +150,9 @@
     <string name="firewallDismiss">忽略掉吧</string>
     <string name="firewallMessage">端口 %s 不被 窗户 防火墙允许。 这可能阻止安卓设备通过 无线保真度 连接。\n\n你想尝试为这个端口添加防火墙规则吗？(需要管理者权限)</string>
     <string name="firewallTitle">防火墙检查标题项</string>
+    <string name="udpWarningTitle">UDP 音讯警告</string>
+    <string name="udpWarningMessage">TCP 连线已建立，但未收到任何 UDP 音讯封包。音讯传输需要 TCP 和 UDP 港口均可存取。\n\n请检查：\n• 确保 UDP 港口 %1$d 已在防火墙中放行（TCP 港口 %2$d + 1）\n• 两台装置应在同一网路中\n• 尝试重新连线</string>
+    <string name="udpWarningConfirm">确定</string>
     <string name="firstLaunchGotItButton">我知道怎么用项</string>
     <string name="firstLaunchGuideButton">让我看看使用指南</string>
     <string name="firstLaunchMessage">您似乎是第一次使用麦克风你。本应用可以将您的安卓设备通过无线保真度、蓝色牙齿或者通用串行总线式变成电脑的高质量微型电话。</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -96,7 +96,7 @@
     <string name="errorDialogTitle">連線錯誤</string>
     <string name="errorFirewallBlockedMessage">連接埠 %s 被 Windows 防火牆封鎖。請新增防火牆規則或以管理員身分執行應用程式。</string>
     <string name="errorFirewallBlockedTitle">防火牆封鎖</string>
-    <string name="errorUdpPortBlockedMessage">UDP 音訊連接埠 %s 被防火牆封鎖。音訊傳輸需要 TCP 和 UDP 連接埠均可存取。請為 UDP 連接埠新增防火牆規則，或以管理員身分執行應用程式。</string>
+    <string name="errorUdpPortBlockedMessage">UDP 音訊連接埠 %d 被防火牆封鎖。音訊傳輸需要 TCP 和 UDP 連接埠均可存取。請為 UDP 連接埠新增防火牆規則，或以管理員身分執行應用程式。</string>
     <string name="errorUdpPortBlockedTitle">UDP 連接埠被封鎖</string>
     <string name="errorHandshakeFailedMessage">與目標裝置握手失敗。這可能表示版本不相符或通訊協定錯誤。</string>
     <string name="errorHandshakeFailedTitle">握手失敗</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -96,6 +96,8 @@
     <string name="errorDialogTitle">連線錯誤</string>
     <string name="errorFirewallBlockedMessage">連接埠 %s 被 Windows 防火牆封鎖。請新增防火牆規則或以管理員身分執行應用程式。</string>
     <string name="errorFirewallBlockedTitle">防火牆封鎖</string>
+    <string name="errorUdpPortBlockedMessage">UDP 音訊連接埠 %s 被防火牆封鎖。音訊傳輸需要 TCP 和 UDP 連接埠均可存取。請為 UDP 連接埠新增防火牆規則，或以管理員身分執行應用程式。</string>
+    <string name="errorUdpPortBlockedTitle">UDP 連接埠被封鎖</string>
     <string name="errorHandshakeFailedMessage">與目標裝置握手失敗。這可能表示版本不相符或通訊協定錯誤。</string>
     <string name="errorHandshakeFailedTitle">握手失敗</string>
     <string name="errorNetworkTimeoutMessage">連線逾時。請檢查網路連線和目標裝置狀態。</string>
@@ -148,6 +150,9 @@
     <string name="firewallDismiss">忽略</string>
     <string name="firewallMessage">連接埠 %s 似乎未被 Windows 防火牆放行。這可能會導致 Android 裝置無法透過 Wi-Fi 連線。\n\n是否嘗試自動新增防火牆規則？（需要管理員權限）</string>
     <string name="firewallTitle">防火牆檢查</string>
+    <string name="udpWarningTitle">UDP 音訊警告</string>
+    <string name="udpWarningMessage">TCP 連線已建立，但未收到任何 UDP 音訊封包。音訊傳輸需要 TCP 和 UDP 連接埠均可存取。\n\n請檢查：\n• 確保 UDP 連接埠 %1$d 已在防火牆中放行（TCP 連接埠 %2$d + 1）\n• 兩台裝置應在同一網路中\n• 嘗試重新連線</string>
+    <string name="udpWarningConfirm">確定</string>
     <string name="firstLaunchGotItButton">我很清楚怎麼使用</string>
     <string name="firstLaunchGuideButton">讓我看看使用指南</string>
     <string name="firstLaunchMessage">您似乎是第一次使用 MicYou，本應用可以將您的 Android 裝置透過 Wi-Fi 或 USB 變成電腦的高品質麥克風</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -96,7 +96,7 @@
     <string name="errorDialogTitle">连接错误</string>
     <string name="errorFirewallBlockedMessage">端口 %s 被 Windows 防火墙阻止。请添加防火墙规则或以管理员身份运行应用。</string>
     <string name="errorFirewallBlockedTitle">防火墙阻止</string>
-    <string name="errorUdpPortBlockedMessage">UDP 音频端口 %s 被防火墙阻止。音频传输需要 TCP 和 UDP 端口均可访问。请为 UDP 端口添加防火墙规则，或以管理员身份运行应用。</string>
+    <string name="errorUdpPortBlockedMessage">UDP 音频端口 %d 被防火墙阻止。音频传输需要 TCP 和 UDP 端口均可访问。请为 UDP 端口添加防火墙规则，或以管理员身份运行应用。</string>
     <string name="errorUdpPortBlockedTitle">UDP 端口被阻止</string>
     <string name="errorHandshakeFailedMessage">与目标设备握手失败。这可能表示版本不匹配或协议错误。</string>
     <string name="errorHandshakeFailedTitle">握手失败</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -96,6 +96,8 @@
     <string name="errorDialogTitle">连接错误</string>
     <string name="errorFirewallBlockedMessage">端口 %s 被 Windows 防火墙阻止。请添加防火墙规则或以管理员身份运行应用。</string>
     <string name="errorFirewallBlockedTitle">防火墙阻止</string>
+    <string name="errorUdpPortBlockedMessage">UDP 音频端口 %s 被防火墙阻止。音频传输需要 TCP 和 UDP 端口均可访问。请为 UDP 端口添加防火墙规则，或以管理员身份运行应用。</string>
+    <string name="errorUdpPortBlockedTitle">UDP 端口被阻止</string>
     <string name="errorHandshakeFailedMessage">与目标设备握手失败。这可能表示版本不匹配或协议错误。</string>
     <string name="errorHandshakeFailedTitle">握手失败</string>
     <string name="errorNetworkTimeoutMessage">连接超时。请检查网络连接和目标设备状态。</string>
@@ -148,6 +150,9 @@
     <string name="firewallDismiss">忽略</string>
     <string name="firewallMessage">端口 %s 似乎未被 Windows 防火墙放行。这可能会导致 Android 设备无法通过 Wi-Fi 连接。\n\n是否尝试自动添加防火墙规则？（需要管理员权限）</string>
     <string name="firewallTitle">防火墙检查</string>
+    <string name="udpWarningTitle">UDP 音频警告</string>
+    <string name="udpWarningMessage">TCP 连接已建立，但未收到任何 UDP 音频包。音频传输需要 TCP 和 UDP 端口均可访问。\n\n请检查：\n• 确保 UDP 端口 %1$d 已在防火墙中放行（TCP 端口 %2$d + 1）\n• 两台设备应在同一网络中\n• 尝试重新连接</string>
+    <string name="udpWarningConfirm">确定</string>
     <string name="firstLaunchGotItButton">我很清楚怎么使用</string>
     <string name="firstLaunchGuideButton">让我看看使用指南</string>
     <string name="firstLaunchMessage">您似乎是第一次使用 MicYou，本应用可以将您的 Android 设备通过 Wi-Fi 或 USB 变成电脑的高质量麦克风</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -116,7 +116,7 @@
     <string name="errorDialogTitle">Connection Error</string>
     <string name="errorFirewallBlockedMessage">Port %s is blocked by Windows Firewall. Please add a firewall rule or run the application as administrator.</string>
     <string name="errorFirewallBlockedTitle">Firewall Blocked</string>
-    <string name="errorUdpPortBlockedMessage">UDP audio port %s is blocked by firewall. Audio transmission requires both TCP and UDP ports to be accessible. Please add a firewall rule for the UDP port or run the application as administrator.</string>
+    <string name="errorUdpPortBlockedMessage">UDP audio port %d is blocked by firewall. Audio transmission requires both TCP and UDP ports to be accessible. Please add a firewall rule for the UDP port or run the application as administrator.</string>
     <string name="errorUdpPortBlockedTitle">UDP Port Blocked</string>
     <string name="errorHandshakeFailedMessage">Handshake failed with the target device. This may indicate a version mismatch or protocol error.</string>
     <string name="errorHandshakeFailedDetailed">Handshake failed: verification with the target device failed. This may be due to a version mismatch or protocol error. Please ensure both devices are using the same version of MicYou.</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -116,6 +116,8 @@
     <string name="errorDialogTitle">Connection Error</string>
     <string name="errorFirewallBlockedMessage">Port %s is blocked by Windows Firewall. Please add a firewall rule or run the application as administrator.</string>
     <string name="errorFirewallBlockedTitle">Firewall Blocked</string>
+    <string name="errorUdpPortBlockedMessage">UDP audio port %s is blocked by firewall. Audio transmission requires both TCP and UDP ports to be accessible. Please add a firewall rule for the UDP port or run the application as administrator.</string>
+    <string name="errorUdpPortBlockedTitle">UDP Port Blocked</string>
     <string name="errorHandshakeFailedMessage">Handshake failed with the target device. This may indicate a version mismatch or protocol error.</string>
     <string name="errorHandshakeFailedDetailed">Handshake failed: verification with the target device failed. This may be due to a version mismatch or protocol error. Please ensure both devices are using the same version of MicYou.</string>
     <string name="errorHandshakeFailedTitle">Handshake Failed</string>
@@ -172,6 +174,9 @@
     <string name="firewallDismiss">Ignore</string>
     <string name="firewallMessage">Port %s is not allowed by Windows Firewall. This may prevent Android devices from connecting via Wi-Fi.\n\nWould you like to try adding a firewall rule for this port? (Requires Administrator privileges)</string>
     <string name="firewallTitle">Firewall Check</string>
+    <string name="udpWarningTitle">UDP Audio Warning</string>
+    <string name="udpWarningMessage">TCP connection is established, but no UDP audio packets have been received. Audio transmission requires both TCP and UDP ports to be accessible.\n\nPlease check:\n• Ensure UDP port %1$d is allowed in your firewall (TCP port %2$d + 1)\n• Both devices should be on the same network\n• Try restarting the connection</string>
+    <string name="udpWarningConfirm">OK</string>
     <string name="firstLaunchGotItButton">I know how to use it</string>
     <string name="firstLaunchGuideButton">View Usage Guide</string>
     <string name="firstLaunchMessage">You seem to be using MicYou for the first time. This app turns your Android device into a high-quality microphone for your computer via Wi-Fi or USB.</string>

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
@@ -31,6 +31,9 @@ data class AudioStreamUiState(
     val showErrorDialog: Boolean = false,
     val errorDetails: ConnectionErrorDetails? = null,
 
+    // UDP Warning Dialog State
+    val showUdpWarningDialog: Boolean = false,
+
     // Audio Processing Settings
     val enableNS: Boolean = false,
     val nsType: NoiseReductionType = NoiseReductionType.Ulunas,
@@ -251,7 +254,11 @@ class AudioStreamViewModel : ViewModel() {
 
         viewModelScope.launch {
             _audioEngine.lastError.collect { error ->
-                _uiState.update { it.copy(errorMessage = error) }
+                if (error == "UDP_AUDIO_WARNING") {
+                    _uiState.update { it.copy(showUdpWarningDialog = true) }
+                } else {
+                    _uiState.update { it.copy(errorMessage = error) }
+                }
             }
         }
 
@@ -654,6 +661,10 @@ class AudioStreamViewModel : ViewModel() {
     
     fun dismissErrorDialog() {
         _uiState.update { it.copy(showErrorDialog = false) }
+    }
+    
+    fun dismissUdpWarningDialog() {
+        _uiState.update { it.copy(showUdpWarningDialog = false) }
     }
     
     fun retryAfterError() {

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/ConnectionError.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/ConnectionError.kt
@@ -356,7 +356,7 @@ object ConnectionErrorHelper {
                 type = type,
                 originalMessage = originalMessage,
                 localizedTitle = getString(Res.string.errorUdpPortBlockedTitle),
-                localizedMessage = String.format(getString(Res.string.errorUdpPortBlockedMessage), port?.let { calculateUdpPort(it).toString() } ?: Constants.DEFAULT_UDP_PORT.toString()),
+                localizedMessage = getString(Res.string.errorUdpPortBlockedMessage, port?.let { calculateUdpPort(it) } ?: Constants.DEFAULT_UDP_PORT),
                 recoverySuggestions = listOf(
                     getString(Res.string.errorSuggestionAddFirewallRule),
                     getString(Res.string.errorSuggestionRunAsAdmin)

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/ConnectionError.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/ConnectionError.kt
@@ -355,8 +355,8 @@ object ConnectionErrorHelper {
             ConnectionErrorType.UdpPortBlocked -> ConnectionErrorDetails(
                 type = type,
                 originalMessage = originalMessage,
-                localizedTitle = getString(Res.string.errorFirewallBlockedTitle),
-                localizedMessage = "UDP 音频端口被防火墙阻止。请确保 UDP 端口 ${port?.let { calculateUdpPort(it) } ?: Constants.DEFAULT_UDP_PORT} 已放行。",
+                localizedTitle = getString(Res.string.errorUdpPortBlockedTitle),
+                localizedMessage = String.format(getString(Res.string.errorUdpPortBlockedMessage), port?.let { calculateUdpPort(it).toString() } ?: Constants.DEFAULT_UDP_PORT.toString()),
                 recoverySuggestions = listOf(
                     getString(Res.string.errorSuggestionAddFirewallRule),
                     getString(Res.string.errorSuggestionRunAsAdmin)

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
@@ -202,6 +202,33 @@ fun DesktopHome(
         )
     }
 
+    if (state.showUdpWarningDialog) {
+        val tcpPort = state.port.toIntOrNull() ?: Constants.DEFAULT_TCP_PORT
+        val udpPort = calculateUdpPort(tcpPort)
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissUdpWarningDialog() },
+            title = { Text(stringResource(Res.string.udpWarningTitle)) },
+            text = { 
+                Column(
+                    modifier = Modifier
+                        .widthIn(min = 400.dp, max = 500.dp)
+                        .heightIn(max = 400.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    Text(
+                        text = String.format(stringResource(Res.string.udpWarningMessage), udpPort, tcpPort),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            },
+            confirmButton = {
+                Button(onClick = { viewModel.dismissUdpWarningDialog() }) {
+                    Text(stringResource(Res.string.udpWarningConfirm))
+                }
+            }
+        )
+    }
+
     Surface(
         color = MaterialTheme.colorScheme.surface,
         contentColor = MaterialTheme.colorScheme.onSurface,

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHome.kt
@@ -203,29 +203,9 @@ fun DesktopHome(
     }
 
     if (state.showUdpWarningDialog) {
-        val tcpPort = state.port.toIntOrNull() ?: Constants.DEFAULT_TCP_PORT
-        val udpPort = calculateUdpPort(tcpPort)
-        AlertDialog(
-            onDismissRequest = { viewModel.dismissUdpWarningDialog() },
-            title = { Text(stringResource(Res.string.udpWarningTitle)) },
-            text = { 
-                Column(
-                    modifier = Modifier
-                        .widthIn(min = 400.dp, max = 500.dp)
-                        .heightIn(max = 400.dp)
-                        .verticalScroll(rememberScrollState())
-                ) {
-                    Text(
-                        text = String.format(stringResource(Res.string.udpWarningMessage), udpPort, tcpPort),
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                }
-            },
-            confirmButton = {
-                Button(onClick = { viewModel.dismissUdpWarningDialog() }) {
-                    Text(stringResource(Res.string.udpWarningConfirm))
-                }
-            }
+        UdpWarningDialog(
+            port = state.port,
+            onDismiss = { viewModel.dismissUdpWarningDialog() }
         )
     }
 
@@ -1079,4 +1059,35 @@ private fun AnimatedIconButton(
     ) {
         content()
     }
+}
+
+@Composable
+fun UdpWarningDialog(
+    port: String,
+    onDismiss: () -> Unit
+) {
+    val tcpPort = port.toIntOrNull() ?: Constants.DEFAULT_TCP_PORT
+    val udpPort = calculateUdpPort(tcpPort)
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.udpWarningTitle)) },
+        text = { 
+            Column(
+                modifier = Modifier
+                    .widthIn(min = 400.dp, max = 500.dp)
+                    .heightIn(max = 400.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                Text(
+                    text = stringResource(Res.string.udpWarningMessage, udpPort, tcpPort),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        },
+        confirmButton = {
+            Button(onClick = onDismiss) {
+                Text(stringResource(Res.string.udpWarningConfirm))
+            }
+        }
+    )
 }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
@@ -206,29 +206,9 @@ fun DesktopHomeEnhanced(
     }
 
     if (state.showUdpWarningDialog) {
-        val tcpPort = state.port.toIntOrNull() ?: Constants.DEFAULT_TCP_PORT
-        val udpPort = calculateUdpPort(tcpPort)
-        AlertDialog(
-            onDismissRequest = { viewModel.dismissUdpWarningDialog() },
-            title = { Text(stringResource(Res.string.udpWarningTitle)) },
-            text = { 
-                Column(
-                    modifier = Modifier
-                        .widthIn(min = 400.dp, max = 500.dp)
-                        .heightIn(max = 400.dp)
-                        .verticalScroll(rememberScrollState())
-                ) {
-                    Text(
-                        text = String.format(stringResource(Res.string.udpWarningMessage), udpPort, tcpPort),
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                }
-            },
-            confirmButton = {
-                Button(onClick = { viewModel.dismissUdpWarningDialog() }) {
-                    Text(stringResource(Res.string.udpWarningConfirm))
-                }
-            }
+        UdpWarningDialog(
+            port = state.port,
+            onDismiss = { viewModel.dismissUdpWarningDialog() }
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
@@ -205,6 +205,33 @@ fun DesktopHomeEnhanced(
         )
     }
 
+    if (state.showUdpWarningDialog) {
+        val tcpPort = state.port.toIntOrNull() ?: Constants.DEFAULT_TCP_PORT
+        val udpPort = calculateUdpPort(tcpPort)
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissUdpWarningDialog() },
+            title = { Text(stringResource(Res.string.udpWarningTitle)) },
+            text = { 
+                Column(
+                    modifier = Modifier
+                        .widthIn(min = 400.dp, max = 500.dp)
+                        .heightIn(max = 400.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    Text(
+                        text = String.format(stringResource(Res.string.udpWarningMessage), udpPort, tcpPort),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            },
+            confirmButton = {
+                Button(onClick = { viewModel.dismissUdpWarningDialog() }) {
+                    Text(stringResource(Res.string.udpWarningConfirm))
+                }
+            }
+        )
+    }
+
     Surface(
         color = MaterialTheme.colorScheme.surfaceContainer,
         contentColor = MaterialTheme.colorScheme.onSurface,

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
@@ -70,6 +70,9 @@ data class AppUiState(
     val showErrorDialog: Boolean = false,
     val errorDetails: ConnectionErrorDetails? = null,
     
+    // UDP Warning Dialog State
+    val showUdpWarningDialog: Boolean = false,
+    
     // Audio Processing Settings
     val enableNS: Boolean = false,
     val nsType: NoiseReductionType = NoiseReductionType.Ulunas,
@@ -311,6 +314,7 @@ class MainViewModel : ViewModel() {
                         pendingFirewallPort = audioState.pendingFirewallPort,
                         showErrorDialog = audioState.showErrorDialog,
                         errorDetails = audioState.errorDetails,
+                        showUdpWarningDialog = audioState.showUdpWarningDialog,
                         enableNS = audioState.enableNS,
                         nsType = audioState.nsType,
                         enableAGC = audioState.enableAGC,
@@ -425,6 +429,7 @@ class MainViewModel : ViewModel() {
     fun dismissFirewallDialog() = audioStreamViewModel.dismissFirewallDialog()
     fun confirmAddFirewallRule() = audioStreamViewModel.confirmAddFirewallRule()
     fun dismissErrorDialog() = audioStreamViewModel.dismissErrorDialog()
+    fun dismissUdpWarningDialog() = audioStreamViewModel.dismissUdpWarningDialog()
     fun retryAfterError() = audioStreamViewModel.retryAfterError()
     
     // Settings methods

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
@@ -271,33 +271,39 @@ class NetworkServer(
         
         delay(monitorStartDelay)
         
-        val monitorStartTime = System.currentTimeMillis()
+        // 记录初始包数，避免受之前连接的统计数据干扰
+        val initialPackets = udpHandler?.getStats()?.packetsReceived ?: 0L
+        val monitorStartTime = System.nanoTime()
         var warningFired = false
         
         while (currentCoroutineContext().isActive) {
             val stats = udpHandler?.getStats()
             if (stats != null) {
-                val now = System.currentTimeMillis()
+                val now = System.nanoTime()
+                val currentPackets = stats.packetsReceived - initialPackets
                 
-                if (stats.packetsReceived == 0L) {
-                    // 从未收到过UDP包，计算从监控开始到现在的时间
-                    val waitingTime = now - monitorStartTime
-                    if (waitingTime > noPacketWarningThreshold && !warningFired) {
-                        Logger.w("NetworkServer", "UDP 连接监控: TCP 连接已建立，但 ${waitingTime/1000} 秒内未收到任何 UDP 音频包。UDP 端口可能被防火墙阻止。")
+                if (currentPackets == 0L) {
+                    // 从未收到过新 UDP 包
+                    val waitingTimeMs = (now - monitorStartTime) / 1_000_000
+                    if (waitingTimeMs > noPacketWarningThreshold && !warningFired) {
+                        Logger.w("NetworkServer", "UDP 连接监控: TCP 连接已建立，但 ${waitingTimeMs/1000} 秒内未收到任何 UDP 音频包。UDP 端口可能被防火墙阻止。")
                         _lastError.value = "UDP_AUDIO_WARNING"
                         warningFired = true
                     }
                 } else {
-                    // 收到过UDP包，检查是否中断
-                    val timeSinceLastPacket = now - stats.lastPacketReceivedTime
-                    if (timeSinceLastPacket > noPacketWarningThreshold && !warningFired) {
-                        Logger.w("NetworkServer", "UDP 连接监控: 已 ${timeSinceLastPacket/1000} 秒未收到 UDP 包，连接可能中断。")
+                    // 检查 UDP 包是否中断
+                    val timeSinceLastPacketMs = (now - stats.lastPacketReceivedTimeNano) / 1_000_000
+                    if (timeSinceLastPacketMs > noPacketWarningThreshold && !warningFired) {
+                        Logger.w("NetworkServer", "UDP 连接监控: 已 ${timeSinceLastPacketMs/1000} 秒未收到 UDP 包，连接可能中断。")
                         _lastError.value = "UDP_AUDIO_WARNING"
                         warningFired = true
                     }
-                    // 收到新包后重置警告标志
-                    if (stats.lastPacketReceivedTime > monitorStartTime) {
-                        warningFired = false
+                    // 收到新包后重置警告标志，并清除错误状态以允许下次触发
+                    if (stats.lastPacketReceivedTimeNano > monitorStartTime) {
+                        if (warningFired) {
+                            _lastError.value = null
+                            warningFired = false
+                        }
                     }
                 }
             }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
@@ -242,13 +242,67 @@ class NetworkServer(
         )
         activeHandler = handler
         
+        // 启动 UDP 连接监控（仅在双协议模式下）
+        val udpMonitorJob = if (udpHandler != null) {
+            serverScope.launch {
+                monitorUdpConnection()
+            }
+        } else null
+        
         try {
             handler.run()
         } finally {
+            udpMonitorJob?.cancel()
             activeHandler = null
             closeAction()
             Logger.i("NetworkServer", "连接已关闭")
             _state.value = StreamState.Connecting
+        }
+    }
+    
+    /**
+     * 监控 UDP 连接状态
+     * 当 TCP 连接成功后，如果一段时间内没有收到 UDP 包，发出警告
+     */
+    private suspend fun monitorUdpConnection() {
+        val monitorStartDelay = 5000L  // 等待5秒让客户端开始发送UDP
+        val monitorInterval = 3000L    // 每3秒检查一次
+        val noPacketWarningThreshold = 10000L  // 10秒没有收到UDP包则警告
+        
+        delay(monitorStartDelay)
+        
+        val monitorStartTime = System.currentTimeMillis()
+        var warningFired = false
+        
+        while (currentCoroutineContext().isActive) {
+            val stats = udpHandler?.getStats()
+            if (stats != null) {
+                val now = System.currentTimeMillis()
+                
+                if (stats.packetsReceived == 0L) {
+                    // 从未收到过UDP包，计算从监控开始到现在的时间
+                    val waitingTime = now - monitorStartTime
+                    if (waitingTime > noPacketWarningThreshold && !warningFired) {
+                        Logger.w("NetworkServer", "UDP 连接监控: TCP 连接已建立，但 ${waitingTime/1000} 秒内未收到任何 UDP 音频包。UDP 端口可能被防火墙阻止。")
+                        _lastError.value = "UDP_AUDIO_WARNING"
+                        warningFired = true
+                    }
+                } else {
+                    // 收到过UDP包，检查是否中断
+                    val timeSinceLastPacket = now - stats.lastPacketReceivedTime
+                    if (timeSinceLastPacket > noPacketWarningThreshold && !warningFired) {
+                        Logger.w("NetworkServer", "UDP 连接监控: 已 ${timeSinceLastPacket/1000} 秒未收到 UDP 包，连接可能中断。")
+                        _lastError.value = "UDP_AUDIO_WARNING"
+                        warningFired = true
+                    }
+                    // 收到新包后重置警告标志
+                    if (stats.lastPacketReceivedTime > monitorStartTime) {
+                        warningFired = false
+                    }
+                }
+            }
+            
+            delay(monitorInterval)
         }
     }
 

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/UdpConnectionHandler.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/UdpConnectionHandler.kt
@@ -55,6 +55,12 @@ class UdpConnectionHandler(
     @Volatile
     private var jitter = 0.0
 
+    // UDP connection monitoring
+    @Volatile
+    private var firstPacketReceivedTime = 0L
+    @Volatile
+    private var lastPacketReceivedTime = 0L
+
     private var lastLossLogTime = 0L
     private var suppressedLossLogs = 0
     private var lastOutOfOrderLogTime = 0L
@@ -92,7 +98,9 @@ class UdpConnectionHandler(
         packetsReceived = packetsReceived,
         packetsLost = packetsLost,
         jitter = jitter,
-        clientAddress = clientAddress
+        clientAddress = clientAddress,
+        firstPacketReceivedTime = firstPacketReceivedTime,
+        lastPacketReceivedTime = lastPacketReceivedTime
     )
 
     private suspend fun runUdpReceiver() {
@@ -177,6 +185,14 @@ class UdpConnectionHandler(
             // UDP channel only processes audio packets
             val audioPacket = wrapper.audioPacket?.audioPacket
             if (audioPacket != null) {
+                // Update packet receive timestamps for connection monitoring
+                val now = System.currentTimeMillis()
+                if (firstPacketReceivedTime == 0L) {
+                    firstPacketReceivedTime = now
+                    Logger.i("UdpConnectionHandler", "First UDP packet received at $now")
+                }
+                lastPacketReceivedTime = now
+
                 // Sequence number tracking
                 val seqNum = wrapper.audioPacket.sequenceNumber
                 if (packetsReceived == 0L) {
@@ -261,7 +277,9 @@ class UdpConnectionHandler(
         val packetsReceived: Long,
         val packetsLost: Long,
         val jitter: Double,
-        val clientAddress: InetSocketAddress?
+        val clientAddress: InetSocketAddress?,
+        val firstPacketReceivedTime: Long,
+        val lastPacketReceivedTime: Long
     ) {
         val lossRate: Double
             get() = if (packetsReceived + packetsLost > 0) {

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/UdpConnectionHandler.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/UdpConnectionHandler.kt
@@ -55,11 +55,11 @@ class UdpConnectionHandler(
     @Volatile
     private var jitter = 0.0
 
-    // UDP connection monitoring
+    // UDP connection monitoring (using monotonic clock)
     @Volatile
-    private var firstPacketReceivedTime = 0L
+    private var firstPacketReceivedTimeNano = 0L
     @Volatile
-    private var lastPacketReceivedTime = 0L
+    private var lastPacketReceivedTimeNano = 0L
 
     private var lastLossLogTime = 0L
     private var suppressedLossLogs = 0
@@ -99,8 +99,8 @@ class UdpConnectionHandler(
         packetsLost = packetsLost,
         jitter = jitter,
         clientAddress = clientAddress,
-        firstPacketReceivedTime = firstPacketReceivedTime,
-        lastPacketReceivedTime = lastPacketReceivedTime
+        firstPacketReceivedTimeNano = firstPacketReceivedTimeNano,
+        lastPacketReceivedTimeNano = lastPacketReceivedTimeNano
     )
 
     private suspend fun runUdpReceiver() {
@@ -185,13 +185,13 @@ class UdpConnectionHandler(
             // UDP channel only processes audio packets
             val audioPacket = wrapper.audioPacket?.audioPacket
             if (audioPacket != null) {
-                // Update packet receive timestamps for connection monitoring
-                val now = System.currentTimeMillis()
-                if (firstPacketReceivedTime == 0L) {
-                    firstPacketReceivedTime = now
-                    Logger.i("UdpConnectionHandler", "First UDP packet received at $now")
+                // Update packet receive timestamps for connection monitoring (monotonic clock)
+                val nowNano = System.nanoTime()
+                if (firstPacketReceivedTimeNano == 0L) {
+                    firstPacketReceivedTimeNano = nowNano
+                    Logger.i("UdpConnectionHandler", "First UDP packet received")
                 }
-                lastPacketReceivedTime = now
+                lastPacketReceivedTimeNano = nowNano
 
                 // Sequence number tracking
                 val seqNum = wrapper.audioPacket.sequenceNumber
@@ -278,8 +278,8 @@ class UdpConnectionHandler(
         val packetsLost: Long,
         val jitter: Double,
         val clientAddress: InetSocketAddress?,
-        val firstPacketReceivedTime: Long,
-        val lastPacketReceivedTime: Long
+        val firstPacketReceivedTimeNano: Long,
+        val lastPacketReceivedTimeNano: Long
     ) {
         val lossRate: Double
             get() = if (packetsReceived + packetsLost > 0) {


### PR DESCRIPTION
## 1. 高层摘要 (TL;DR)

*   **影响范围:** 🟡 **中等** - 新增UDP连接监控和用户警告功能，提升网络诊断能力
*   **核心变更:**
    *   ✨ 新增UDP连接状态监控机制，检测UDP音频包是否正常接收
    *   ⚠️ 当TCP连接成功但UDP端口被防火墙阻止时，向用户显示警告对话框
    *   🌍 为6种语言添加了新的本地化字符串资源
    *   🔧 改进了错误处理逻辑，区分UDP端口阻塞警告与其他错误

---

## 2. 可视化概览 (代码与逻辑映射)

```mermaid
graph TD
    subgraph "NetworkServer.kt"
        A["startConnection()"]
        B["monitorUdpConnection()"]
        C["检查UDP包接收状态"]
        D["发送 UDP_AUDIO_WARNING"]
    end
    
    subgraph "UdpConnectionHandler.kt"
        E["runUdpReceiver()"]
        F["更新时间戳<br/>firstPacketReceivedTime<br/>lastPacketReceivedTime"]
        G["getStats()"]
    end
    
    subgraph "AudioStreamViewModel.kt"
        H["lastError.collect"]
        I["识别 UDP_AUDIO_WARNING"]
        J["更新 showUdpWarningDialog"]
        K["dismissUdpWarningDialog()"]
    end
    
    subgraph "DesktopHome.kt / DesktopHomeEnhanced.kt"
        L["显示 UDP 警告对话框"]
        M["用户点击确定"]
    end
    
    A --> B
    B --> C
    C -->|10秒无UDP包| D
    E --> F
    B --> G
    D --> H
    H --> I
    I --> J
    J --> L
    L --> M
    M --> K
    K --> J
    
    style A fill:#bbdefb,color:#0d47a1
    style B fill:#bbdefb,color:#0d47a1
    style E fill:#c8e6c9,color:#1a5e20
    style F fill:#c8e6c9,color:#1a5e20
    style H fill:#fff3e0,color:#e65100
    style I fill:#fff3e0,color:#e65100
    style L fill:#f3e5f5,color:#7b1fa2
```

**业务流程说明:**
1. **NetworkServer** 启动连接后，并行运行 **UDP监控协程**
2. **UdpConnectionHandler** 接收UDP包时更新时间戳
3. 监控协程定期检查UDP统计信息
4. 如果10秒内未收到UDP包，触发 **UDP_AUDIO_WARNING** 错误
5. **AudioStreamViewModel** 捕获该错误并显示警告对话框
6. 用户确认后关闭对话框

---

## 3. 详细变更分析

### 📦 组件 1: 多语言字符串资源

**变更文件:** 6个 `strings.xml` 文件
- `values/strings.xml` (英语)
- `values-zh/strings.xml` (简体中文)
- `values-zh-rTW/strings.xml` (繁体中文-台湾)
- `values-zh-rHK/strings.xml` (繁体中文-香港)
- `values-zh-rSS/strings.xml` (特殊简体中文)
- `values-ca/strings.xml` (加泰罗尼亚语)

**新增字符串资源:**

| 资源键 | 用途 | 示例 (英语) |
|--------|------|-------------|
| `errorUdpPortBlockedTitle` | UDP端口被阻止的错误标题 | "UDP Port Blocked" |
| `errorUdpPortBlockedMessage` | UDP端口被阻止的详细消息 | "UDP audio port %s is blocked by firewall..." |
| `udpWarningTitle` | UDP警告对话框标题 | "UDP Audio Warning" |
| `udpWarningMessage` | UDP警告对话框内容 | "TCP connection is established, but no UDP audio packets..." |
| `udpWarningConfirm` | UDP警告确认按钮 | "OK" |

---

### 🧠 组件 2: 网络层 - UDP连接监控

#### 文件: `NetworkServer.kt`

**新增功能:** `monitorUdpConnection()` 方法

**监控逻辑:**
- **启动延迟:** 5秒（等待客户端开始发送UDP）
- **检查间隔:** 每3秒
- **警告阈值:** 10秒无UDP包

**关键代码逻辑:**
```kotlin
// 检查从未收到UDP包的情况
if (stats.packetsReceived == 0L) {
    val waitingTime = now - monitorStartTime
    if (waitingTime > 10000L && !warningFired) {
        _lastError.value = "UDP_AUDIO_WARNING"
    }
}
// 检查UDP包中断情况
else if (timeSinceLastPacket > 10000L) {
    _lastError.value = "UDP_AUDIO_WARNING"
}
```

---

#### 文件: `UdpConnectionHandler.kt`

**变更内容:**

| 变更项 | 说明 |
|--------|------|
| 新增字段 | `firstPacketReceivedTime: Long` - 首次接收UDP包的时间戳 |
| 新增字段 | `lastPacketReceivedTime: Long` - 最后接收UDP包的时间戳 |
| 更新逻辑 | 在接收音频包时更新这两个时间戳 |
| 数据结构 | `UdpStats` 数据类新增这两个字段 |

**代码片段:**
```kotlin
val now = System.currentTimeMillis()
if (firstPacketReceivedTime == 0L) {
    firstPacketReceivedTime = now
    Logger.i("UdpConnectionHandler", "First UDP packet received at $now")
}
lastPacketReceivedTime = now
```

---

### 🎨 组件 3: UI层 - 警告对话框

#### 文件: `DesktopHome.kt` 和 `DesktopHomeEnhanced.kt`

**新增UI组件:** UDP警告对话框

**对话框特性:**
- 最小宽度: 400dp，最大宽度: 500dp
- 最大高度: 400dp，支持垂直滚动
- 显示TCP端口和UDP端口信息
- 单个"确定"按钮关闭对话框

**代码逻辑:**
```kotlin
if (state.showUdpWarningDialog) {
    val tcpPort = state.port.toIntOrNull() ?: Constants.DEFAULT_TCP_PORT
    val udpPort = calculateUdpPort(tcpPort)
    AlertDialog(
        title = { Text(stringResource(Res.string.udpWarningTitle)) },
        text = { 
            Text(
                text = String.format(
                    stringResource(Res.string.udpWarningMessage), 
                    udpPort, 
                    tcpPort
                )
            )
        }
    )
}
```

---

### 🔄 组件 4: ViewModel层 - 状态管理

#### 文件: `AudioStreamViewModel.kt`

**变更内容:**

| 变更项 | 说明 |
|--------|------|
| UI状态字段 | `showUdpWarningDialog: Boolean` - 控制警告对话框显示 |
| 错误处理 | 识别 `"UDP_AUDIO_WARNING"` 错误并显示对话框 |
| 新方法 | `dismissUdpWarningDialog()` - 关闭警告对话框 |

**错误处理逻辑:**
```kotlin
_audioEngine.lastError.collect { error ->
    if (error == "UDP_AUDIO_WARNING") {
        _uiState.update { it.copy(showUdpWarningDialog = true) }
    } else {
        _uiState.update { it.copy(errorMessage = error) }
    }
}
```

---

#### 文件: `MainViewModel.kt`

**变更内容:**

| 变更项 | 说明 |
|--------|------|
| UI状态字段 | `showUdpWarningDialog: Boolean` - 同步UDP警告状态 |
| 状态同步 | 在 `syncAudioStreamState()` 中同步该状态 |
| 委托方法 | `dismissUdpWarningDialog()` - 委托给 `AudioStreamViewModel` |

---

### 🔧 组件 5: 错误处理改进

#### 文件: `ConnectionError.kt`

**变更内容:**

**改进前:**
```kotlin
localizedTitle = getString(Res.string.errorFirewallBlockedTitle),
localizedMessage = "UDP 音频端口被防火墙阻止。请确保 UDP 端口 ${port?.let { calculateUdpPort(it) } ?: Constants.DEFAULT_UDP_PORT} 已放行。"
```

**改进后:**
```kotlin
localizedTitle = getString(Res.string.errorUdpPortBlockedTitle),
localizedMessage = String.format(
    getString(Res.string.errorUdpPortBlockedMessage), 
    port?.let { calculateUdpPort(it).toString() } ?: Constants.DEFAULT_UDP_PORT.toString()
)
```

**改进点:**
- 使用专用的UDP端口错误字符串资源
- 使用 `String.format()` 进行格式化，支持多语言
- 提高了代码的可维护性和本地化支持

---

## 4. 影响与风险评估

### ✅ 正面影响

1. **提升用户体验:** 用户能更清楚地了解网络连接问题，特别是防火墙阻止UDP端口的情况
2. **更好的诊断能力:** 自动检测UDP连接问题，无需用户手动排查
3. **国际化支持:** 为6种语言提供了完整的本地化支持

### ⚠️ 潜在风险

| 风险项 | 严重性 | 说明 | 缓解措施 |
|--------|--------|------|----------|
| 误报 | 🟡 低 | 在网络延迟高时可能误判为UDP中断 | 10秒阈值较为保守，可降低误报率 |
| 性能影响 | 🟢 极低 | 监控协程每3秒检查一次，开销很小 | 使用轻量级统计查询 |
| 状态同步 | 🟢 低 | 新增状态字段需要正确同步 | 已在 `MainViewModel` 中实现同步 |

### 🧪 测试建议

**功能测试:**
1. ✅ **正常场景:** TCP和UDP都正常连接，不应显示警告
2. ✅ **UDP被阻止:** 防火墙阻止UDP端口，10秒后应显示警告对话框
3. ✅ **UDP中断:** 连接后UDP包停止发送，应显示警告
4. ✅ **对话框关闭:** 点击确定按钮应正确关闭对话框
5. ✅ **多语言:** 切换语言后，警告对话框文本应正确显示

**边界测试:**
- 网络延迟较高时的UDP包接收
- 快速重连场景下的警告状态重置
- 多个错误同时发生时的处理优先级

---

## 5. 变更统计

| 指标 | 数量 |
|------|------|
| 修改文件数 | 13 |
| 新增字符串资源 | 5个 × 6种语言 = 30个 |
| 新增方法 | 3个 |
| 新增字段 | 4个 |
| 代码行数增加 | ~150行 |