### PR TITLE
docs: 相关文档更新

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,14 +44,14 @@ Built with Compose Multiplatform, Material 3, Ktor, and kotlinx-serialization.
 
 - Uses Compose Multiplatform Resources (`composeApp/src/commonMain/composeResources/values*/strings.xml`)
 - Base languages: English (`values/strings.xml`) and Simplified Chinese (`values-zh/strings.xml`)
-- Adding a new language: create `values-xx/strings.xml`, register in `Localization.kt` (`AppLanguage` enum)
+- Adding a new language: create `values-xx/strings.xml`, register in `Localization.kt` (`AppLanguage` enum), codes using ISO 639-1 or IETF BCP 47 standards are recommended
 - Validation: `./gradlew checkLocalization` (blocks commits via pre-commit hook)
 - Install hooks: `./gradlew installGitHooks`
 - PRs should be submitted directly to update translation files, updating both base languages first
 
 ## Environment requirements
 
-- JDK 21 (Liberica distribution used in CI)
+- JDK 21 (Liberica distribution used in CI; other OpenJDK distributions is accepted)
 - Android SDK: compileSdk 36, minSdk 24, targetSdk 36
 - Version is set in `gradle.properties` (`project.version` and `project.version.code`)
 - Optional: `local.properties` for `AIFADIAN_API_TOKEN` / `AIFADIAN_USER_ID` (sponsorship features)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Built with Compose Multiplatform, Material 3, Ktor, and kotlinx-serialization.
 
 ## Environment requirements
 
-- JDK 21 (Liberica distribution used in CI; other OpenJDK distributions is accepted)
+- JDK 21 (Liberica distribution used in CI; other OpenJDK distributions are accepted)
 - Android SDK: compileSdk 36, minSdk 24, targetSdk 36
 - Version is set in `gradle.properties` (`project.version` and `project.version.code`)
 - Optional: `local.properties` for `AIFADIAN_API_TOKEN` / `AIFADIAN_USER_ID` (sponsorship features)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,90 +1,89 @@
-# 贡献者公约
+# Code of Conduct
 
-## 我们的承诺
+## Our Pledge
 
-我们承诺使我们的社区对所有人保持友好、安全且公平。
+We pledge to make our community welcoming, safe, and equitable for all.
 
-我们承诺营造一个尊重并促进每位个体尊严、权利与贡献的环境，无论其种族、民族、种姓、肤色、年龄、体貌特征、神经多样性、残疾状况、生理性别或社会性别、性别认同或表达、性取向、语言、哲学或宗教信仰、国籍或社会出身、社会经济地位、教育程度或其他身份属性。所有真诚参与并遵守本公约者，均享有同等的参与权利。
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
 
-## 受鼓励的行为
 
-虽然各自的社会规范可能有差异，但我们都努力达到这个社区对积极行为的期待。我们也了解，因为文化、背景或母语的不同，别人对我们的言行的解读可能不同于我们的初衷。
+## Encouraged Behaviors
 
-考虑到以上这些，我们承诺以审慎的态度彼此相待，并以践行以下共同价值为行为准则：
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
 
-- 尊重我们社区的宗旨、各项活动及集会方式
-- 以善意与诚实的态度与他人互动
-- 尊重不同的观点与经历
-- 对自己的言行及贡献负责
-- 以得体的方式给予并接受建设性意见
-- 承诺在造成伤害时进行弥补
-- 采取其他有益于社区福祉的行为
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
 
-## 受限制的行为
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
 
-我们同意在社区内限制以下行为。出现这些行为、威胁实施这些行为、或宣传这些行为，均视为违反本行为准则。
 
-- **骚扰：** 在明确表达界限后仍侵犯这些界限，或在被清楚要求停止后，仍进行不必要的个人关注。
-- **人身攻击：** 针对社区成员或群体发表侮辱、贬低或带有蔑视性的言论。
-- **刻板印象或歧视：** 基于无法改变的身份或特征，来评判他人的性格或行为。
-- **性化：** 做出在社区场景或宗旨下普遍认为不恰当的亲密举动。
-- **侵犯保密性：** 未经允许分享或利用他人的个人或隐私信息。
-- **危害行为：** 对任何人或群体实施、煽动或威胁施加暴力及其他伤害。
-- **其他威胁社区福祉的行为。**
+## Restricted Behaviors
 
-### 其他限制行为
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
 
-- **虚假身份：** 出于任何原因冒充他人，或假扮他人以规避监管措施。
-- **未正确标明来源：** 未正确标明所贡献内容的来源。
-- **宣传材料：** 以不符合社区规范的方式分享营销或其他商业内容。
-- **不当传播：** 未能以负责任的方式呈现包含、链接或描述任何其他受限制行为的内容。
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
 
-## 通报问题
+### Other Restrictions
 
-即使社区成员之间尽其所能地合作，也仍然可能发生矛盾。并不是所有冲突都涉及违反行为准则，本准则旨在强化受鼓励的行为与规范，它们有助于预防冲突并将伤害降到最低。
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
 
-当事件发生时，及时报告非常重要。要报告可能的违规行为，请在 GitHub 上创建 Issue 或直接联系项目维护者。
 
-社区管理员会严肃对待违规报告，并尽力及时回应。将对所有违反行为准则的报告展开调查，方式包括查阅消息、日志及录音，或访谈证人及其他相关参与人。社区管理员在优先保障安全与保密性的前提下，会尽可能保持调查与执行过程的透明度。为践行这些价值观，执行措施会在涉事各方的私下环境中进行，但如经各方同意，将事件通报全体社区也可以作为解决方案的一部分。
+## Reporting an Issue
 
-## 处理与弥补伤害
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
 
-若社区管理员经调查确认存在违反此行为准则的行为，将参照以下"分级处理"机制，根据事件对相关人员及社区整体造成的影响程度，确定最适宜的伤害弥补方案。根据违规严重程度，可跳过较低级别的处理措施。
+When an incident does occur, it is important to report it promptly. To report a possible violation, please create an issue at GitHub or contact the project owner directly.
 
-### 警告
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
 
-- **事件：** 单次或连续违规行为
-- **后果：** 社区管理员将发出书面私信警告
-- **弥补：** 弥补的方式如书面私下致歉、坦承自己的责任，或主动确认清楚今后该如何做才符合期待。
 
-### 暂时限制活动
+## Addressing and Repairing Harm
 
-- **事件：** 重复造成先前已被警告的违规，或首次发生略为严重的违规行为。
-- **后果：** 发出私下的书面警告，并设定一个有时间限制的冷静期，旨在强调事态的严重性，并让相关社区成员有时间消化与处理该事件。冷静期可能是限制在特定的交流渠道，或限制与特定社区成员的互动。
-- **弥补：** 修复的方式可能包括道歉、利用冷静期反思自身行为及其影响，以及充分意识到在冷静期结束后如何重新进入社区空间。
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
 
-### 暂时停权
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
 
-- **事件：** 出现社区管理员已多次警告后仍然重复违规的模式，或一次严重违规行为。
-- **后果：** 发出私下的书面警告，并附上恢复权限所需满足的条件。通常，临时停权旨在给予被停权者时间，反思其行为以及考虑可能的改正措施。
-- **弥补：** 弥补的条件包括尊重停权的意旨、达成恢复权限的指定条件，以及充分认识到在停权解除后如何重新融入社区。
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
 
-### 永久封禁
 
-- **事件：** 多次违反行为准则，且其他分级处理措施均未能解决问题，或发生严重到社区管理员认定无法在该成员继续存在的情况下保障社区安全的违规行为。
-- **后果：** 撤销其对所有社区空间、工具及交流渠道的访问权限。一般而言，永久封禁应极少使用，必须有充分且有力的理由，且仅在其他弥补手段未能改变其行为时才作为最后手段实施。
-- **弥补：** 此类严重情形下，不存在可行的弥补途径。
+## Scope
 
-本分级处理措施旨在作为指导方针，并不限制社区管理者在符合社区最大利益的前提下，运用其自主裁量权与判断力。
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
-## 施行范围
 
-本行为准则适用于社区所有空间，同时也适用于个人在公共场合或其他场合正式代表社区的情况。代表社区的行为包括但不限于：使用官方电子邮件地址；通过官方社交媒体账号发布内容；作为指定代表出席线上或线下活动。
+## Attribution
 
-## 贡献归属
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
 
-本行为准则改编自 [贡献者公约](https://www.contributor-covenant.org) 3.0 版，该公约永久可在此查阅：<https://www.contributor-covenant.org/version/3/0/>。
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
 
-贡献者公约 由 [Organization for Ethical Source](https://ethicalsource.dev) 负责维护，并以 [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) 许可协议发布。
-
-关于 贡献者公约 的常见问题解答，请参阅：<https://www.contributor-covenant.org/faq>。各语言版本译文请见：<https://www.contributor-covenant.org/translations>。更多执行与社区指南资源请见：<https://www.contributor-covenant.org/resources>。本分级措施的灵感来源于 [Mozilla 行为准则团队](https://github.com/mozilla/inclusion) 的工作。
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,14 +41,14 @@ This project is built using Kotlin Multiplatform.
 ```
 
 **macOS DMG package:**
-~~~bash
-./gradlew :composeApp:packageDmg 
-~~~
+```bash
+./gradlew :composeApp:packageDmg
+```
 
 **No-JRE package:**
-~~~bash
+```bash
 ./gradlew :composeApp:packageNoJreAll
-~~~
+```
 
 ## Internationalization (i18n)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,16 @@ This project is built using Kotlin Multiplatform.
 ./gradlew :composeApp:packageRpm
 ```
 
+**macOS DMG package:**
+~~~bash
+./gradlew :composeApp:packageDmg 
+~~~
+
+**No-JRE package:**
+~~~bash
+./gradlew :composeApp:packageNoJreAll
+~~~
+
 ## Internationalization (i18n)
 
 MicYou uses Compose Multiplatform Resources for localization. All user-facing strings are stored in `strings.xml` files. We welcome contributions to translate MicYou into your language!
@@ -59,7 +69,7 @@ cd MicYou
 mkdir -p composeApp/src/commonMain/composeResources/values-xx
 cp composeApp/src/commonMain/composeResources/values/strings.xml composeApp/src/commonMain/composeResources/values-xx/strings.xml
 ```
-Replace `xx` with your language code (e.g., `fr` for French, `es` for Spanish).
+Replace `xx` with your language code (e.g., `fr` for French, `es` for Spanish, according to ISO 639-1 or other related standards like IETF BCP 47).
 
 3. Edit the new `strings.xml` file and translate all string values while keeping the keys unchanged:
 ```xml

--- a/CONTRIBUTING_zh-cn.md
+++ b/CONTRIBUTING_zh-cn.md
@@ -41,14 +41,14 @@
 ```
 
 **macOS DMG 包:**
-~~~bash
-./gradlew :composeApp:packageDmg 
-~~~
+```bash
+./gradlew :composeApp:packageDmg
+```
 
 **无 JRE 包:**
-~~~bash
+```bash
 ./gradlew :composeApp:packageNoJreAll
-~~~
+```
 
 ## 国际化（i18n）
 

--- a/CONTRIBUTING_zh-cn.md
+++ b/CONTRIBUTING_zh-cn.md
@@ -40,6 +40,16 @@
 ./gradlew :composeApp:packageRpm
 ```
 
+**macOS DMG 包:**
+~~~bash
+./gradlew :composeApp:packageDmg 
+~~~
+
+**无 JRE 包:**
+~~~bash
+./gradlew :composeApp:packageNoJreAll
+~~~
+
 ## 国际化（i18n）
 
 MicYou 使用 Compose Multiplatform Resources 进行本地化。所有用户可见的字符串存储在 `strings.xml` 文件中。我们欢迎贡献者将 MicYou 翻译成您的母语！
@@ -59,7 +69,7 @@ cd MicYou
 mkdir -p composeApp/src/commonMain/composeResources/values-xx
 cp composeApp/src/commonMain/composeResources/values/strings.xml composeApp/src/commonMain/composeResources/values-xx/strings.xml
 ```
-将 `xx` 替换为您的语言代码（例如，法语为 `fr`，西班牙语为 `es`）。
+将 `xx` 替换为您的语言代码（例如，法语为 `fr`，西班牙语为 `es`，基于 ISO 639-1 或其他相关标准，例如 IETF BCP 47）。
 
 3. 编辑新的 `strings.xml` 文件，翻译所有字符串值，同时保持键不变：
 ```xml

--- a/CONTRIBUTING_zh-tw.md
+++ b/CONTRIBUTING_zh-tw.md
@@ -41,14 +41,14 @@
 ```
 
 **macOS DMG 套件:**
-~~~bash
-./gradlew :composeApp:packageDmg 
-~~~
+```bash
+./gradlew :composeApp:packageDmg
+```
 
 **不含 JRE 套件:**
-~~~bash
+```bash
 ./gradlew :composeApp:packageNoJreAll
-~~~
+```
 
 ## 國際化（i18n）
 

--- a/CONTRIBUTING_zh-tw.md
+++ b/CONTRIBUTING_zh-tw.md
@@ -40,6 +40,16 @@
 ./gradlew :composeApp:packageRpm
 ```
 
+**macOS DMG 套件:**
+~~~bash
+./gradlew :composeApp:packageDmg 
+~~~
+
+**不含 JRE 套件:**
+~~~bash
+./gradlew :composeApp:packageNoJreAll
+~~~
+
 ## 國際化（i18n）
 
 MicYou 使用 Compose Multiplatform Resources 進行本地化。所有使用者可見的字串儲存在 `strings.xml` 檔案中。我們歡迎貢獻者將 MicYou 翻譯成您的母語！
@@ -59,7 +69,7 @@ cd MicYou
 mkdir -p composeApp/src/commonMain/composeResources/values-xx
 cp composeApp/src/commonMain/composeResources/values/strings.xml composeApp/src/commonMain/composeResources/values-xx/strings.xml
 ```
-將 `xx` 替換為您的語言代碼（例如，法語為 `fr`，西班牙語為 `es`）。
+將 `xx` 替換為您的語言代碼（例如，法語為 `fr`，西班牙語為 `es`，基於 ISO 639-1 或其他相關標準，如 IETF BCP 47）。
 
 3. 編輯新的 `strings.xml` 檔案，翻譯所有字串值，同時保持鍵不變：
 ```xml


### PR DESCRIPTION
# Summary:

- `CODE_OF_CONDUCT.md`: 使用英语替代中文，依旧套用 Contributor Covenant 3.0 Code of Conduct
- `CONTRIBUTING**.md`: 强调语言代码最好遵循 ISO 639-1 或 IETF BCP 47 标准，同时补充 macOS 构建与 No-JRE 构建指南
- `AGENTS.md`: 语言代码标准遵循强调，弱化对其他 OpenJDK 分支限制