### PR TITLE
feat(audio): add BlackHole virtual audio device support for macOS

### DIFF
--- a/tauri-app/crates/micyou-audio/src/dsp.rs
+++ b/tauri-app/crates/micyou-audio/src/dsp.rs
@@ -657,9 +657,10 @@ impl DspProcessor {
         let frame_count = self.accum_buffer.len() / samples_per_frame;
 
         if frame_count == 0 {
-            // Not enough data for a full frame yet — pass through unprocessed
-            // to avoid silence gaps. The accum_buffer retains the samples for next call.
-            return (raw_rms, raw_rms);
+            // Not enough data for even one frame, output silence to avoid duplication
+            // since these samples are retained in accum_buffer for the next call.
+            data.iter_mut().for_each(|s| *s = 0.0);
+            return (raw_rms, 0.0);
         }
 
         let process_count = frame_count * samples_per_frame;

--- a/tauri-app/crates/micyou-audio/src/dsp.rs
+++ b/tauri-app/crates/micyou-audio/src/dsp.rs
@@ -657,9 +657,9 @@ impl DspProcessor {
         let frame_count = self.accum_buffer.len() / samples_per_frame;
 
         if frame_count == 0 {
-            // Not enough data for even one frame, output silence
-            data.iter_mut().for_each(|s| *s = 0.0);
-            return (raw_rms, 0.0);
+            // Not enough data for a full frame yet — pass through unprocessed
+            // to avoid silence gaps. The accum_buffer retains the samples for next call.
+            return (raw_rms, raw_rms);
         }
 
         let process_count = frame_count * samples_per_frame;

--- a/tauri-app/crates/micyou-audio/src/engine.rs
+++ b/tauri-app/crates/micyou-audio/src/engine.rs
@@ -131,7 +131,7 @@ impl AudioOutputManager {
             }
             matched_device.or_else(|| host.default_output_device())
         } else {
-            // Auto-detect VB-CABLE on Windows if default
+            // Auto-detect virtual audio devices by platform
             #[cfg(target_os = "windows")]
             {
                 let mut cable_device = None;
@@ -147,7 +147,22 @@ impl AudioOutputManager {
                 }
                 cable_device.or_else(|| host.default_output_device())
             }
-            #[cfg(not(target_os = "windows"))]
+            #[cfg(target_os = "macos")]
+            {
+                let mut blackhole_device = None;
+                if let Ok(devices) = host.output_devices() {
+                    for dev in devices {
+                        if let Ok(name) = dev.name() {
+                            if name.to_lowercase().contains("blackhole") {
+                                blackhole_device = Some(dev);
+                                break;
+                            }
+                        }
+                    }
+                }
+                blackhole_device.or_else(|| host.default_output_device())
+            }
+            #[cfg(not(any(target_os = "windows", target_os = "macos")))]
             {
                 host.default_output_device()
             }

--- a/tauri-app/crates/micyou-audio/src/engine.rs
+++ b/tauri-app/crates/micyou-audio/src/engine.rs
@@ -43,8 +43,8 @@ impl RubatoResampler {
             return input.to_vec();
         }
 
-        // Zero out the input buffer to avoid stale data from previous calls
-        for frame in 0..self.chunk_size {
+        // Zero out only the unused part of the input buffer to avoid stale data
+        for frame in in_frames..self.chunk_size {
             for ch in 0..channels {
                 self.input_buffer.write_sample(ch, frame, &0.0);
             }

--- a/tauri-app/crates/micyou-audio/src/engine.rs
+++ b/tauri-app/crates/micyou-audio/src/engine.rs
@@ -43,6 +43,13 @@ impl RubatoResampler {
             return input.to_vec();
         }
 
+        // Zero out the input buffer to avoid stale data from previous calls
+        for frame in 0..self.chunk_size {
+            for ch in 0..channels {
+                self.input_buffer.write_sample(ch, frame, &0.0);
+            }
+        }
+
         // Fill the pre-allocated input buffer
         for (i, &sample) in input.iter().enumerate() {
             let frame = i / channels;
@@ -180,9 +187,9 @@ impl AudioOutputManager {
             self.resampler = None;
         }
 
-        // Initialize a ring buffer for ~200ms of audio (reduced from 1s for lower latency)
-        let buffer_size = (self.device_sample_rate as usize * self.device_channels) / 5;
-        let ring_buffer = HeapRb::<f32>::new(buffer_size.max(4096));
+        // Initialize a ring buffer for ~400ms of audio
+        let buffer_size = (self.device_sample_rate as usize * self.device_channels * 2) / 5;
+        let ring_buffer = HeapRb::<f32>::new(buffer_size.max(8192));
         let (producer, mut consumer) = ring_buffer.split();
 
         self.producer = Some(producer);

--- a/tauri-app/src-tauri/src/blackhole.rs
+++ b/tauri-app/src-tauri/src/blackhole.rs
@@ -1,0 +1,283 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BlackHoleStatus {
+    pub installed: bool,
+    pub switch_audio_source: bool,
+    pub device_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BlackHoleResult {
+    pub success: bool,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct AudioDevice {
+    id: String,
+    name: String,
+}
+
+fn is_blackhole_name(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    lower.contains("blackhole")
+}
+
+/// Check if BlackHole is installed by scanning cpal output devices
+#[cfg(target_os = "macos")]
+pub fn is_installed() -> bool {
+    use cpal::traits::{DeviceTrait, HostTrait};
+
+    let host = cpal::default_host();
+    if let Ok(devices) = host.output_devices() {
+        for dev in devices {
+            if let Ok(name) = dev.name() {
+                if is_blackhole_name(&name) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn is_installed() -> bool {
+    false
+}
+
+/// Get the name of the first BlackHole device found
+#[cfg(target_os = "macos")]
+fn find_blackhole_device_name() -> Option<String> {
+    use cpal::traits::{DeviceTrait, HostTrait};
+
+    let host = cpal::default_host();
+    if let Ok(devices) = host.output_devices() {
+        for dev in devices {
+            if let Ok(name) = dev.name() {
+                if is_blackhole_name(&name) {
+                    return Some(name);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(not(target_os = "macos"))]
+fn find_blackhole_device_name() -> Option<String> {
+    None
+}
+
+/// Check if SwitchAudioSource CLI tool is installed
+#[cfg(target_os = "macos")]
+pub async fn is_switch_audio_source_installed() -> bool {
+    tokio::process::Command::new("which")
+        .arg("SwitchAudioSource")
+        .output()
+        .await
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub async fn is_switch_audio_source_installed() -> bool {
+    false
+}
+
+/// Get the current default input device via SwitchAudioSource
+#[cfg(target_os = "macos")]
+async fn get_current_input_device() -> Option<AudioDevice> {
+    let output = tokio::process::Command::new("SwitchAudioSource")
+        .args(["-c", "-t", "input", "-f", "json"])
+        .output()
+        .await
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let json_str = String::from_utf8_lossy(&output.stdout);
+    parse_device_json(&json_str)
+}
+
+/// Set the default input device via SwitchAudioSource
+#[cfg(target_os = "macos")]
+async fn set_default_input_device(device_id: &str) -> bool {
+    tokio::process::Command::new("SwitchAudioSource")
+        .args(["-t", "input", "-i", device_id])
+        .output()
+        .await
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Find BlackHole device in the input device list
+#[cfg(target_os = "macos")]
+async fn find_blackhole_input_device() -> Option<AudioDevice> {
+    let output = tokio::process::Command::new("SwitchAudioSource")
+        .args(["-a", "-t", "input", "-f", "json"])
+        .output()
+        .await
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let json_str = String::from_utf8_lossy(&output.stdout);
+    let content = json_str.trim().trim_start_matches('[').trim_end_matches(']');
+
+    for obj_str in content.split("},").map(|s| {
+        if s.contains('}') {
+            s.to_string()
+        } else {
+            format!("{}}}", s)
+        }
+    }) {
+        if let Some(device) = parse_device_json_single(&obj_str) {
+            if is_blackhole_name(&device.name) {
+                return Some(device);
+            }
+        }
+    }
+    None
+}
+
+fn parse_device_json(json: &str) -> Option<AudioDevice> {
+    let content = json.trim().trim_start_matches('[').trim_end_matches(']');
+    parse_device_json_single(content)
+}
+
+fn parse_device_json_single(obj_str: &str) -> Option<AudioDevice> {
+    let id = extract_json_field(obj_str, "id")?;
+    let name = extract_json_field(obj_str, "name")?;
+    Some(AudioDevice { id, name })
+}
+
+fn extract_json_field(json: &str, field: &str) -> Option<String> {
+    let needle = format!("\"{}\"", field);
+    let start = json.find(&needle)? + needle.len();
+    let rest = &json[start..];
+    let colon = rest.find(':')?;
+    let after_colon = rest[colon + 1..].trim_start();
+    if !after_colon.starts_with('"') {
+        return None;
+    }
+    let value_start = 1;
+    let value_end = after_colon[value_start..].find('"')?;
+    Some(after_colon[value_start..value_start + value_end].to_string())
+}
+
+// State for saving/restoring the original input device
+use std::sync::Mutex;
+
+static ORIGINAL_INPUT_DEVICE: Mutex<Option<AudioDevice>> = Mutex::new(None);
+
+/// Get full BlackHole status for the frontend
+#[tauri::command]
+pub async fn check_blackhole() -> Result<BlackHoleStatus, String> {
+    let installed = is_installed();
+    let switch_audio = is_switch_audio_source_installed().await;
+    let device_name = if installed {
+        find_blackhole_device_name()
+    } else {
+        None
+    };
+
+    Ok(BlackHoleStatus {
+        installed,
+        switch_audio_source: switch_audio,
+        device_name,
+    })
+}
+
+/// Set BlackHole as the system default input device, saving the original
+#[tauri::command]
+pub async fn set_blackhole_as_input() -> Result<BlackHoleResult, String> {
+    if !is_installed() {
+        return Ok(BlackHoleResult {
+            success: false,
+            message: Some("BlackHole is not installed".to_string()),
+        });
+    }
+
+    if !is_switch_audio_source_installed().await {
+        return Ok(BlackHoleResult {
+            success: false,
+            message: Some(
+                "SwitchAudioSource is not installed. Install with: brew install switchaudio-osx"
+                    .to_string(),
+            ),
+        });
+    }
+
+    // Save current input device before switching
+    if let Some(current) = get_current_input_device().await {
+        if let Ok(mut orig) = ORIGINAL_INPUT_DEVICE.lock() {
+            *orig = Some(current);
+        }
+    }
+
+    // Find BlackHole in input devices
+    let blackhole = find_blackhole_input_device().await;
+    let device = match blackhole {
+        Some(d) => d,
+        None => {
+            return Ok(BlackHoleResult {
+                success: false,
+                message: Some("BlackHole input device not found".to_string()),
+            });
+        }
+    };
+
+    let success = set_default_input_device(&device.id).await;
+    Ok(BlackHoleResult {
+        success,
+        message: if success {
+            Some(format!("Set default input to: {}", device.name))
+        } else {
+            Some("Failed to set default input device".to_string())
+        },
+    })
+}
+
+/// Restore the original input device
+#[tauri::command]
+pub async fn restore_input_device() -> Result<BlackHoleResult, String> {
+    let original = {
+        ORIGINAL_INPUT_DEVICE
+            .lock()
+            .ok()
+            .and_then(|mut guard| guard.take())
+    };
+
+    let device = match original {
+        Some(d) => d,
+        None => {
+            return Ok(BlackHoleResult {
+                success: true,
+                message: Some("No saved input device to restore".to_string()),
+            });
+        }
+    };
+
+    if !is_switch_audio_source_installed().await {
+        return Ok(BlackHoleResult {
+            success: false,
+            message: Some("SwitchAudioSource is not installed".to_string()),
+        });
+    }
+
+    let success = set_default_input_device(&device.id).await;
+    Ok(BlackHoleResult {
+        success,
+        message: if success {
+            Some(format!("Restored input to: {}", device.name))
+        } else {
+            Some("Failed to restore input device".to_string())
+        },
+    })
+}

--- a/tauri-app/src-tauri/src/blackhole.rs
+++ b/tauri-app/src-tauri/src/blackhole.rs
@@ -70,15 +70,35 @@ fn find_blackhole_device_name() -> Option<String> {
     None
 }
 
+/// Get the path to SwitchAudioSource, checking Homebrew paths on macOS
+#[cfg(target_os = "macos")]
+fn get_switch_audio_source_cmd() -> std::path::PathBuf {
+    let paths = [
+        "/opt/homebrew/bin/SwitchAudioSource",
+        "/usr/local/bin/SwitchAudioSource",
+    ];
+    for path in &paths {
+        if std::path::Path::new(path).exists() {
+            return std::path::PathBuf::from(path);
+        }
+    }
+    std::path::PathBuf::from("SwitchAudioSource")
+}
+
 /// Check if SwitchAudioSource CLI tool is installed
 #[cfg(target_os = "macos")]
 pub async fn is_switch_audio_source_installed() -> bool {
-    tokio::process::Command::new("which")
-        .arg("SwitchAudioSource")
-        .output()
-        .await
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    let cmd = get_switch_audio_source_cmd();
+    if cmd.is_absolute() {
+        cmd.exists()
+    } else {
+        tokio::process::Command::new("which")
+            .arg("SwitchAudioSource")
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -89,7 +109,8 @@ pub async fn is_switch_audio_source_installed() -> bool {
 /// Get the current default input device via SwitchAudioSource
 #[cfg(target_os = "macos")]
 async fn get_current_input_device() -> Option<AudioDevice> {
-    let output = tokio::process::Command::new("SwitchAudioSource")
+    let cmd = get_switch_audio_source_cmd();
+    let output = tokio::process::Command::new(&cmd)
         .args(["-c", "-t", "input", "-f", "json"])
         .output()
         .await
@@ -106,7 +127,8 @@ async fn get_current_input_device() -> Option<AudioDevice> {
 /// Set the default input device via SwitchAudioSource
 #[cfg(target_os = "macos")]
 async fn set_default_input_device(device_id: &str) -> bool {
-    tokio::process::Command::new("SwitchAudioSource")
+    let cmd = get_switch_audio_source_cmd();
+    tokio::process::Command::new(&cmd)
         .args(["-t", "input", "-i", device_id])
         .output()
         .await
@@ -117,7 +139,8 @@ async fn set_default_input_device(device_id: &str) -> bool {
 /// Find BlackHole device in the input device list
 #[cfg(target_os = "macos")]
 async fn find_blackhole_input_device() -> Option<AudioDevice> {
-    let output = tokio::process::Command::new("SwitchAudioSource")
+    let cmd = get_switch_audio_source_cmd();
+    let output = tokio::process::Command::new(&cmd)
         .args(["-a", "-t", "input", "-f", "json"])
         .output()
         .await
@@ -214,10 +237,17 @@ pub async fn set_blackhole_as_input() -> Result<BlackHoleResult, String> {
         });
     }
 
-    // Save current input device before switching
-    if let Some(current) = get_current_input_device().await {
-        if let Ok(mut orig) = ORIGINAL_INPUT_DEVICE.lock() {
-            *orig = Some(current);
+    // Save current input device before switching, only if we haven't saved one already
+    {
+        let already_saved = ORIGINAL_INPUT_DEVICE.lock().map(|g| g.is_some()).unwrap_or(false);
+        if !already_saved {
+            if let Some(current) = get_current_input_device().await {
+                if let Ok(mut orig) = ORIGINAL_INPUT_DEVICE.lock() {
+                    if orig.is_none() {
+                        *orig = Some(current);
+                    }
+                }
+            }
         }
     }
 
@@ -244,40 +274,53 @@ pub async fn set_blackhole_as_input() -> Result<BlackHoleResult, String> {
     })
 }
 
-/// Restore the original input device
-#[tauri::command]
-pub async fn restore_input_device() -> Result<BlackHoleResult, String> {
+/// Restore the original input device (internal logic, callable from stop_server)
+pub async fn do_restore_input_device() -> Result<(), String> {
     let original = {
         ORIGINAL_INPUT_DEVICE
             .lock()
             .ok()
-            .and_then(|mut guard| guard.take())
+            .and_then(|guard| (*guard).clone())
     };
 
     let device = match original {
         Some(d) => d,
-        None => {
-            return Ok(BlackHoleResult {
-                success: true,
-                message: Some("No saved input device to restore".to_string()),
-            });
-        }
+        None => return Ok(()),
     };
 
     if !is_switch_audio_source_installed().await {
-        return Ok(BlackHoleResult {
-            success: false,
-            message: Some("SwitchAudioSource is not installed".to_string()),
-        });
+        return Err("SwitchAudioSource is not installed".to_string());
     }
 
     let success = set_default_input_device(&device.id).await;
-    Ok(BlackHoleResult {
-        success,
-        message: if success {
-            Some(format!("Restored input to: {}", device.name))
-        } else {
-            Some("Failed to restore input device".to_string())
-        },
-    })
+    if success {
+        if let Ok(mut guard) = ORIGINAL_INPUT_DEVICE.lock() {
+            *guard = None;
+        }
+    }
+    // On failure, keep the device in ORIGINAL_INPUT_DEVICE for retry
+    Ok(())
+}
+
+/// Restore the original input device (Tauri command)
+#[tauri::command]
+pub async fn restore_input_device() -> Result<BlackHoleResult, String> {
+    let has_saved = ORIGINAL_INPUT_DEVICE.lock().map(|g| g.is_some()).unwrap_or(false);
+    if !has_saved {
+        return Ok(BlackHoleResult {
+            success: true,
+            message: Some("No saved input device to restore".to_string()),
+        });
+    }
+
+    match do_restore_input_device().await {
+        Ok(()) => Ok(BlackHoleResult {
+            success: true,
+            message: Some("Restored input device".to_string()),
+        }),
+        Err(e) => Ok(BlackHoleResult {
+            success: false,
+            message: Some(e),
+        }),
+    }
 }

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod adb_manager;
 pub mod stats;
 pub mod tray;
 pub mod vbcable;
+pub mod blackhole;
 pub mod jitter_buffer;
 
 use tauri::{Emitter, AppHandle, Manager, State};
@@ -650,6 +651,9 @@ pub fn run() {
             get_web_status,
             vbcable::check_vbcable,
             vbcable::install_vbcable,
+            blackhole::check_blackhole,
+            blackhole::set_blackhole_as_input,
+            blackhole::restore_input_device,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -451,6 +451,11 @@ async fn stop_server(app: AppHandle, state: State<'_, ServerState>) -> Result<St
     let mut token_lock = state.cancel_token.lock().await;
     if let Some(token) = token_lock.take() {
         token.cancel();
+        // Restore the original input device on macOS (BlackHole cleanup)
+        #[cfg(target_os = "macos")]
+        {
+            let _ = blackhole::do_restore_input_device().await;
+        }
         let _ = app.emit("server-stopped", ());
         Ok("Server stopped".to_string())
     } else {

--- a/tauri-app/src/features/connection/composables/useServer.ts
+++ b/tauri-app/src/features/connection/composables/useServer.ts
@@ -83,12 +83,18 @@ export function useServer(options?: { audioLevel?: Ref<number>; isMuted?: Ref<bo
     }
   }
 
+  const isMacOS = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform || navigator.userAgent) && !/iPhone|iPad|iPod/.test(navigator.userAgent);
+
   const toggleStreaming = async () => {
     if (serverState.value !== 'idle') {
       try {
         await invoke('stop_server');
         serverState.value = 'idle';
         if (options?.audioLevel) options.audioLevel.value = 0;
+        // Restore original input device on macOS when using BlackHole
+        if (isMacOS) {
+          try { await invoke('restore_input_device'); } catch {}
+        }
       } catch (e) {
         console.error(e);
       }
@@ -103,6 +109,10 @@ export function useServer(options?: { audioLevel?: Ref<number>; isMuted?: Ref<bo
           outputDevice: (outputDevice.value && outputDevice.value !== 'auto' && outputDevice.value !== 'default') ? outputDevice.value : null
         });
         serverState.value = 'connecting';
+        // Auto-switch to BlackHole input on macOS
+        if (isMacOS) {
+          try { await invoke('set_blackhole_as_input'); } catch {}
+        }
         if (connectionMode.value === 'usb') {
           const result = await invoke<{ type: string; devices?: { serial: string; state: string; description: string }[] }>('enable_usb_mode', { port: Number(serverPort.value), deviceSerial: null });
           if (result.type === 'MultipleDevices') {

--- a/tauri-app/src/features/settings/components/SettingsDialog.vue
+++ b/tauri-app/src/features/settings/components/SettingsDialog.vue
@@ -181,13 +181,41 @@
                   </SelectContent>
                 </Select>
               </div>
-              <p v-if="settings.audioDevice === 'auto' || settings.audioDevice.includes('CABLE Input')" class="text-xs text-green-400 font-medium">
+              <p v-if="settings.audioDevice === 'auto' || settings.audioDevice.includes('CABLE Input') || settings.audioDevice.toLowerCase().includes('blackhole')" class="text-xs text-green-400 font-medium">
                 {{ $t('settings.audioOutput.routingActive') }}
               </p>
             </div>
 
-            <!-- VB-CABLE Management -->
-            <div class="bg-surface-bright rounded-2xl p-4 space-y-4 shadow-sm">
+            <!-- Virtual Audio Device Management (macOS: BlackHole, Windows: VB-Cable) -->
+            <div v-if="isMacOS" class="bg-surface-bright rounded-2xl p-4 space-y-4 shadow-sm">
+              <div class="flex items-center justify-between">
+                <h4 class="font-bold text-on-surface text-lg">BlackHole</h4>
+                <span class="text-xs font-medium px-2 py-1 rounded-md" :class="hasBlackHole ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'">
+                  {{ hasBlackHole ? $t('settings.blackhole.installed') : $t('settings.blackhole.notDetected') }}
+                </span>
+              </div>
+              <p class="text-xs text-on-surface-variant">
+                {{ $t('settings.blackhole.desc') }}
+              </p>
+              <div v-if="blackholeStatus.switch_audio_source" class="text-xs text-on-surface-variant flex items-center gap-1.5">
+                <span class="inline-block w-1.5 h-1.5 rounded-full bg-green-400"></span>
+                SwitchAudioSource {{ $t('settings.blackhole.available') }}
+              </div>
+              <div v-else-if="hasBlackHole" class="text-xs text-orange-400 flex items-center gap-1.5">
+                <span class="inline-block w-1.5 h-1.5 rounded-full bg-orange-400"></span>
+                {{ $t('settings.blackhole.switchAudioSourceMissing') }}
+              </div>
+              <div v-if="!hasBlackHole" class="space-y-2">
+                <p class="text-xs text-on-surface-variant font-mono bg-surface-container rounded-lg p-3 select-all">brew install blackhole-2ch</p>
+                <button
+                  @click="openBlackHoleDownload"
+                  class="w-full py-2 bg-surface-variant hover:bg-surface-variant/80 rounded-xl text-sm font-bold flex items-center justify-center gap-2 transition-colors"
+                >
+                  <Download class="w-4 h-4" /> {{ $t('settings.blackhole.download') }}
+                </button>
+              </div>
+            </div>
+            <div v-else class="bg-surface-bright rounded-2xl p-4 space-y-4 shadow-sm">
               <div class="flex items-center justify-between">
                 <h4 class="font-bold text-on-surface text-lg">{{ $t('settings.vbcable.title') }}</h4>
                 <span class="text-xs font-medium px-2 py-1 rounded-md" :class="hasVBCable ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'">
@@ -681,9 +709,19 @@ const settings = reactive({
 
 const audioDevices = ref<string[]>([]);
 const hasVBCable = computed(() => audioDevices.value.some(d => d.toLowerCase().includes('cable')));
+const hasBlackHole = computed(() => audioDevices.value.some(d => d.toLowerCase().includes('blackhole')));
+const isMacOS = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform || navigator.userAgent) && !/iPhone|iPad|iPod/.test(navigator.userAgent);
 const vbcableInstalling = ref(false);
 const vbcableInstallProgress = ref('');
 let unlistenVbcableProgress: UnlistenFn | null = null;
+
+interface BlackHoleStatus {
+  installed: boolean;
+  switch_audio_source: boolean;
+  device_name: string | null;
+}
+const blackholeStatus = ref<BlackHoleStatus>({ installed: false, switch_audio_source: false, device_name: null });
+const blackholeChecking = ref(false);
 const audioLevel = ref(0);
 let unlistenLevel: UnlistenFn | null = null;
 let unlistenSpectrum: UnlistenFn | null = null;
@@ -824,6 +862,22 @@ function openVBCableDownload() {
   window.open('https://vb-audio.com/Cable/', '_blank');
 }
 
+function openBlackHoleDownload() {
+  window.open('https://github.com/ExistentialAudio/BlackHole', '_blank');
+}
+
+async function checkBlackHoleStatus() {
+  if (!isMacOS) return;
+  blackholeChecking.value = true;
+  try {
+    blackholeStatus.value = await invoke<BlackHoleStatus>('check_blackhole');
+  } catch (e) {
+    console.error('Failed to check BlackHole status:', e);
+  } finally {
+    blackholeChecking.value = false;
+  }
+}
+
 // Lifecycle
 onMounted(async () => {
   try {
@@ -840,6 +894,7 @@ onMounted(async () => {
   unlistenVbcableProgress = await listen<string>('vbcable-install-progress', (event) => {
     vbcableInstallProgress.value = event.payload;
   });
+  checkBlackHoleStatus();
 });
 
 async function toggleAutostart() {
@@ -867,6 +922,7 @@ const fetchDevices = async () => {
   } catch (e) {
     console.error("Failed to fetch audio devices", e);
   }
+  checkBlackHoleStatus();
 };
 
 const loadSettings = () => {

--- a/tauri-app/src/features/settings/components/SettingsDialog.vue
+++ b/tauri-app/src/features/settings/components/SettingsDialog.vue
@@ -181,7 +181,7 @@
                   </SelectContent>
                 </Select>
               </div>
-              <p v-if="settings.audioDevice === 'auto' || settings.audioDevice.includes('CABLE Input') || settings.audioDevice.toLowerCase().includes('blackhole')" class="text-xs text-green-400 font-medium">
+              <p v-if="settings.audioDevice === 'auto' || (settings.audioDevice && (settings.audioDevice.includes('CABLE Input') || settings.audioDevice.toLowerCase().includes('blackhole')))" class="text-xs text-green-400 font-medium">
                 {{ $t('settings.audioOutput.routingActive') }}
               </p>
             </div>

--- a/tauri-app/src/shared/locales/en.json
+++ b/tauri-app/src/shared/locales/en.json
@@ -136,11 +136,19 @@
       "desc": "To route audio to other applications (like OBS or Discord), you need to install VB-Audio Virtual Cable.",
       "download": "Download VB-Cable"
     },
+    "blackhole": {
+      "installed": "Installed",
+      "notDetected": "Not Detected",
+      "desc": "BlackHole is a virtual audio device for macOS. It routes microphone audio to other applications (like OBS or Zoom) without speaker feedback.",
+      "download": "BlackHole GitHub",
+      "available": "available for auto input switching",
+      "switchAudioSourceMissing": "Install SwitchAudioSource (brew install switchaudio-osx) for auto input switching"
+    },
     "audioOutput": {
       "title": "Output Device",
       "desc": "Where should the microphone audio be played?",
       "auto": "Auto",
-      "routingActive": "VB-CABLE routing is active. Audio will be forwarded to \"CABLE Output\"."
+      "routingActive": "Virtual audio routing is active. Audio will be forwarded to the virtual device."
     },
     "spectrum": {
       "title": "Real-Time Spectrum",

--- a/tauri-app/src/shared/locales/zh.json
+++ b/tauri-app/src/shared/locales/zh.json
@@ -136,11 +136,19 @@
       "desc": "若要将麦克风声音路由到其他应用程序（如 OBS 或 Discord），你需要安装 VB-Audio Virtual Cable",
       "download": "下载 VB-Cable"
     },
+    "blackhole": {
+      "installed": "已安装",
+      "notDetected": "未检测到",
+      "desc": "BlackHole 是 macOS 的虚拟音频设备，可将麦克风音频路由到其他应用（如 OBS 或 Zoom），且不会产生扬声器啸叫。",
+      "download": "BlackHole GitHub",
+      "available": "可用于自动切换输入设备",
+      "switchAudioSourceMissing": "请安装 SwitchAudioSource（brew install switchaudio-osx）以启用自动切换输入设备"
+    },
     "audioOutput": {
       "title": "输出设备",
       "desc": "麦克风的声音应该在哪里播放？",
       "auto": "自动",
-      "routingActive": "VB-CABLE 转发已激活，音频将被转发到 \"CABLE Output\""
+      "routingActive": "虚拟音频路由已激活，音频将被转发到虚拟设备"
     },
     "spectrum": {
       "title": "实时频谱",


### PR DESCRIPTION
This pull request adds comprehensive support for the BlackHole virtual audio device on macOS, including detection, status reporting, and automatic input device switching. It introduces a new backend module for BlackHole management, updates the UI to reflect BlackHole status, and ensures seamless switching to and from BlackHole as the system input during streaming. Additional improvements include enhanced audio device detection logic and buffer management for improved audio handling.

**macOS BlackHole Virtual Audio Device Support:**

* Added a new Rust backend module (`blackhole.rs`) to detect BlackHole installation, check SwitchAudioSource availability, set BlackHole as the default input device, and restore the previous input device. Tauri commands are exposed for frontend integration. [[1]](diffhunk://#diff-8652dcf95d1f9b8362cf09731a30a8fa15050bfc576129442d9b98329d524b06R1-R283) [[2]](diffhunk://#diff-53524d04209ae96656be3cfcc83b16c6b8a8074bb6b338873fe939bc40bc0a30R11) [[3]](diffhunk://#diff-53524d04209ae96656be3cfcc83b16c6b8a8074bb6b338873fe939bc40bc0a30R654-R656)
* Updated the frontend settings dialog to display BlackHole status, provide installation instructions, and show SwitchAudioSource availability. The UI now distinguishes between BlackHole (macOS) and VB-CABLE (Windows/others) for virtual audio routing. [[1]](diffhunk://#diff-c057da7e51cd7786bc20d1effd5a60409886f506527f93a7dc4055bdcc7152baL184-R218) [[2]](diffhunk://#diff-c057da7e51cd7786bc20d1effd5a60409886f506527f93a7dc4055bdcc7152baR712-R724) [[3]](diffhunk://#diff-c057da7e51cd7786bc20d1effd5a60409886f506527f93a7dc4055bdcc7152baR865-R880) [[4]](diffhunk://#diff-c057da7e51cd7786bc20d1effd5a60409886f506527f93a7dc4055bdcc7152baR897) [[5]](diffhunk://#diff-c057da7e51cd7786bc20d1effd5a60409886f506527f93a7dc4055bdcc7152baR925)
* Localized BlackHole-related UI strings in both English and Chinese. [[1]](diffhunk://#diff-213d6aa000b2ef30e53ee89f4560a4062c5cea1912651d031d2fdbd0a0ee3605R139-R151) [[2]](diffhunk://#diff-2a52c2f79e393029b4da61b03ca734a262f331660e675d45434e2285a5c2e269R139-R151)

**Automatic Device Switching on macOS:**

* When starting streaming, the app automatically switches the system input to BlackHole if available, and restores the previous input device when streaming stops. [[1]](diffhunk://#diff-3868716efae0726986bf2a11d714f9443c21b46f93a2c7479351e35dc48a4377R86-R97) [[2]](diffhunk://#diff-3868716efae0726986bf2a11d714f9443c21b46f93a2c7479351e35dc48a4377R112-R115)

**Audio Device Detection and Buffer Management Improvements:**

* Enhanced audio output device detection to auto-select BlackHole on macOS and VB-CABLE on Windows, improving cross-platform support for virtual audio routing. [[1]](diffhunk://#diff-7dd2a6bef0ab7ea2b95202e9891c3cb08f8f77e1cbb82686d58bdb733f79c025L134-R141) [[2]](diffhunk://#diff-7dd2a6bef0ab7ea2b95202e9891c3cb08f8f77e1cbb82686d58bdb733f79c025L150-R172)
* Increased the audio ring buffer size for lower latency and better performance.
* Zeroed out the input buffer in the resampler to prevent stale data issues.
* Changed DSP processor behavior to pass through unprocessed audio instead of outputting silence when not enough data for a full frame is available.