### PR TITLE
fix:修复袖珍模式下主题颜色切换的问题以及袖珍模式下初次启动后切换菜单两菜单同时展开的问题

### DIFF
--- a/tauri-app/src/features/connection/components/IpPopup.vue
+++ b/tauri-app/src/features/connection/components/IpPopup.vue
@@ -52,6 +52,7 @@ const selectIp = (ip: string, autoSelect: boolean) => {
 };
 
 const refreshState = () => {
+  syncTheme();
   selectedIp.value = localStorage.getItem('popup_ip') || '0.0.0.0';
   isAutoBind.value = localStorage.getItem('popup_isAutoBind') !== 'false';
   interfaces.value = JSON.parse(localStorage.getItem('popup_interfaces') || '[]');

--- a/tauri-app/src/features/connection/components/IpPopup.vue
+++ b/tauri-app/src/features/connection/components/IpPopup.vue
@@ -19,11 +19,14 @@ const isAutoBind = ref(localStorage.getItem('popup_isAutoBind') !== 'false');
 const interfaces = ref<NetworkInterface[]>(JSON.parse(localStorage.getItem('popup_interfaces') || '[]'));
 const contentRef = ref<HTMLElement | null>(null);
 
+const mq = window.matchMedia('(prefers-color-scheme: dark)');
+const handleSystemThemeChange = (e: MediaQueryListEvent) => {
+  document.documentElement.classList.toggle('dark', e.matches);
+};
+
 const syncTheme = () => {
   const html = document.documentElement;
-  const mq = window.matchMedia('(prefers-color-scheme: dark)');
   html.classList.toggle('dark', mq.matches);
-  mq.addEventListener('change', (e) => html.classList.toggle('dark', e.matches));
 
   const themeColor = localStorage.getItem('micyou_theme_color') || 'theme-blue';
   const uiStyle = localStorage.getItem('micyou_ui_style') || 'style-default';
@@ -87,6 +90,7 @@ let unlisteners: (() => void)[] = [];
 
 onMounted(async () => {
   syncTheme();
+  mq.addEventListener('change', handleSystemThemeChange);
   // Remove default focus outline on the popup window
   const style = document.createElement('style');
   style.textContent = 'html, body, *:focus { outline: none !important; }';
@@ -111,6 +115,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  mq.removeEventListener('change', handleSystemThemeChange);
   window.removeEventListener('blur', onBlur);
   unlisteners.forEach(fn => fn());
 });

--- a/tauri-app/src/features/pocket/components/PocketLayout.vue
+++ b/tauri-app/src/features/pocket/components/PocketLayout.vue
@@ -72,6 +72,7 @@ interface OverlayHandle {
   window: WebviewWindow | null;
   created: boolean;
   unlisteners: (() => void)[];
+  dismissed: boolean;
 }
 
 const OVERLAY_W = 220;
@@ -80,7 +81,7 @@ const OVERLAY_LABEL_PREFIX = 'pocket-overlay-';
 const overlays: Record<string, OverlayHandle> = {};
 
 const getOverlay = (id: string): OverlayHandle => {
-  if (!overlays[id]) overlays[id] = { window: null, created: false, unlisteners: [] };
+  if (!overlays[id]) overlays[id] = { window: null, created: false, unlisteners: [], dismissed: false };
   return overlays[id];
 };
 
@@ -95,7 +96,7 @@ const positionOverlay = async (align: 'right' | 'left' = 'right', offsetY = 2) =
 };
 
 const showOverlay = async (h: OverlayHandle) => {
-  if (!h.window) return;
+  if (!h.window || h.dismissed) return;
   try {
     // Prepare: set isShowing guard + reset state before show()
     await h.window.emit('popup-prepare');
@@ -130,6 +131,8 @@ const syncAndShow = async (id: string, url: string, syncFn: () => void, opts?: {
     // Register popup-ready BEFORE other async ops to avoid missing the event
     h.unlisteners.push(
       await h.window.listen('popup-ready', () => {
+        if (h.dismissed) return;  // was dismissed while loading
+        h.dismissed = false;
         showOverlay(h);
       })
     );
@@ -146,6 +149,7 @@ const syncAndShow = async (id: string, url: string, syncFn: () => void, opts?: {
     opts?.onCreated?.(h);
     h.created = true;
   } else {
+    h.dismissed = false;
     const { x, y } = await positionOverlay(opts?.align);
     try { await h.window.setPosition(new LogicalPosition(x, y)); } catch {}
     try { await h.window.emit('popup-refresh'); } catch {}
@@ -167,6 +171,7 @@ const closePopup = async () => {
 const hideAllOverlays = async () => {
   for (const id of Object.keys(overlays)) {
     const h = overlays[id];
+    h.dismissed = true;
     if (h.window) {
       try {
         await h.window.emit('popup-closing');

--- a/tauri-app/src/features/pocket/components/PocketLayout.vue
+++ b/tauri-app/src/features/pocket/components/PocketLayout.vue
@@ -109,6 +109,7 @@ const showOverlay = async (h: OverlayHandle) => {
 
 const syncAndShow = async (id: string, url: string, syncFn: () => void, opts?: { height?: number; align?: 'right' | 'left'; onCreated?: (h: OverlayHandle) => void }) => {
   const h = getOverlay(id);
+  h.dismissed = false;
   emit('update:popupOpen', true);
   syncFn();
 
@@ -132,7 +133,6 @@ const syncAndShow = async (id: string, url: string, syncFn: () => void, opts?: {
     h.unlisteners.push(
       await h.window.listen('popup-ready', () => {
         if (h.dismissed) return;  // was dismissed while loading
-        h.dismissed = false;
         showOverlay(h);
       })
     );

--- a/tauri-app/src/shared/components/PopupWindow.vue
+++ b/tauri-app/src/shared/components/PopupWindow.vue
@@ -14,12 +14,14 @@ const animState = ref<'hidden' | 'entering' | 'visible' | 'leaving'>('hidden');
 const noTransition = ref(false);
 
 // Sync theme
+const mq = window.matchMedia('(prefers-color-scheme: dark)');
+const handleSystemThemeChange = (e: MediaQueryListEvent) => {
+  document.documentElement.classList.toggle('dark', e.matches);
+};
+
 const syncTheme = () => {
   const html = document.documentElement;
-
-  const mq = window.matchMedia('(prefers-color-scheme: dark)');
   html.classList.toggle('dark', mq.matches);
-  mq.addEventListener('change', (e) => html.classList.toggle('dark', e.matches));
 
   const themeColor = localStorage.getItem('micyou_theme_color') || 'theme-blue';
   const uiStyle = localStorage.getItem('micyou_ui_style') || 'style-default';
@@ -152,6 +154,7 @@ let unlisteners: (() => void)[] = [];
 
 onMounted(async () => {
   syncTheme();
+  mq.addEventListener('change', handleSystemThemeChange);
   // Remove default focus outline on the popup window
   const style = document.createElement('style');
   style.textContent = 'html, body, *:focus { outline: none !important; }';
@@ -174,6 +177,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  mq.removeEventListener('change', handleSystemThemeChange);
   window.removeEventListener('blur', onBlur);
   unlisteners.forEach(fn => fn());
 });

--- a/tauri-app/src/shared/components/PopupWindow.vue
+++ b/tauri-app/src/shared/components/PopupWindow.vue
@@ -115,6 +115,7 @@ const openSettings = () => {
 };
 
 const refreshState = () => {
+  syncTheme();
   connectionMode.value = localStorage.getItem('popup_connectionMode') || 'wifi';
   serverPort.value = Number(localStorage.getItem('popup_serverPort')) || 8554;
   webPort.value = Number(localStorage.getItem('popup_webPort')) || 8443;


### PR DESCRIPTION
对于PR #254 中提到的问题和新发现的问题进行了小部分修复
修复了以下内容：
1. 袖珍模式下主题颜色切换子菜单颜色未发生变化
2. 袖珍模式下初次启动后切换菜单两菜单同时展开
3. 袖珍模式下设置需要多次点击才能打开