### PR TITLE
fix: 修复异常断连后僵尸连接与重连无声问题

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Constants.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Constants.kt
@@ -27,6 +27,12 @@ object Constants {
     /** TCP 连接超时时间 (毫秒) */
     const val TCP_CONNECTION_TIMEOUT_MS = 10000L
 
+    /** 连接存活检测：超过该时间未收到对端任何数据(pong 每秒一次)则判定连接已死并主动断开 (毫秒) */
+    const val CONNECTION_LIVENESS_TIMEOUT_MS = 5000L
+
+    /** 连接存活检测的轮询间隔 (毫秒) */
+    const val CONNECTION_LIVENESS_CHECK_INTERVAL_MS = 1000L
+
     // ==================== 端口配置 ====================
     /** 默认 TCP 端口 (Wi-Fi / USB 模式) */
     const val DEFAULT_TCP_PORT = 6000

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/ConnectionHandler.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/ConnectionHandler.kt
@@ -51,6 +51,10 @@ class ConnectionHandler(
     @Volatile
     private var rtt = 0L
 
+    // 连接存活检测：记录最近一次收到对端数据的时间
+    @Volatile
+    private var lastInboundAt = System.currentTimeMillis()
+
     /**
      * Starts the connection handling loop.
      * This function suspends until the connection is closed or an error occurs.
@@ -80,12 +84,29 @@ class ConnectionHandler(
                     }
                 }
 
+                // 存活看门狗：客户端每秒回一次 pong，若长时间收不到任何数据，
+                // 说明对端已异常掉线(半开连接)，主动断开以便服务器接受新连接。
+                // 否则接收循环会阻塞在无超时的 read 上，直到操作系统内核放弃
+                // 该死连接(可能长达十几分钟)，期间新客户端无法真正接入。
+                lastInboundAt = System.currentTimeMillis()
+                val watchdogJob = launch {
+                    while (isActive) {
+                        delay(Constants.CONNECTION_LIVENESS_CHECK_INTERVAL_MS)
+                        val silentMs = System.currentTimeMillis() - lastInboundAt
+                        if (silentMs > Constants.CONNECTION_LIVENESS_TIMEOUT_MS) {
+                            Logger.w("ConnectionHandler", "存活检测超时: ${silentMs}ms 未收到对端数据，判定连接已死，主动断开")
+                            throw IOException("Liveness timeout: no inbound data for ${silentMs}ms")
+                        }
+                    }
+                }
+
                 // 3. Start receive loop
                 try {
                     processReceiveLoop()
                 } finally {
                     writerJob?.cancel()
                     pingJob?.cancel()
+                    watchdogJob.cancel()
                 }
             }
         } catch (e: Exception) {
@@ -189,6 +210,9 @@ class ConnectionHandler(
     val packetBytes = ByteArray(length)
             input.readFully(packetBytes)
 
+            // 收到一个完整数据包，刷新存活时间戳
+            lastInboundAt = System.currentTimeMillis()
+
             try {
                 val wrapper: MessageWrapper = proto.decodeFromByteArray(MessageWrapper.serializer(), packetBytes)
 
@@ -255,6 +279,7 @@ class ConnectionHandler(
             if (msg.contains("Socket closed", ignoreCase = true)) return true
             if (msg.contains("Connection reset", ignoreCase = true)) return true
             if (msg.contains("Broken pipe", ignoreCase = true)) return true
+            if (msg.contains("Liveness timeout", ignoreCase = true)) return true
         }
         return false
     }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/ConnectionHandler.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/ConnectionHandler.kt
@@ -51,9 +51,9 @@ class ConnectionHandler(
     @Volatile
     private var rtt = 0L
 
-    // 连接存活检测：记录最近一次收到对端数据的时间
+    // 连接存活检测：记录最近一次收到对端数据的时间（单调时钟，避免系统校时影响）
     @Volatile
-    private var lastInboundAt = System.currentTimeMillis()
+    private var lastInboundAtNs = System.nanoTime()
 
     /**
      * Starts the connection handling loop.
@@ -88,11 +88,11 @@ class ConnectionHandler(
                 // 说明对端已异常掉线(半开连接)，主动断开以便服务器接受新连接。
                 // 否则接收循环会阻塞在无超时的 read 上，直到操作系统内核放弃
                 // 该死连接(可能长达十几分钟)，期间新客户端无法真正接入。
-                lastInboundAt = System.currentTimeMillis()
+                lastInboundAtNs = System.nanoTime()
                 val watchdogJob = launch {
                     while (isActive) {
                         delay(Constants.CONNECTION_LIVENESS_CHECK_INTERVAL_MS)
-                        val silentMs = System.currentTimeMillis() - lastInboundAt
+                        val silentMs = (System.nanoTime() - lastInboundAtNs) / 1_000_000
                         if (silentMs > Constants.CONNECTION_LIVENESS_TIMEOUT_MS) {
                             Logger.w("ConnectionHandler", "存活检测超时: ${silentMs}ms 未收到对端数据，判定连接已死，主动断开")
                             throw IOException("Liveness timeout: no inbound data for ${silentMs}ms")
@@ -211,7 +211,7 @@ class ConnectionHandler(
             input.readFully(packetBytes)
 
             // 收到一个完整数据包，刷新存活时间戳
-            lastInboundAt = System.currentTimeMillis()
+            lastInboundAtNs = System.nanoTime()
 
             try {
                 val wrapper: MessageWrapper = proto.decodeFromByteArray(MessageWrapper.serializer(), packetBytes)

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/JitterBuffer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/JitterBuffer.kt
@@ -82,7 +82,7 @@ class JitterBuffer(
         // 若不处理，新会话的小序列号会一直被下面的 "< currentExpected" 判定为
         // 过期乱序包而全部丢弃，导致重连后有连接、有 UDP 包却完全没有声音。
         // 此处重置缓冲状态，以新序列号为基准重新开始播放。
-        if (packet.sequenceNumber < currentExpected - SESSION_RESET_BACKWARD_GAP) {
+        if (currentExpected - packet.sequenceNumber > SESSION_RESET_BACKWARD_GAP) {
             Logger.i(
                 "JitterBuffer",
                 "检测到序列号大幅倒退 (期待 $currentExpected, 收到 ${packet.sequenceNumber})，" +

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/JitterBuffer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/JitterBuffer.kt
@@ -24,6 +24,15 @@ class JitterBuffer(
     private val onAudioPacketReady: suspend (AudioPacketMessage) -> Unit,
     private val fecGroupSize: Int = 12
 ) {
+    companion object {
+        /**
+         * 序列号倒退超过该阈值时，判定为客户端重连的新会话（而非普通乱序）。
+         * 取一个足够大的值以免把正常乱序误判为重连：正常网络乱序只差几个到几十个包，
+         * 而重连时序列号会从头(接近 0)开始，与当前期待值相差成千上万。
+         */
+        private const val SESSION_RESET_BACKWARD_GAP = 1000
+    }
+
     private val buffer = ConcurrentHashMap<Int, AudioPacketMessageOrdered>()
 
     private val fecPackets = ConcurrentHashMap<Int, AudioPacketMessageOrdered>()
@@ -68,7 +77,22 @@ class JitterBuffer(
         }
 
         val currentExpected = expectedSequenceNumber.get()
-        if (packet.sequenceNumber < currentExpected) {
+
+        // 新会话检测：序列号大幅倒退说明客户端已重连、序列号从头重新开始。
+        // 若不处理，新会话的小序列号会一直被下面的 "< currentExpected" 判定为
+        // 过期乱序包而全部丢弃，导致重连后有连接、有 UDP 包却完全没有声音。
+        // 此处重置缓冲状态，以新序列号为基准重新开始播放。
+        if (packet.sequenceNumber < currentExpected - SESSION_RESET_BACKWARD_GAP) {
+            Logger.i(
+                "JitterBuffer",
+                "检测到序列号大幅倒退 (期待 $currentExpected, 收到 ${packet.sequenceNumber})，" +
+                        "判定为客户端重连，重置抖动缓冲以恢复音频"
+            )
+            resetForNewSession(packet.sequenceNumber)
+        }
+
+        val expectedAfterReset = expectedSequenceNumber.get()
+        if (packet.sequenceNumber < expectedAfterReset) {
             packetsOutOfOrder.incrementAndGet()
             return
         }
@@ -76,6 +100,17 @@ class JitterBuffer(
         buffer[packet.sequenceNumber] = packet
         processBuffer()
         maybeLogStats()
+    }
+
+    /**
+     * 客户端重连后，序列号从头开始，需要清空旧会话遗留的缓冲/FEC/已播放数据，
+     * 并以新的序列号作为新的期待起点，否则新包会被当作过期乱序包丢弃。
+     */
+    private fun resetForNewSession(newSequenceNumber: Int) {
+        buffer.clear()
+        fecPackets.clear()
+        playedPackets.clear()
+        expectedSequenceNumber.set(newSequenceNumber)
     }
 
     private fun processBuffer() {


### PR DESCRIPTION
## 背景

本 PR 修复 `legacy/v1` 桌面端在 Wi-Fi 串流场景下的两个相关故障：

1. **手机异常断开后，PC 端抱着僵尸 TCP 连接，重连恢复极慢**
2. **手机长时间关闭后再连，PC 显示“正在传输”但无声音**

这两个问题用户体感很像，都是“断了再连就不好用，只能重启 PC 端”，但根因不同。详细复现、现场证据和根因分析见关联 Issue：#273。

> 本 PR **只针对 `legacy/v1`**，不改 master / Tauri / Rust 重构路线。

## 根因摘要

### 1) 僵尸连接

- `ConnectionHandler` 接收循环无读超时
- 虽有每秒 ping，但没有“超时未收到入站数据就断开”的判定
- accept 循环串行等待当前连接结束
- 手机异常断开形成半开连接后，PC 可能长时间卡死在旧会话上

### 2) 重连无声

- `JitterBuffer` 用序列号排序播放
- 旧逻辑把所有 `seq < expected` 的包直接丢弃
- 旧会话序列号未在重连时重置
- 新会话从小序列号重新开始时，音频包会被全部当成过期乱序包丢掉
- 所以 TCP/UI 正常，但没有声音

## 修复内容

### 1. 连接存活看门狗

文件：

- `composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Constants.kt`
- `composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/ConnectionHandler.kt`

改动：

- 新增 `CONNECTION_LIVENESS_TIMEOUT_MS = 5000`
- 新增 `CONNECTION_LIVENESS_CHECK_INTERVAL_MS = 1000`
- 记录最近一次入站数据时间
- 超时无入站数据时主动断开死连接
- 将 `Liveness timeout` 归为正常断开，避免误报错误弹窗

### 2. JitterBuffer 新会话重置

文件：

- `composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/JitterBuffer.kt`

改动：

- 当序列号倒退超过 `1000` 时，判定为客户端重连新会话
- 清空旧 buffer / FEC / 已播放缓存
- 以新序列号为起点恢复播放

## 为什么阈值这样设

- 正常 UDP 乱序通常只差几个到几十个包
- 客户端重连后序列号通常从头开始，与旧期待值往往相差成千上万
- 因此：
  - 存活超时 5 秒：对正常心跳足够宽松，对异常断开足够快
  - 序列号倒退阈值 1000：足够区分“普通乱序”和“新会话重连”

## 验证

### 场景 A：异常断开后重连

1. 正常串流
2. 手机端关闭 / 强杀 App
3. 手机再次连接

结果：

- 修复前：恢复很慢，常需 PC 端手动重启
- 修复后：约 5 秒左右可自动恢复

### 场景 B：长时间关闭后再连

1. 正常串流一段时间
2. 手机长时间关闭
3. 再次连接

预期：

- PC 显示正在传输后应立刻有声音
- 不再因为旧序列号残留而静音

### 回归

- 正常连接与正常串流未观察到破坏

## 变更文件

- `composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/Constants.kt`
- `composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/ConnectionHandler.kt`
- `composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/network/JitterBuffer.kt`

## 范围说明

- 目标分支：`legacy/v1`
- 不修改 master / V2 重构代码
- 不改变协议格式，不要求 Android 端同步升级

## 关联

Closes #273