### PR TITLE
fix(android): 修复快速点击开始/停止按钮失效

### DIFF
--- a/composeApp/src/main/kotlin/com/lanrhyme/micyou/audio/AudioEngine.kt
+++ b/composeApp/src/main/kotlin/com/lanrhyme/micyou/audio/AudioEngine.kt
@@ -106,7 +106,11 @@ class AudioEngine constructor() {
         private var activeEngine: AudioEngine? = null
 
         fun requestDisconnectFromNotification() {
-            activeEngine?.stop()
+            activeEngine?.let { engine ->
+                CoroutineScope(Dispatchers.Main).launch {
+                    engine.stop()
+                }
+            }
         }
 
         fun isStreaming(): Boolean {
@@ -671,24 +675,25 @@ class AudioEngine constructor() {
         }
     }
     
-    fun stop() {
-        job?.cancel()
-        job = null
-        _state.value = StreamState.Idle
-        isRunning = false
+    suspend fun stop() {
+        startStopMutex.withLock {
+            job?.cancel()
+            job?.join()
+            job = null
+            _state.value = StreamState.Idle
+            isRunning = false
 
-        clearActiveEngine()
-    val context = ContextHelper.getContext()
-        if (context != null) {
-            val intent = Intent(context, AudioService::class.java).apply { action = AudioService.ACTION_STOP }
-            context.startService(intent)
+            clearActiveEngine()
+        val context = ContextHelper.getContext()
+            if (context != null) {
+                val intent = Intent(context, AudioService::class.java).apply { action = AudioService.ACTION_STOP }
+                context.startService(intent)
+            }
         }
     }
 
     suspend fun stopAndWait() {
-        val currentJob = job
         stop()
-        currentJob?.join()
     }
     
     fun setMonitoring(enabled: Boolean) { }

--- a/composeApp/src/main/kotlin/com/lanrhyme/micyou/viewmodel/AudioStreamViewModel.kt
+++ b/composeApp/src/main/kotlin/com/lanrhyme/micyou/viewmodel/AudioStreamViewModel.kt
@@ -2,12 +2,15 @@ package com.lanrhyme.micyou.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import com.lanrhyme.micyou.audio.AudioEngine
 import com.lanrhyme.micyou.audio.AudioFormat
 import com.lanrhyme.micyou.audio.AudioLevelData
@@ -114,7 +117,7 @@ class AudioStreamViewModel : ViewModel() {
     val metricsHistoryFlow: StateFlow<List<AudioMetrics>> = _metricsHistoryFlow.asStateFlow()
 
     private val settings = SettingsFactory.getSettings()
-    private var isStartStreamRequestPending = false
+    private var streamJob: Job? = null
 
     init {
         loadSettings()
@@ -346,20 +349,21 @@ class AudioStreamViewModel : ViewModel() {
     }
 
     fun startStream() {
-        if (isStartStreamRequestPending ||
-            _uiState.value.streamState == StreamState.Streaming ||
+        if (_uiState.value.streamState == StreamState.Streaming ||
             _uiState.value.streamState == StreamState.Connecting
         ) {
             Logger.d("AudioStreamViewModel", "Start stream request ignored: already starting or running")
             return
         }
 
-        isStartStreamRequestPending = true
-        viewModelScope.launch {
+        streamJob?.cancel()
+        streamJob = viewModelScope.launch {
+            _uiState.update { it.copy(streamState = StreamState.Connecting) }
             try {
                 startStreamInternal()
-            } finally {
-                isStartStreamRequestPending = false
+            } catch (e: CancellationException) {
+                _uiState.update { it.copy(streamState = StreamState.Idle) }
+                throw e
             }
         }
     }
@@ -449,8 +453,11 @@ class AudioStreamViewModel : ViewModel() {
 
     fun stopStream() {
         Logger.i("AudioStreamViewModel", "Stopping stream")
+        streamJob?.cancel()
         _uiState.update { it.copy(streamState = StreamState.Idle) }
-        _audioEngine.stop()
+        viewModelScope.launch {
+            _audioEngine.stop()
+        }
     }
 
     fun setMode(mode: ConnectionMode) {
@@ -727,7 +734,9 @@ class AudioStreamViewModel : ViewModel() {
     override fun onCleared() {
         super.onCleared()
         discoveryManager.stopDiscovery()
-        _audioEngine.stop()
+        runBlocking {
+            _audioEngine.stop()
+        }
     }
 
     fun startDiscovery() {

--- a/plugin-api/build.gradle.kts
+++ b/plugin-api/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.androidLibrary)
+}
+
+val pluginApiVersion: String by project
+
+android {
+    namespace = "com.lanrhyme.micyou.plugin.api"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    buildToolsVersion = libs.versions.android.buildTools.get()
+
+    defaultConfig {
+        minSdk = libs.versions.android.minSdk.get().toInt()
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+dependencies {
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.runtime)
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.kotlinx.serialization.json)
+}
+
+group = "com.lanrhyme.micyou"
+version = pluginApiVersion

--- a/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/AudioEffectPlugin.kt
+++ b/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/AudioEffectPlugin.kt
@@ -1,0 +1,16 @@
+package com.lanrhyme.micyou.plugin
+
+interface AudioEffectPlugin : Plugin {
+    val audioEffectProvider: AudioEffectProvider
+    
+    val effectPriority: Int get() = 100
+    
+    override fun onEnable() {
+        super.onEnable()
+    }
+    
+    override fun onDisable() {
+        super.onDisable()
+        audioEffectProvider.release()
+    }
+}

--- a/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/AudioEffectProvider.kt
+++ b/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/AudioEffectProvider.kt
@@ -1,0 +1,17 @@
+package com.lanrhyme.micyou.plugin
+
+interface AudioEffectProvider {
+    val id: String
+    val name: String
+    val description: String
+    
+    var isEnabled: Boolean
+    
+    fun process(input: ShortArray, channelCount: Int, sampleRate: Int): ShortArray
+    
+    fun reset()
+    
+    fun release()
+    
+    fun onConfigChanged(config: AudioConfig) {}
+}

--- a/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/Plugin.kt
+++ b/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/Plugin.kt
@@ -1,0 +1,9 @@
+package com.lanrhyme.micyou.plugin
+
+interface Plugin {
+    val manifest: PluginManifest
+    fun onLoad(context: PluginContext) {}
+    fun onEnable() {}
+    fun onDisable() {}
+    fun onUnload() {}
+}

--- a/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginContext.kt
+++ b/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginContext.kt
@@ -1,0 +1,23 @@
+package com.lanrhyme.micyou.plugin
+
+interface PluginContext {
+    val pluginId: String
+    val pluginDataDir: String
+
+    val localization: PluginLocalization
+    val appLocalization: PluginLocalization
+
+    fun getString(key: String, defaultValue: String): String
+    fun putString(key: String, value: String)
+    fun getBoolean(key: String, defaultValue: Boolean): Boolean
+    fun putBoolean(key: String, value: Boolean)
+    fun getInt(key: String, defaultValue: Int): Int
+    fun putInt(key: String, value: Int)
+    fun getFloat(key: String, defaultValue: Float): Float
+    fun putFloat(key: String, value: Float)
+    
+    fun log(message: String)
+    fun logError(message: String, throwable: Throwable? = null)
+    
+    val host: PluginHost
+}

--- a/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginDataChannel.kt
+++ b/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginDataChannel.kt
@@ -1,0 +1,43 @@
+package com.lanrhyme.micyou.plugin
+
+import kotlinx.coroutines.flow.Flow
+
+enum class DataChannelMode {
+    Tcp, Udp
+}
+
+data class DataChannelConfig(
+    val mode: DataChannelMode = DataChannelMode.Tcp,
+    val port: Int = 0,
+    val bufferSize: Int = 8192
+)
+
+interface PluginDataChannel {
+    val id: String
+    val config: DataChannelConfig
+    val isConnected: Flow<Boolean>
+    val localPort: Int
+    
+    suspend fun connect(host: String, port: Int): Result<Unit>
+    suspend fun bind(port: Int = 0): Result<Unit>
+    suspend fun send(data: ByteArray): Result<Unit>
+    fun receive(): Flow<ByteArray>
+    suspend fun close()
+    
+    data class ReceivedPacket(
+        val data: ByteArray,
+        val remoteHost: String,
+        val remotePort: Int
+    )
+}
+
+interface PluginDataChannelProvider {
+    fun createChannel(
+        id: String,
+        config: DataChannelConfig = DataChannelConfig()
+    ): PluginDataChannel
+    
+    fun getChannel(id: String): PluginDataChannel?
+    fun closeChannel(id: String)
+    fun closeAllChannels()
+}

--- a/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginHost.kt
+++ b/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginHost.kt
@@ -1,0 +1,89 @@
+package com.lanrhyme.micyou.plugin
+
+import kotlinx.coroutines.flow.StateFlow
+
+enum class StreamState {
+    Idle, Connecting, Streaming, Error
+}
+
+enum class ConnectionMode {
+    Wifi, Usb
+}
+
+enum class NoiseReductionType {
+    Ulunas, RNNoise, Speexdsp, None
+}
+
+data class AudioConfig(
+    val enableNS: Boolean = false,
+    val nsType: NoiseReductionType = NoiseReductionType.RNNoise,
+    val enableAGC: Boolean = false,
+    val agcTargetLevel: Int = 32000,
+    val enableVAD: Boolean = false,
+    val vadThreshold: Int = 10,
+    val enableDereverb: Boolean = false,
+    val dereverbLevel: Float = 0.5f,
+    val amplification: Float = 15.0f
+)
+
+data class ConnectionInfo(
+    val mode: ConnectionMode,
+    val ipAddress: String,
+    val port: Int,
+    val isClient: Boolean
+)
+
+interface PluginHost {
+    val streamState: StateFlow<StreamState>
+    val audioLevels: StateFlow<Float>
+    val isMuted: StateFlow<Boolean>
+    val connectionInfo: StateFlow<ConnectionInfo?>
+    val audioConfig: StateFlow<AudioConfig>
+    
+    fun updateAudioConfig(config: AudioConfig)
+    fun updateAudioConfig(block: AudioConfig.() -> AudioConfig)
+    
+    suspend fun startStream(
+        ip: String,
+        port: Int,
+        mode: ConnectionMode,
+        isClient: Boolean
+    )
+    
+    suspend fun stopStream()
+    suspend fun setMute(muted: Boolean)
+    
+    fun setMonitoring(enabled: Boolean)
+    
+    fun registerAudioEffect(effect: AudioEffectProvider, priority: Int = 100)
+    fun unregisterAudioEffect(effect: AudioEffectProvider)
+    
+    fun createDataChannel(
+        id: String,
+        config: DataChannelConfig = DataChannelConfig()
+    ): PluginDataChannel
+    
+    fun getDataChannel(id: String): PluginDataChannel?
+    fun closeDataChannel(id: String)
+    
+    fun showSnackbar(message: String)
+    fun showNotification(title: String, message: String)
+    
+    fun getSetting(key: String, defaultValue: String): String
+    fun setSetting(key: String, value: String)
+    fun getSettingBoolean(key: String, defaultValue: Boolean): Boolean
+    fun setSettingBoolean(key: String, value: Boolean)
+    fun getSettingInt(key: String, defaultValue: Int): Int
+    fun setSettingInt(key: String, value: Int)
+    fun getSettingFloat(key: String, defaultValue: Float): Float
+    fun setSettingFloat(key: String, value: Float)
+    
+    val platform: PlatformInfo
+    
+    data class PlatformInfo(
+        val name: String,
+        val version: String,
+        val isDesktop: Boolean,
+        val isMobile: Boolean
+    )
+}

--- a/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginInfo.kt
+++ b/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginInfo.kt
@@ -1,0 +1,9 @@
+package com.lanrhyme.micyou.plugin
+
+data class PluginInfo(
+    val manifest: PluginManifest,
+    val isEnabled: Boolean = false,
+    val isLoaded: Boolean = false,
+    val installPath: String,
+    val iconPath: String? = null
+)

--- a/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginLocalization.kt
+++ b/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginLocalization.kt
@@ -1,0 +1,66 @@
+package com.lanrhyme.micyou.plugin
+
+/**
+ * 插件本地化接口
+ * 提供插件多语言支持功能
+ */
+interface PluginLocalization {
+    /**
+     * 当前语言代码，如 "zh", "en", "ja" 等
+     */
+    val currentLanguage: String
+
+    /**
+     * 获取本地化字符串
+     * @param key 字符串键名
+     * @param defaultValue 默认值，当找不到对应本地化字符串时返回
+     * @return 本地化后的字符串
+     */
+    fun getString(key: String, defaultValue: String = key): String
+
+    /**
+     * 获取带格式的本地化字符串
+     * @param key 字符串键名
+     * @param formatArgs 格式化参数
+     * @return 格式化后的本地化字符串
+     */
+    fun getString(key: String, vararg formatArgs: Any): String
+
+    /**
+     * 切换语言
+     * @param languageCode 语言代码，如 "zh", "en" 等
+     */
+    fun setLanguage(languageCode: String)
+
+    /**
+     * 获取支持的语言列表
+     * @return 支持的语言代码列表
+     */
+    fun getSupportedLanguages(): List<String>
+
+    /**
+     * 重新加载本地化资源
+     * 当插件更新或语言切换时调用
+     */
+    fun reload()
+}
+
+/**
+ * 插件本地化提供者接口
+ * 插件可以实现此接口来提供自己的本地化资源
+ */
+interface PluginLocalizationProvider {
+    /**
+     * 获取插件的本地化字符串
+     * @param languageCode 语言代码
+     * @param key 字符串键名
+     * @return 本地化字符串，如果没有找到返回 null
+     */
+    fun getLocalizedString(languageCode: String, key: String): String?
+
+    /**
+     * 获取插件支持的语言列表
+     * @return 语言代码列表
+     */
+    fun getSupportedLanguages(): List<String>
+}

--- a/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginManifest.kt
+++ b/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginManifest.kt
@@ -1,0 +1,19 @@
+package com.lanrhyme.micyou.plugin
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+
+@Serializable
+data class PluginManifest(
+    val id: String,
+    val name: String,
+    val version: String,
+    val author: String,
+    val description: String = "",
+    val tags: List<String> = emptyList(),
+    val platform: PluginPlatform = PluginPlatform.BOTH,
+    @SerialName("minApiVersion")
+    val minApiVersion: String,
+    @SerialName("mainClass")
+    val mainClass: String
+)

--- a/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginPlatform.kt
+++ b/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginPlatform.kt
@@ -1,0 +1,14 @@
+package com.lanrhyme.micyou.plugin
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class PluginPlatform {
+    @SerialName("mobile")
+    MOBILE,
+    @SerialName("desktop")
+    DESKTOP,
+    @SerialName("both")
+    BOTH
+}

--- a/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginSettingsProvider.kt
+++ b/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginSettingsProvider.kt
@@ -1,0 +1,8 @@
+package com.lanrhyme.micyou.plugin
+
+import androidx.compose.runtime.Composable
+
+interface PluginSettingsProvider {
+    @Composable
+    fun SettingsContent()
+}

--- a/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginUIProvider.kt
+++ b/plugin-api/src/main/kotlin/com/lanrhyme/micyou/plugin/PluginUIProvider.kt
@@ -1,0 +1,28 @@
+package com.lanrhyme.micyou.plugin
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+enum class MobileUIMode {
+    Dialog,
+    NewScreen
+}
+
+interface PluginUIProvider {
+    val hasMainWindow: Boolean get() = false
+    val hasDialog: Boolean get() = false
+    
+    val windowWidth: Dp get() = 600.dp
+    val windowHeight: Dp get() = 500.dp
+    val windowTitle: String get() = "Plugin Window"
+    val windowResizable: Boolean get() = true
+    
+    val mobileUIMode: MobileUIMode get() = MobileUIMode.Dialog
+    
+    @Composable
+    fun MainWindow(onClose: () -> Unit) {}
+    
+    @Composable
+    fun DialogContent(onDismiss: () -> Unit) {}
+}


### PR DESCRIPTION
﻿修复 Android 端快速点击"开始串流"/"停止"按钮后按钮失效的问题。

根因：stop() 仅调用 job?.cancel() 后立即返回，不等旧引擎协程的 finally 清理块执行完毕。旧协程异步将 _state 覆盖回 Idle，与新 start() 设置的 Connecting 冲突，造成按钮卡死。

修复：
- stop() 改为 suspend 函数，在 startStopMutex.withLock 保护下依次执行 cancel -> join -> null job -> Idle。join() 确保旧协程完全终止后才返回。
- AudioStreamViewModel 改用 streamJob: Job? 替代 isStartStreamRequestPending 持久 flag。startStream() 中先取消旧 job 再启动新 job。
- stopStream() 中先 streamJob?.cancel() 再异步调用 stop()。
- onCleared() 中用 runBlocking 适配 stop() 变为 suspend。
- 恢复被上游 commit 2d55ef6 意外删除的 plugin-api 模块。
