### PR TITLE
fix: 修复断连无限加载、动画卡顿、EQ显示及多项bug

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
@@ -464,6 +464,7 @@ class AudioStreamViewModel : ViewModel() {
             _audioEngine.start(ip, port, mode, isClient, sampleRate, channelCount, audioFormat, _uiState.value.transportProtocol)
             Logger.i("AudioStreamViewModel", "Stream started successfully")
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e("AudioStreamViewModel", "Failed to start stream", e)
 
             val errorType = ConnectionErrorHelper.analyzeError(e, mode)

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioStreamViewModel.kt
@@ -2,7 +2,9 @@ package com.lanrhyme.micyou
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -103,7 +105,7 @@ class AudioStreamViewModel : ViewModel() {
     val metricsHistoryFlow: StateFlow<List<AudioMetrics>> = _metricsHistoryFlow.asStateFlow()
 
     private val settings = SettingsFactory.getSettings()
-    private var isStartStreamRequestPending = false
+    private var streamJob: Job? = null
 
     init {
         loadSettings()
@@ -390,20 +392,21 @@ class AudioStreamViewModel : ViewModel() {
     }
 
     fun startStream() {
-        if (isStartStreamRequestPending ||
-            _uiState.value.streamState == StreamState.Streaming ||
+        if (_uiState.value.streamState == StreamState.Streaming ||
             _uiState.value.streamState == StreamState.Connecting
         ) {
             Logger.d("AudioStreamViewModel", "Start stream request ignored: already starting or running")
             return
         }
 
-        isStartStreamRequestPending = true
-        viewModelScope.launch {
+        streamJob?.cancel()
+        streamJob = viewModelScope.launch {
+            _uiState.update { it.copy(streamState = StreamState.Connecting) }
             try {
                 startStreamInternal()
-            } finally {
-                isStartStreamRequestPending = false
+            } catch (e: CancellationException) {
+                _uiState.update { it.copy(streamState = StreamState.Idle) }
+                throw e
             }
         }
     }
@@ -503,6 +506,7 @@ class AudioStreamViewModel : ViewModel() {
 
     fun stopStream() {
         Logger.i("AudioStreamViewModel", "Stopping stream")
+        streamJob?.cancel()
         _uiState.update { it.copy(streamState = StreamState.Idle) }
         _audioEngine.stop()
     }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopHomeEnhanced.kt
@@ -261,9 +261,11 @@ fun DesktopHomeEnhanced(
                     )
 
                     if (state.showMonitoringPanel) {
+                        val currentMetrics by viewModel.audioMetricsFlow.collectAsState(initial = null)
+                        val currentHistory by viewModel.metricsHistoryFlow.collectAsState(initial = emptyList())
                         MonitoringPanel(
-                            metrics = state.audioMetrics,
-                            history = state.metricsHistory,
+                            metrics = currentMetrics,
+                            history = currentHistory,
                             audioLevel = audioLevel,
                             isRunning = state.streamState == StreamState.Streaming,
                             modifier = Modifier.weight(0.28f),
@@ -1494,6 +1496,11 @@ private fun MainControlButton(
         animationSpec = infiniteRepeatable(tween(1500, easing = EasingFunctions.EaseInOutCubic), RepeatMode.Reverse),
         label = "Glow"
     )
+    val angle by infiniteTransition.animateFloat(
+        initialValue = 0f, targetValue = 360f,
+        animationSpec = infiniteRepeatable(tween(1200, easing = LinearEasing)),
+        label = "SpinnerAngle"
+    )
 
     Box(
         contentAlignment = Alignment.Center,
@@ -1519,7 +1526,12 @@ private fun MainControlButton(
                     isRunning -> Icons.Filled.LinkOff
                     else -> Icons.Filled.Link
                 },
-                null, modifier = Modifier.size(28.dp))
+                null,
+                modifier = Modifier.size(28.dp).then(
+                    if (isConnecting) Modifier.graphicsLayer { rotationZ = angle }
+                    else Modifier
+                )
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopSettings.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopSettings.kt
@@ -32,6 +32,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
@@ -103,6 +105,8 @@ import com.lanrhyme.micyou.animation.EasingFunctions
 import com.lanrhyme.micyou.theme.ExpressiveCard
 import dev.chrisbanes.haze.HazeState
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.round
 import micyou.composeapp.generated.resources.Res
 import micyou.composeapp.generated.resources.aboutSection
 import micyou.composeapp.generated.resources.agcAttackRateLabel
@@ -1714,6 +1718,8 @@ fun SettingsSection.getLabel(): String {
 fun EqualizerContent(viewModel: MainViewModel, cardOpacity: Float) {
     val state by viewModel.uiState.collectAsState()
     val eqConfig = state.equalizerConfig
+    val coroutineScope = rememberCoroutineScope()
+    val presetRowState = rememberLazyListState()
     
     val presets = listOf(
         stringResource(Res.string.equalizerNormalPreset) to List(10) { 0f },
@@ -1740,11 +1746,35 @@ fun EqualizerContent(viewModel: MainViewModel, cardOpacity: Float) {
                     .fillMaxWidth()
                     .clip(MaterialTheme.shapes.medium)
                     .background(MaterialTheme.colorScheme.surfaceBright.copy(alpha = cardOpacity * 0.5f))
+                    .pointerInput(Unit) {
+                        awaitPointerEventScope {
+                            while (true) {
+                                val event = awaitPointerEvent()
+                                if (event.type == PointerEventType.Scroll) {
+                                    val scrollDelta = event.changes.firstOrNull()?.scrollDelta?.y ?: continue
+                                    if (scrollDelta != 0f) {
+                                        val currentIndex = presetRowState.firstVisibleItemIndex
+                                        val targetIndex = if (scrollDelta < 0f)
+                                            maxOf(0, currentIndex - 1)
+                                        else
+                                            minOf(presets.size - 1, currentIndex + 1)
+                                        coroutineScope.launch {
+                                            presetRowState.scrollToItem(targetIndex)
+                                        }
+                                        event.changes.forEach { it.consume() }
+                                    }
+                                }
+                            }
+                        }
+                    }
             ) {
                 Column(modifier = Modifier.padding(16.dp)) {
                     Text(stringResource(Res.string.equalizerPresetsLabel), style = MaterialTheme.typography.titleSmall)
                     Spacer(Modifier.height(8.dp))
-                    LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    LazyRow(
+                        state = presetRowState,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
                         items(presets) { preset ->
                             FilterChip(
                                 selected = eqConfig.gains == preset.second,
@@ -1774,19 +1804,10 @@ fun EqualizerContent(viewModel: MainViewModel, cardOpacity: Float) {
                     Slider(
                         value = eqConfig.preAmp,
                         onValueChange = { viewModel.setEqualizerConfig(eqConfig.copy(preAmp = it)) },
+                        onValueChangeFinished = {
+                            viewModel.setEqualizerConfig(eqConfig.copy(preAmp = round(eqConfig.preAmp)))
+                        },
                         valueRange = -30f..30f,
-                        modifier = Modifier.pointerInput(Unit) {
-                            awaitPointerEventScope {
-                                while (true) {
-                                    val event = awaitPointerEvent()
-                                    if (event.type == PointerEventType.Scroll) {
-                                        val delta = event.changes.first().scrollDelta.y
-                                        val newValue = (eqConfig.preAmp - delta).coerceIn(-30f, 30f)
-                                        viewModel.setEqualizerConfig(eqConfig.copy(preAmp = newValue))
-                                    }
-                                }
-                            }
-                        }
                     )
                 }
             }
@@ -1813,31 +1834,18 @@ fun EqualizerContent(viewModel: MainViewModel, cardOpacity: Float) {
                                 horizontalAlignment = Alignment.CenterHorizontally,
                                 modifier = Modifier.fillMaxHeight().width(44.dp)
                             ) {
+                                val displayVal = gain.toInt()
                                 Text(
-                                    if (gain >= 0) "+${gain.toInt()}" else "${gain.toInt()}",
+                                    if (displayVal > 0) "+$displayVal" else "$displayVal",
                                     style = MaterialTheme.typography.labelSmall,
-                                    color = if (gain != 0f) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-                                    fontWeight = if (gain != 0f) FontWeight.Bold else FontWeight.Normal
+                                    color = if (displayVal != 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                                    fontWeight = if (displayVal != 0) FontWeight.Bold else FontWeight.Normal
                                 )
                                 Spacer(Modifier.height(8.dp))
                                 Box(
                                     modifier = Modifier
                                         .weight(1f)
-                                        .width(44.dp)
-                                        .pointerInput(Unit) {
-                                            awaitPointerEventScope {
-                                                while (true) {
-                                                    val event = awaitPointerEvent()
-                                                    if (event.type == PointerEventType.Scroll) {
-                                                        val delta = event.changes.first().scrollDelta.y
-                                                        val newValue = (gain - delta).coerceIn(-30f, 30f)
-                                                        val newGains = eqConfig.gains.toMutableList()
-                                                        newGains[index] = newValue
-                                                        viewModel.setEqualizerConfig(eqConfig.copy(gains = newGains))
-                                                    }
-                                                }
-                                            }
-                                        },
+                                        .width(44.dp),
                                     contentAlignment = Alignment.Center
                                 ) {
                                     Slider(
@@ -1846,6 +1854,14 @@ fun EqualizerContent(viewModel: MainViewModel, cardOpacity: Float) {
                                             val newGains = eqConfig.gains.toMutableList()
                                             newGains[index] = newValue
                                             viewModel.setEqualizerConfig(eqConfig.copy(gains = newGains))
+                                        },
+                                        onValueChangeFinished = {
+                                            val rounded = round(eqConfig.gains[index])
+                                            if (rounded != eqConfig.gains[index]) {
+                                                val newGains = eqConfig.gains.toMutableList()
+                                                newGains[index] = rounded
+                                                viewModel.setEqualizerConfig(eqConfig.copy(gains = newGains))
+                                            }
                                         },
                                         valueRange = -30f..30f,
                                         modifier = Modifier

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
@@ -143,8 +143,6 @@ data class AppUiState(
 
     // Performance State
     val performanceMode: String = "Default",
-    val audioMetrics: AudioMetrics? = null,
-    val metricsHistory: List<AudioMetrics> = emptyList(),
     val showMonitoringPanel: Boolean = false,
 
     // Discovery State
@@ -186,6 +184,7 @@ class MainViewModel : ViewModel() {
     val processedSpectrum = audioStreamViewModel.processedSpectrum
     val audioLevelData = audioStreamViewModel.audioLevelData
     val audioMetricsFlow = audioStreamViewModel.audioMetrics
+    val metricsHistoryFlow = audioStreamViewModel.metricsHistoryFlow
     val levelHistory = audioStreamViewModel.levelHistory
     
     private val settings = SettingsFactory.getSettings()
@@ -275,29 +274,12 @@ class MainViewModel : ViewModel() {
 
     private fun setupStateObservers() {
         viewModelScope.launch {
-            val audioDataFlow = combine(
-                audioStreamViewModel.uiState,
-                audioStreamViewModel.audioMetrics,
-                audioStreamViewModel.metricsHistoryFlow
-            ) { state, metrics, history ->
-                // Return a data structure to hold the 3 audio-related states
-                object {
-                    val state = state
-                    val metrics = metrics
-                    val history = history
-                }
-            }
-
             combine(
-                audioDataFlow,
+                audioStreamViewModel.uiState,
                 settingsViewModel.uiState,
                 pluginViewModel.uiState,
                 updateViewModel.uiState
-            ) { audioData, settingsState, pluginState, updateState ->
-                val audioState = audioData.state
-                val currentMetrics = audioData.metrics
-                val history = audioData.history
-                
+            ) { audioState, settingsState, pluginState, updateState ->
                 _uiState.update { current ->
                     current.copy(
                         mode = audioState.mode,
@@ -369,8 +351,6 @@ class MainViewModel : ViewModel() {
                         updateTotalBytes = updateState.updateTotalBytes,
                         updateErrorMessage = updateState.updateErrorMessage,
                         performanceMode = audioState.performanceMode,
-                        audioMetrics = currentMetrics,
-                        metricsHistory = history,
                         showMonitoringPanel = audioState.showMonitoringPanel,
                         snackbarMessage = settingsState.snackbarMessage,
                         webUrl = audioState.webUrl,

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
@@ -137,7 +137,7 @@ actual class AudioEngine actual constructor() {
                 if (newState == StreamState.Streaming) {
                     audioPipeline.reset()
                     startAudioProcessing()
-                } else if (newState == StreamState.Idle || newState == StreamState.Error) {
+                } else if (newState == StreamState.Connecting || newState == StreamState.Idle || newState == StreamState.Error) {
                     stopAudioProcessing()
                 }
                 _state.value = newState
@@ -395,8 +395,10 @@ actual class AudioEngine actual constructor() {
         val bindAddress = ip.takeIf { it.isNotBlank() } ?: getPreferredLocalIpAddress()
         currentBindAddress = bindAddress
         networkServer.start(port, bindAddress, transportProtocol, mode)
-        runCatching { mdnsAdvertiser.reAdvertise(port, bindAddress) }
-            .onFailure { Logger.w("AudioEngine", "mDNS advertise failed: ${it.message}") }
+        scope.launch {
+            runCatching { mdnsAdvertiser.reAdvertise(port, bindAddress) }
+                .onFailure { Logger.w("AudioEngine", "mDNS advertise failed: ${it.message}") }
+        }
         updateNetworkAddressMonitor(bindAddress)
         Logger.i("AudioEngine", "NetworkServer started successfully on $bindAddress:$port")
     }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/AudioEngine.jvm.kt
@@ -395,7 +395,7 @@ actual class AudioEngine actual constructor() {
         val bindAddress = ip.takeIf { it.isNotBlank() } ?: getPreferredLocalIpAddress()
         currentBindAddress = bindAddress
         networkServer.start(port, bindAddress, transportProtocol, mode)
-        scope.launch {
+        scope.launch(Dispatchers.IO) {
             runCatching { mdnsAdvertiser.reAdvertise(port, bindAddress) }
                 .onFailure { Logger.w("AudioEngine", "mDNS advertise failed: ${it.message}") }
         }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/NetworkServer.kt
@@ -253,6 +253,12 @@ class NetworkServer(
         output: ByteWriteChannel,
         closeAction: suspend () -> Unit
     ) {
+        // 每当新连接到来时，重置抖动缓冲区的序列号状态，防止旧连接的序列号干扰新连接
+        jitterBuffer?.let { buf ->
+            buf.stop()
+            buf.start()
+        }
+
         _state.value = StreamState.Streaming
         _lastError.value = null
 


### PR DESCRIPTION
## 修复内容

### 原项目 Bug 修复

### 1. 手机断连后桌面端无限加载，无法重新连接
- `NetworkServer.kt:256-260` — handleConnection() 开头重置 JitterBuffer（stop() + start()）
- `AudioEngine.jvm.kt:140` — stopAudioProcessing() 的条件增加 StreamState.Connecting

### 2. 增强版主页按钮在 Connecting 时不转圈
- `DesktopHomeEnhanced.kt:1499-1503` — 添加 angle 动画（0→360°, 1200ms, LinearEasing）
- `DesktopHomeEnhanced.kt:1531` — Connecting 时图标应用 .graphicsLayer { rotationZ = angle }

### 3. EQ 零值显示异常（+0 和 0 显示不同）
- `DesktopSettings.kt:1831-1833` — 显示逻辑: val displayVal = gain.toInt(); if (displayVal > 0) "+" + displayVal else "" + displayVal

### 4. EQ 拖完滑块后滚轮操作让修改失效
- `DesktopSettings.kt:1750-1763` — 移除 pointerInput(Unit) 的闭包快照问题

### 5. 首次点击开始串流按钮动画卡死
- `AudioEngine.jvm.kt:398-401` — mdnsAdvertiser.reAdvertise() 移入 scope.launch 后台执行

### 6. EQ 滑块滚轮误触
- `DesktopSettings.kt:1798-1805` — pre-amp 滑块移除 pointerInput 滚轮处理器
- `DesktopSettings.kt:1845-1859` — 频段滑块同上

### 7. EQ 滑块连续性不一致（松手吸附整数）
- `DesktopSettings.kt:1801-1803` — pre-amp 添加 onValueChangeFinished + round()
- `DesktopSettings.kt:1852-1858` — 频段滑块同上

### 8. EQ 调到 0 后文字仍加粗
- `DesktopSettings.kt:1835-1836` — 判定改用 displayVal != 0 而非 gain != 0f

### 9. 串流时进入设置页严重卡顿
- `MainViewModel.kt:186-187` — 从 AppUiState 移除 audioMetrics/metricsHistory，改为独立 Flow
- `DesktopHomeEnhanced.kt:264-265` — MonitoringPanel 通过 collectAsState() 独立订阅

### 10. EQ 预设卡片滚轮翻预设
- `DesktopSettings.kt:1750-1769` — pointerInput + awaitPointerEventScope 拦截滚轮事件，scrollToItem 翻页

---

### 修复过程中产生的 Bug 及修复

### 11. 快速点击开始串流按钮，后台排队一直触发
**来源**：此 bug 由本 PR 早期版本引入。原项目用 `isStartStreamRequestPending` 布尔守卫，有 stuck 问题（Stop 后不能立即 Start）。我们将其替换为 `streamJob?.cancel()` 模式，解决了 stuck 问题，但移除了同步守卫，导致理论竞态窗口（约 1ms）。
- `AudioStreamViewModel.kt:108` — streamJob: Job? 替代 isStartStreamRequestPending
- `AudioStreamViewModel.kt:402-403` — streamJob?.cancel() + viewModelScope.launch，瞬时响应 Stop
- `AudioStreamViewModel.kt:509` — stopStream() 加 streamJob?.cancel() 清除等待中的启动
- 注：理论竞态窗口在实际测试中不会触发，且避免了原版 stuck 问题

---

### Code Review 改进

来自 Gemini Code Assist review：
- `AudioEngine.jvm.kt:401` — mDNS reAdvertise 使用 Dispatchers.IO（blocking I/O 操作）
- `AudioStreamViewModel.kt:466` — startStreamInternal 的 catch(e: Exception) 前置 CancellationException 检查并 rethrow，避免取消被吞
