### PR TITLE
feat(blackhole): add non-macOS stubs for audio device functions

### DIFF
--- a/tauri-app/src-tauri/src/blackhole.rs
+++ b/tauri-app/src-tauri/src/blackhole.rs
@@ -106,6 +106,11 @@ pub async fn is_switch_audio_source_installed() -> bool {
     false
 }
 
+#[cfg(not(target_os = "macos"))]
+async fn get_current_input_device() -> Option<AudioDevice> {
+    None
+}
+
 /// Get the current default input device via SwitchAudioSource
 #[cfg(target_os = "macos")]
 async fn get_current_input_device() -> Option<AudioDevice> {
@@ -124,6 +129,11 @@ async fn get_current_input_device() -> Option<AudioDevice> {
     parse_device_json(&json_str)
 }
 
+#[cfg(not(target_os = "macos"))]
+async fn set_default_input_device(_device_id: &str) -> bool {
+    false
+}
+
 /// Set the default input device via SwitchAudioSource
 #[cfg(target_os = "macos")]
 async fn set_default_input_device(device_id: &str) -> bool {
@@ -134,6 +144,11 @@ async fn set_default_input_device(device_id: &str) -> bool {
         .await
         .map(|o| o.status.success())
         .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn find_blackhole_input_device() -> Option<AudioDevice> {
+    None
 }
 
 /// Find BlackHole device in the input device list


### PR DESCRIPTION
This pull request adds cross-platform compatibility stubs for audio device management functions in `blackhole.rs`. For non-macOS platforms, it defines placeholder async functions that return default values, ensuring the code compiles and runs without errors when targeting platforms other than macOS.

Platform compatibility improvements:

* Added non-macOS (`#[cfg(not(target_os = "macos"))]`) async stubs for `get_current_input_device`, `set_default_input_device`, and `find_blackhole_input_device` in `blackhole.rs`, returning `None` or `false` as appropriate. [[1]](diffhunk://#diff-8652dcf95d1f9b8362cf09731a30a8fa15050bfc576129442d9b98329d524b06R109-R113) [[2]](diffhunk://#diff-8652dcf95d1f9b8362cf09731a30a8fa15050bfc576129442d9b98329d524b06R132-R136) [[3]](diffhunk://#diff-8652dcf95d1f9b8362cf09731a30a8fa15050bfc576129442d9b98329d524b06R149-R153)