### PR TITLE
新增iOS客户端协议支持

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/IosConnectionHandler.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/IosConnectionHandler.kt
@@ -2,11 +2,9 @@ package com.lanrhyme.micyou.network
 
 import com.lanrhyme.micyou.AudioFormat
 import com.lanrhyme.micyou.AudioPacketMessage
+import com.lanrhyme.micyou.Constants
 import com.lanrhyme.micyou.Logger
-import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.ByteWriteChannel
-import io.ktor.utils.io.readFully
-import io.ktor.utils.io.writeFully
+import io.ktor.utils.io.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -41,8 +39,8 @@ class IosConnectionHandler(
                 return
             }
 
-            if (header.payloadLength <= 0) {
-                onError("iOS protocol: Hello payload is empty")
+            if (header.payloadLength <= 0 || header.payloadLength > Constants.MAX_PACKET_SIZE) {
+                onError("iOS protocol: Hello payload length invalid: ${header.payloadLength}")
                 return
             }
 
@@ -122,12 +120,27 @@ class IosConnectionHandler(
     private fun parseHelloPayload(bytes: ByteArray): IosHelloPayload {
         var offset = 0
 
+        if (bytes.size < 4) {
+            throw IllegalArgumentException("iOS protocol: Hello payload too short for nameLen")
+        }
         val nameLen = readBigEndianInt(bytes, offset); offset += 4
+        if (nameLen < 0 || offset + nameLen > bytes.size) {
+            throw IllegalArgumentException("iOS protocol: invalid nameLen $nameLen in Hello payload")
+        }
         val deviceName = bytes.copyOfRange(offset, offset + nameLen).decodeToString(); offset += nameLen
 
+        if (offset + 4 > bytes.size) {
+            throw IllegalArgumentException("iOS protocol: Hello payload too short for idLen")
+        }
         val idLen = readBigEndianInt(bytes, offset); offset += 4
+        if (idLen < 0 || offset + idLen > bytes.size) {
+            throw IllegalArgumentException("iOS protocol: invalid idLen $idLen in Hello payload")
+        }
         val deviceId = bytes.copyOfRange(offset, offset + idLen).decodeToString(); offset += idLen
 
+        if (offset + 8 > bytes.size) {
+            throw IllegalArgumentException("iOS protocol: Hello payload too short for sampleRate/channelCount")
+        }
         val sampleRate = readBigEndianInt(bytes, offset); offset += 4
         val channelCount = readBigEndianInt(bytes, offset); offset += 4
 
@@ -195,14 +208,36 @@ class IosConnectionHandler(
             val headerBytes = ByteArray(IosProtocolConstants.HEADER_SIZE)
             input.readFully(headerBytes)
 
-            val header = parseHeader(headerBytes)
+            var header = parseHeader(headerBytes)
 
             if (header.magic != IosProtocolConstants.MAGIC_HEADER) {
                 Logger.w("IosConnectionHandler", "Invalid magic: 0x${header.magic.toString(16).uppercase()}, resyncing")
-                continue
+                var resyncMagic = header.magic
+                while (currentCoroutineContext().isActive) {
+                    val byte = input.readByte().toInt() and 0xFF
+                    resyncMagic = ((resyncMagic shl 8) or byte) and 0xFFFFFFFF.toInt()
+                    if (resyncMagic == IosProtocolConstants.MAGIC_HEADER) {
+                        break
+                    }
+                }
+                if (!currentCoroutineContext().isActive) return
+                val remainingBytes = ByteArray(12)
+                input.readFully(remainingBytes)
+                val syncedHeaderBytes = ByteArray(IosProtocolConstants.HEADER_SIZE)
+                val magic = IosProtocolConstants.MAGIC_HEADER
+                syncedHeaderBytes[0] = (magic shr 24).toByte()
+                syncedHeaderBytes[1] = (magic shr 16).toByte()
+                syncedHeaderBytes[2] = (magic shr 8).toByte()
+                syncedHeaderBytes[3] = magic.toByte()
+                remainingBytes.copyInto(syncedHeaderBytes, 4)
+                header = parseHeader(syncedHeaderBytes)
             }
 
             val payload = if (header.payloadLength > 0) {
+                if (header.payloadLength > Constants.MAX_PACKET_SIZE) {
+                    Logger.w("IosConnectionHandler", "Payload too large: ${header.payloadLength} bytes, closing connection")
+                    return
+                }
                 val payloadBytes = ByteArray(header.payloadLength)
                 input.readFully(payloadBytes)
                 payloadBytes

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/IosConnectionHandler.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/IosConnectionHandler.kt
@@ -1,0 +1,286 @@
+package com.lanrhyme.micyou.network
+
+import com.lanrhyme.micyou.AudioFormat
+import com.lanrhyme.micyou.AudioPacketMessage
+import com.lanrhyme.micyou.Logger
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.ByteWriteChannel
+import io.ktor.utils.io.readFully
+import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.io.EOFException
+import java.io.IOException
+
+class IosConnectionHandler(
+    private val input: ByteReadChannel,
+    private val output: ByteWriteChannel,
+    private val headerBytes: ByteArray,
+    private val onAudioPacketReceived: suspend (AudioPacketMessage) -> Unit,
+    private val onError: (String) -> Unit
+) {
+    private var keepAliveJob: Job? = null
+    private var sequenceCounter = 0
+
+    suspend fun run() {
+        try {
+            if (headerBytes.size < IosProtocolConstants.HEADER_SIZE) {
+                onError("iOS protocol header too short: ${headerBytes.size} bytes")
+                return
+            }
+
+            val header = parseHeader(headerBytes)
+            if (header.type != IosProtocolConstants.TYPE_HELLO) {
+                onError("iOS protocol: expected Hello (type=1), got type=${header.type}")
+                return
+            }
+
+            if (header.payloadLength <= 0) {
+                onError("iOS protocol: Hello payload is empty")
+                return
+            }
+
+            val payloadBytes = ByteArray(header.payloadLength)
+            input.readFully(payloadBytes)
+
+            val hello = parseHelloPayload(payloadBytes)
+            Logger.i("IosConnectionHandler", "iOS client connected: ${hello.deviceName} (${hello.deviceId}), sampleRate=${hello.sampleRate}, channels=${hello.channelCount}")
+
+            sendAck()
+
+            coroutineScope {
+                keepAliveJob = launch(Dispatchers.IO) {
+                    while (isActive) {
+                        sendKeepAlive()
+                        delay(5000)
+                    }
+                }
+
+                try {
+                    processReceiveLoop(hello.sampleRate, hello.channelCount)
+                } finally {
+                    keepAliveJob?.cancel()
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: EOFException) {
+            Logger.i("IosConnectionHandler", "iOS client disconnected")
+        } catch (e: IOException) {
+            val msg = e.message ?: ""
+            if (msg.contains("Socket closed", ignoreCase = true) ||
+                msg.contains("Connection reset", ignoreCase = true) ||
+                msg.contains("Broken pipe", ignoreCase = true)) {
+                Logger.i("IosConnectionHandler", "iOS connection closed: $msg")
+            } else {
+                Logger.e("IosConnectionHandler", "iOS connection error", e)
+                onError("iOS connection error: $msg")
+            }
+        } catch (e: Exception) {
+            Logger.e("IosConnectionHandler", "iOS handler error", e)
+            onError("iOS handler error: ${e.message}")
+        } finally {
+            keepAliveJob?.cancel()
+        }
+    }
+
+    private fun parseHeader(bytes: ByteArray): IosPacketHeader {
+        val magic = ((bytes[0].toInt() and 0xFF) shl 24) or
+                    ((bytes[1].toInt() and 0xFF) shl 16) or
+                    ((bytes[2].toInt() and 0xFF) shl 8) or
+                    (bytes[3].toInt() and 0xFF)
+
+        val type = ((bytes[4].toInt() and 0xFF) shl 24) or
+                   ((bytes[5].toInt() and 0xFF) shl 16) or
+                   ((bytes[6].toInt() and 0xFF) shl 8) or
+                   (bytes[7].toInt() and 0xFF)
+
+        val payloadLength = ((bytes[8].toInt() and 0xFF) shl 24) or
+                            ((bytes[9].toInt() and 0xFF) shl 16) or
+                            ((bytes[10].toInt() and 0xFF) shl 8) or
+                            (bytes[11].toInt() and 0xFF)
+
+        val sequence = ((bytes[12].toInt() and 0xFF) shl 24) or
+                       ((bytes[13].toInt() and 0xFF) shl 16) or
+                       ((bytes[14].toInt() and 0xFF) shl 8) or
+                       (bytes[15].toInt() and 0xFF)
+
+        return IosPacketHeader(
+            magic = magic,
+            type = type,
+            payloadLength = payloadLength,
+            sequence = sequence
+        )
+    }
+
+    private fun parseHelloPayload(bytes: ByteArray): IosHelloPayload {
+        var offset = 0
+
+        val nameLen = readBigEndianInt(bytes, offset); offset += 4
+        val deviceName = bytes.copyOfRange(offset, offset + nameLen).decodeToString(); offset += nameLen
+
+        val idLen = readBigEndianInt(bytes, offset); offset += 4
+        val deviceId = bytes.copyOfRange(offset, offset + idLen).decodeToString(); offset += idLen
+
+        val sampleRate = readBigEndianInt(bytes, offset); offset += 4
+        val channelCount = readBigEndianInt(bytes, offset); offset += 4
+
+        return IosHelloPayload(
+            deviceName = deviceName,
+            deviceId = deviceId,
+            sampleRate = sampleRate,
+            channelCount = channelCount
+        )
+    }
+
+    private fun readBigEndianInt(bytes: ByteArray, offset: Int): Int {
+        return ((bytes[offset].toInt() and 0xFF) shl 24) or
+               ((bytes[offset + 1].toInt() and 0xFF) shl 16) or
+               ((bytes[offset + 2].toInt() and 0xFF) shl 8) or
+               (bytes[offset + 3].toInt() and 0xFF)
+    }
+
+    private suspend fun sendAck() {
+        val ackPayload = ByteArray(IosProtocolConstants.ACK_PAYLOAD_SIZE)
+        ackPayload[0] = 1 // success = true
+        // udpPort = 0 (bytes 1-4), indicating no UDP audio channel, use TCP
+        // msgLen = 0 (bytes 5-8)
+        val ackPacket = encodePacket(IosProtocolConstants.TYPE_ACK, 0, ackPayload)
+        output.writeFully(ackPacket)
+        output.flush()
+        Logger.i("IosConnectionHandler", "Sent ACK (UDP port = 0, TCP-only mode)")
+    }
+
+    private suspend fun sendKeepAlive() {
+        try {
+            val packet = encodePacket(IosProtocolConstants.TYPE_KEEPALIVE, ++sequenceCounter, ByteArray(0))
+            output.writeFully(packet)
+            output.flush()
+        } catch (e: Exception) {
+            Logger.d("IosConnectionHandler", "Failed to send keepalive: ${e.message}")
+        }
+    }
+
+    private fun encodePacket(type: Int, sequence: Int, payload: ByteArray): ByteArray {
+        val packet = ByteArray(IosProtocolConstants.HEADER_SIZE + payload.size)
+        val magic = IosProtocolConstants.MAGIC_HEADER
+        packet[0] = (magic shr 24).toByte()
+        packet[1] = (magic shr 16).toByte()
+        packet[2] = (magic shr 8).toByte()
+        packet[3] = magic.toByte()
+        packet[4] = (type shr 24).toByte()
+        packet[5] = (type shr 16).toByte()
+        packet[6] = (type shr 8).toByte()
+        packet[7] = type.toByte()
+        packet[8] = (payload.size shr 24).toByte()
+        packet[9] = (payload.size shr 16).toByte()
+        packet[10] = (payload.size shr 8).toByte()
+        packet[11] = payload.size.toByte()
+        packet[12] = (sequence shr 24).toByte()
+        packet[13] = (sequence shr 16).toByte()
+        packet[14] = (sequence shr 8).toByte()
+        packet[15] = sequence.toByte()
+        payload.copyInto(packet, IosProtocolConstants.HEADER_SIZE)
+        return packet
+    }
+
+    private suspend fun processReceiveLoop(sampleRate: Int, channelCount: Int) {
+        while (currentCoroutineContext().isActive) {
+            val headerBytes = ByteArray(IosProtocolConstants.HEADER_SIZE)
+            input.readFully(headerBytes)
+
+            val header = parseHeader(headerBytes)
+
+            if (header.magic != IosProtocolConstants.MAGIC_HEADER) {
+                Logger.w("IosConnectionHandler", "Invalid magic: 0x${header.magic.toString(16).uppercase()}, resyncing")
+                continue
+            }
+
+            val payload = if (header.payloadLength > 0) {
+                val payloadBytes = ByteArray(header.payloadLength)
+                input.readFully(payloadBytes)
+                payloadBytes
+            } else {
+                ByteArray(0)
+            }
+
+            when (header.type) {
+                IosProtocolConstants.TYPE_HELLO -> {
+                    Logger.w("IosConnectionHandler", "Received unexpected Hello after handshake, ignoring")
+                }
+                IosProtocolConstants.TYPE_KEEPALIVE -> {
+                    // Client heartbeat, no action needed
+                }
+                IosProtocolConstants.TYPE_DISCONNECT -> {
+                    val reason = if (payload.size > 4) {
+                        val reasonLen = readBigEndianInt(payload, 0)
+                        if (reasonLen > 0 && reasonLen <= payload.size - 4) {
+                            payload.copyOfRange(4, 4 + reasonLen).decodeToString()
+                        } else {
+                            "unknown"
+                        }
+                    } else {
+                        "unknown"
+                    }
+                    Logger.i("IosConnectionHandler", "iOS client disconnected: $reason")
+                    return
+                }
+                IosProtocolConstants.TYPE_AUDIO_FRAME -> {
+                    processAudioFrame(payload, sampleRate, channelCount)
+                }
+                else -> {
+                    Logger.d("IosConnectionHandler", "Unknown message type: ${header.type}")
+                }
+            }
+        }
+    }
+
+    private suspend fun processAudioFrame(payload: ByteArray, defaultSampleRate: Int, defaultChannelCount: Int) {
+        if (payload.size < 24) {
+            Logger.w("IosConnectionHandler", "Audio frame payload too short: ${payload.size} bytes")
+            return
+        }
+
+        var offset = 0
+        offset += 4 // seq (already handled by sequence in header)
+
+        val timestamp = ((payload[offset].toLong() and 0xFF) shl 56) or
+                        ((payload[offset + 1].toLong() and 0xFF) shl 48) or
+                        ((payload[offset + 2].toLong() and 0xFF) shl 40) or
+                        ((payload[offset + 3].toLong() and 0xFF) shl 32) or
+                        ((payload[offset + 4].toLong() and 0xFF) shl 24) or
+                        ((payload[offset + 5].toLong() and 0xFF) shl 16) or
+                        ((payload[offset + 6].toLong() and 0xFF) shl 8) or
+                        (payload[offset + 7].toLong() and 0xFF)
+        offset += 8
+
+        val sampleRate = readBigEndianInt(payload, offset); offset += 4
+        val channelCount = readBigEndianInt(payload, offset); offset += 4
+        val dataLen = readBigEndianInt(payload, offset); offset += 4
+
+        if (dataLen <= 0 || offset + dataLen > payload.size) {
+            Logger.w("IosConnectionHandler", "Audio frame data length invalid: $dataLen")
+            return
+        }
+
+        val pcmData = payload.copyOfRange(offset, offset + dataLen)
+
+        val effectiveSampleRate = if (sampleRate > 0) sampleRate else defaultSampleRate
+        val effectiveChannelCount = if (channelCount > 0) channelCount else defaultChannelCount
+
+        onAudioPacketReceived(
+            AudioPacketMessage(
+                buffer = pcmData,
+                sampleRate = effectiveSampleRate,
+                channelCount = effectiveChannelCount,
+                audioFormat = AudioFormat.PCM_16BIT.value
+            )
+        )
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/IosProtocol.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/IosProtocol.kt
@@ -1,0 +1,36 @@
+package com.lanrhyme.micyou.network
+
+object IosProtocolConstants {
+    const val MAGIC_HEADER = 0x694F5354  // "iOST" in ASCII (big-endian)
+
+    const val TYPE_HELLO = 1
+    const val TYPE_ACK = 2
+    const val TYPE_KEEPALIVE = 3
+    const val TYPE_DISCONNECT = 4
+    const val TYPE_AUDIO_FRAME = 16
+
+    const val HEADER_SIZE = 16
+    const val ACK_PAYLOAD_SIZE = 9 // success(1) + udpPort(4) + msgLen(4)
+}
+
+data class IosPacketHeader(
+    val magic: Int,
+    val type: Int,
+    val payloadLength: Int,
+    val sequence: Int
+)
+
+data class IosHelloPayload(
+    val deviceName: String,
+    val deviceId: String,
+    val sampleRate: Int,
+    val channelCount: Int
+)
+
+data class IosAudioFramePayload(
+    val sequence: Int,
+    val timestamp: Long,
+    val sampleRate: Int,
+    val channelCount: Int,
+    val pcmData: ByteArray
+)

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/IosProtocol.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/IosProtocol.kt
@@ -27,10 +27,29 @@ data class IosHelloPayload(
     val channelCount: Int
 )
 
-data class IosAudioFramePayload(
+class IosAudioFramePayload(
     val sequence: Int,
     val timestamp: Long,
     val sampleRate: Int,
     val channelCount: Int,
     val pcmData: ByteArray
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || other !is IosAudioFramePayload) return false
+        return sequence == other.sequence &&
+                timestamp == other.timestamp &&
+                sampleRate == other.sampleRate &&
+                channelCount == other.channelCount &&
+                pcmData.contentEquals(other.pcmData)
+    }
+
+    override fun hashCode(): Int {
+        var result = sequence
+        result = 31 * result + timestamp.hashCode()
+        result = 31 * result + sampleRate
+        result = 31 * result + channelCount
+        result = 31 * result + pcmData.contentHashCode()
+        return result
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
@@ -248,9 +248,14 @@ class NetworkServer(
         when (magic) {
             IosProtocolConstants.MAGIC_HEADER -> {
                 Logger.i("NetworkServer", "检测到 iOS 协议客户端")
-                // Read remaining 12 bytes of iOS packet header
                 val headerRemaining = ByteArray(12)
-                input.readFully(headerRemaining)
+                try {
+                    input.readFully(headerRemaining)
+                } catch (e: Exception) {
+                    Logger.e("NetworkServer", "Failed to read iOS header", e)
+                    closeAction()
+                    return
+                }
                 val fullHeader = magicBytes + headerRemaining
                 handleIosConnection(input, output, fullHeader, closeAction)
             }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
@@ -14,6 +14,7 @@ import io.ktor.utils.io.jvm.javaio.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.io.EOFException
 import java.net.BindException
 
 /**
@@ -230,6 +231,42 @@ class NetworkServer(
         _state.value = StreamState.Streaming
         _lastError.value = null
 
+        // Read first 4 bytes for protocol detection
+        val magicBytes = ByteArray(4)
+        try {
+            input.readFully(magicBytes)
+        } catch (e: EOFException) {
+            closeAction()
+            return
+        }
+
+        val magic = ((magicBytes[0].toInt() and 0xFF) shl 24) or
+                    ((magicBytes[1].toInt() and 0xFF) shl 16) or
+                    ((magicBytes[2].toInt() and 0xFF) shl 8) or
+                    (magicBytes[3].toInt() and 0xFF)
+
+        when (magic) {
+            IosProtocolConstants.MAGIC_HEADER -> {
+                Logger.i("NetworkServer", "检测到 iOS 协议客户端")
+                // Read remaining 12 bytes of iOS packet header
+                val headerRemaining = ByteArray(12)
+                input.readFully(headerRemaining)
+                val fullHeader = magicBytes + headerRemaining
+                handleIosConnection(input, output, fullHeader, closeAction)
+            }
+            else -> {
+                // Android protocol: prepend read bytes back to stream
+                val androidInput = prependByteReadChannel(input, magicBytes)
+                handleAndroidConnection(androidInput, output, closeAction)
+            }
+        }
+    }
+
+    private suspend fun handleAndroidConnection(
+        input: ByteReadChannel,
+        output: ByteWriteChannel,
+        closeAction: suspend () -> Unit
+    ) {
         val handler = ConnectionHandler(
             input = input,
             output = output,
@@ -241,14 +278,13 @@ class NetworkServer(
             }
         )
         activeHandler = handler
-        
-        // 启动 UDP 连接监控（仅在双协议模式下）
+
         val udpMonitorJob = if (udpHandler != null) {
             serverScope.launch {
                 monitorUdpConnection()
             }
         } else null
-        
+
         try {
             handler.run()
         } finally {
@@ -258,6 +294,52 @@ class NetworkServer(
             Logger.i("NetworkServer", "连接已关闭")
             _state.value = StreamState.Connecting
         }
+    }
+
+    private suspend fun handleIosConnection(
+        input: ByteReadChannel,
+        output: ByteWriteChannel,
+        headerBytes: ByteArray,
+        closeAction: suspend () -> Unit
+    ) {
+        val handler = IosConnectionHandler(
+            input = input,
+            output = output,
+            headerBytes = headerBytes,
+            onAudioPacketReceived = onAudioPacketReceived,
+            onError = { error ->
+                _lastError.value = error
+            }
+        )
+
+        try {
+            handler.run()
+        } finally {
+            closeAction()
+            Logger.i("NetworkServer", "iOS 连接已关闭")
+            _state.value = StreamState.Connecting
+        }
+    }
+
+    private fun prependByteReadChannel(source: ByteReadChannel, prefix: ByteArray): ByteReadChannel {
+        val out = ByteChannel(autoFlush = true)
+        serverScope.launch {
+            try {
+                out.writeFully(prefix)
+                out.flush()
+                val buffer = ByteArray(4096)
+                while (!source.isClosedForRead) {
+                    val read = source.readAvailable(buffer, 0, buffer.size)
+                    if (read == -1) break
+                    if (read > 0) {
+                        out.writeFully(buffer, 0, read)
+                    }
+                }
+            } finally {
+                out.close()
+            }
+        }
+        return out
     }
     
     /**

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.io.EOFException
+import java.io.IOException
 import java.net.BindException
 
 /**
@@ -231,38 +232,44 @@ class NetworkServer(
         _state.value = StreamState.Streaming
         _lastError.value = null
 
-        // Read first 4 bytes for protocol detection
-        val magicBytes = ByteArray(4)
         try {
-            input.readFully(magicBytes)
-        } catch (e: EOFException) {
-            closeAction()
-            return
-        }
-
-        val magic = ((magicBytes[0].toInt() and 0xFF) shl 24) or
-                    ((magicBytes[1].toInt() and 0xFF) shl 16) or
-                    ((magicBytes[2].toInt() and 0xFF) shl 8) or
-                    (magicBytes[3].toInt() and 0xFF)
-
-        when (magic) {
-            IosProtocolConstants.MAGIC_HEADER -> {
-                Logger.i("NetworkServer", "检测到 iOS 协议客户端")
-                val headerRemaining = ByteArray(12)
-                try {
-                    input.readFully(headerRemaining)
-                } catch (e: Exception) {
-                    Logger.e("NetworkServer", "Failed to read iOS header", e)
-                    closeAction()
-                    return
-                }
-                val fullHeader = magicBytes + headerRemaining
-                handleIosConnection(input, output, fullHeader, closeAction)
+            // Read first 4 bytes for protocol detection
+            val magicBytes = ByteArray(4)
+            try {
+                input.readFully(magicBytes)
+            } catch (e: EOFException) {
+                closeAction()
+                return
             }
-            else -> {
-                // Android protocol: prepend read bytes back to stream
-                val androidInput = prependByteReadChannel(input, magicBytes)
-                handleAndroidConnection(androidInput, output, closeAction)
+
+            val magic = ((magicBytes[0].toInt() and 0xFF) shl 24) or
+                        ((magicBytes[1].toInt() and 0xFF) shl 16) or
+                        ((magicBytes[2].toInt() and 0xFF) shl 8) or
+                        (magicBytes[3].toInt() and 0xFF)
+
+            when (magic) {
+                IosProtocolConstants.MAGIC_HEADER -> {
+                    Logger.i("NetworkServer", "检测到 iOS 协议客户端")
+                    val headerRemaining = ByteArray(12)
+                    try {
+                        input.readFully(headerRemaining)
+                    } catch (e: IOException) {
+                        Logger.e("NetworkServer", "Failed to read iOS header", e)
+                        closeAction()
+                        return
+                    }
+                    val fullHeader = magicBytes + headerRemaining
+                    handleIosConnection(input, output, fullHeader, closeAction)
+                }
+                else -> {
+                    // Android protocol: prepend read bytes back to stream
+                    val androidInput = prependByteReadChannel(input, magicBytes)
+                    handleAndroidConnection(androidInput, output, closeAction)
+                }
+            }
+        } finally {
+            if (_state.value == StreamState.Streaming) {
+                _state.value = StreamState.Connecting
             }
         }
     }


### PR DESCRIPTION
## 高层摘要

- 影响范围：中等，新增iOS客户端协议支持，扩展跨平台音频流能力。
- 核心变更：
  - 新增 `IosProtocol.kt` 定义iOS协议常量与数据结构
  - 新增 `IosConnectionHandler.kt` 实现iOS协议握手、心跳、音频帧处理
  - 修改 `NetworkServer.kt` 实现协议自动检测（Magic Header），分发至iOS或Android处理器

## 协议定义 (IosProtocol.kt)

| 常量 | 值 | 说明 |
|------|-----|------|
| MAGIC_HEADER | 0x694F5354 | 协议标识 "iOST" |
| TYPE_HELLO | 1 | 握手 |
| TYPE_ACK | 2 | 确认 |
| TYPE_KEEPALIVE | 3 | 心跳 |
| TYPE_DISCONNECT | 4 | 断开 |
| TYPE_AUDIO_FRAME | 16 | 音频帧 |
| HEADER_SIZE | 16 | 包头固定长度 |

数据结构（大端序）：
- `IosPacketHeader`：magic, type, payloadLength, sequence
- `IosHelloPayload`：deviceName, deviceId, sampleRate, channelCount
- `IosAudioFramePayload`：sequence, timestamp, sampleRate, channelCount, pcmData

## 连接处理 (IosConnectionHandler.kt)

- `run()`：读取完整16字节包头 → 解析Hello → 发送ACK（UDP端口=0，纯TCP模式）→ 启动心跳协程（间隔5秒）→ 进入接收循环
- `processReceiveLoop()`：根据type分发处理 `TYPE_AUDIO_FRAME` 调用 `processAudioFrame()`，解析PCM数据并转换为 `AudioPacketMessage`
- 异常处理：区分正常断开（EOFException）、IO错误、超时

## 协议自动检测 (NetworkServer.kt)

- `handleConnection()` 先读取4字节Magic：
  - 若 `magic == IosProtocolConstants.MAGIC_HEADER` → 继续读取剩余12字节构成完整包头 → 调用 `handleIosConnection()`
  - 否则 → 通过 `prependByteReadChannel()` 将4字节回注入流 → 调用 `handleAndroidConnection()`（原逻辑重构提取）
- 新增 `EOFException` 导入，处理连接断开