### PR TITLE
refactor: 简化 AEC 架构并使用 WASAPI loopback 获取真实扬声器参考

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ QWEN.md
 .trae
 composeApp/micyou.conf
 agentchattr/
+.reasonix/

--- a/tauri-app/Cargo.lock
+++ b/tauri-app/Cargo.lock
@@ -3229,6 +3229,7 @@ dependencies = [
  "rubato",
  "rustfft",
  "serde",
+ "wasapi",
 ]
 
 [[package]]
@@ -6720,6 +6721,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasapi"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa8cc540a2d488fe9d9060a76cf1f777c6d081a08217f2e4a7a0cca110e6e04"
+dependencies = [
+ "log",
+ "num-integer",
+ "thiserror 2.0.18",
+ "widestring",
+ "windows 0.59.0",
+ "windows-core 0.59.0",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6949,7 +6964,7 @@ dependencies = [
  "webview2-com-sys",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
+ "windows-implement 0.60.2",
  "windows-interface",
 ]
 
@@ -6974,6 +6989,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -7057,6 +7078,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
+dependencies = [
+ "windows-core 0.59.0",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -7089,11 +7120,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
+dependencies = [
+ "windows-implement 0.59.0",
+ "windows-interface",
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
+ "windows-implement 0.60.2",
  "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
@@ -7106,7 +7150,7 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
+ "windows-implement 0.60.2",
  "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7122,6 +7166,17 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7204,6 +7259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/tauri-app/crates/micyou-audio/Cargo.toml
+++ b/tauri-app/crates/micyou-audio/Cargo.toml
@@ -17,16 +17,11 @@ cpal = "0.15.3"
 rubato = "3.0.0"
 ringbuf = "0.3.3"
 
+[target.'cfg(windows)'.dependencies]
+wasapi = "0.16"
+
 # DSP dependencies (optional)
 nnnoiseless = { version = "0.5.2", optional = true }
 ort = { version = "=2.0.0-rc.12", features = ["download-binaries", "coreml", "tls-rustls", "std", "ndarray", "api-17"], optional = true }
 rustfft = { version = "6.4.1", optional = true }
 ndarray = { version = "0.17", optional = true }
-
-# [[bin]]
-# name = "test_onnx"
-# path = "src/test_onnx.rs"
-
-# [[bin]]
-# name = "test_ola"
-# path = "src/test_ola.rs"

--- a/tauri-app/crates/micyou-audio/src/dsp.rs
+++ b/tauri-app/crates/micyou-audio/src/dsp.rs
@@ -772,166 +772,42 @@ impl AecProcessor {
 
 /// Delay estimator for far-end/mic time alignment.
 ///
-/// Maintains a circular buffer of far-end (speaker) audio history and
-/// periodically cross-correlates it with the mic signal to estimate the
-/// acoustic delay.  Uses coarse-to-fine search for efficiency:
-/// 1. Downsamples both signals by 8x for a fast coarse search
-/// 2. Refines around the coarse peak at full resolution
-/// 3. Applies EMA smoothing to avoid jitter
+/// Simple ring buffer for far-end audio fed to AEC.
 #[cfg(feature = "noise-suppression")]
-struct DelayEstimator {
-    far_history: Vec<f32>,
+struct FarEndBuffer {
+    buffer: Vec<f32>,
     write_pos: usize,
-    total_written: usize,
-    smoothed_delay: f32,
-    max_delay: usize,
-    alpha: f32,
-    estimate_interval: usize,
-    frame_count: usize,
-    ds_factor: usize,
-    ds_mic: Vec<f32>,
-    ds_far: Vec<f32>,
-    fine_far: Vec<f32>,
 }
 
 #[cfg(feature = "noise-suppression")]
-impl DelayEstimator {
-    fn new(max_delay_ms: f32, sample_rate: usize) -> Self {
-        let max_delay = (max_delay_ms / 1000.0 * sample_rate as f32).ceil() as usize;
-        let history_len = max_delay + AEC_HOP_LEN;
-        let ds_factor = 8;
+impl FarEndBuffer {
+    fn new() -> Self {
         Self {
-            far_history: vec![0.0; history_len],
+            buffer: vec![0.0; 480 * 2],
             write_pos: 0,
-            total_written: 0,
-            smoothed_delay: 0.0,
-            max_delay,
-            alpha: 0.92,
-            estimate_interval: 5,
-            frame_count: 0,
-            ds_factor,
-            ds_mic: vec![0.0; AEC_HOP_LEN / ds_factor],
-            ds_far: vec![0.0; (max_delay + AEC_HOP_LEN) / ds_factor],
-            fine_far: vec![0.0; AEC_HOP_LEN + 64],
         }
     }
 
-    fn feed_far(&mut self, far_audio: &[f32]) {
-        for &sample in far_audio {
-            self.far_history[self.write_pos] = sample;
-            self.write_pos = (self.write_pos + 1) % self.far_history.len();
+    fn feed(&mut self, data: &[f32]) {
+        for &sample in data {
+            self.buffer[self.write_pos] = sample;
+            self.write_pos = (self.write_pos + 1) % self.buffer.len();
         }
-        self.total_written += far_audio.len();
     }
 
-    fn is_ready(&self) -> bool {
-        self.total_written >= self.max_delay + AEC_HOP_LEN
-    }
-
-    fn aligned_far(&mut self, mic_chunk: &[f32]) -> Vec<f32> {
-        debug_assert_eq!(mic_chunk.len(), AEC_HOP_LEN);
-        if !self.is_ready() {
-            return vec![0.0; AEC_HOP_LEN];
-        }
-        self.frame_count += 1;
-        if self.frame_count % self.estimate_interval == 0 {
-            self.estimate(mic_chunk);
-        }
-        self.read_at_delay(self.smoothed_delay.round() as usize)
-    }
-
-    fn read_at_delay(&self, delay: usize) -> Vec<f32> {
-        let delay = delay.min(self.max_delay);
-        let len = self.far_history.len();
-        let start = (self.write_pos + len - delay) % len;
-        let mut out = vec![0.0; AEC_HOP_LEN];
-        if start + AEC_HOP_LEN <= len {
-            out.copy_from_slice(&self.far_history[start..start + AEC_HOP_LEN]);
+    fn read_last_hop(&self) -> Vec<f32> {
+        let hop = AEC_HOP_LEN;
+        let len = self.buffer.len();
+        let start = (self.write_pos + len - hop) % len;
+        let mut out = vec![0.0; hop];
+        if start + hop <= len {
+            out.copy_from_slice(&self.buffer[start..start + hop]);
         } else {
             let first = len - start;
-            out[..first].copy_from_slice(&self.far_history[start..]);
-            out[first..].copy_from_slice(&self.far_history[..AEC_HOP_LEN - first]);
+            out[..first].copy_from_slice(&self.buffer[start..]);
+            out[first..].copy_from_slice(&self.buffer[..hop - first]);
         }
         out
-    }
-
-    fn estimate(&mut self, mic_chunk: &[f32]) {
-        let df = self.ds_factor;
-        let ds_mic_len = AEC_HOP_LEN / df;
-        let ds_far_len = (self.max_delay + AEC_HOP_LEN) / df;
-
-        for i in 0..ds_mic_len {
-            self.ds_mic[i] = mic_chunk[i * df];
-        }
-
-        let far_segment_len = self.max_delay + AEC_HOP_LEN;
-        {
-            let len = self.far_history.len();
-            let seg_start = (self.write_pos + len - far_segment_len) % len;
-            for i in 0..ds_far_len {
-                let si = i * df;
-                self.ds_far[i] = if seg_start + si < len {
-                    self.far_history[seg_start + si]
-                } else {
-                    self.far_history[seg_start + si - len]
-                };
-            }
-        }
-
-        let search_range = ds_far_len.saturating_sub(ds_mic_len);
-        if search_range == 0 {
-            return;
-        }
-
-        let mut best_coarse = f32::NEG_INFINITY;
-        let mut best_coarse_lag = 0usize;
-        for lag in 0..=search_range {
-            let mut corr = 0.0f32;
-            for i in 0..ds_mic_len {
-                corr += self.ds_mic[i] * self.ds_far[lag + i];
-            }
-            if corr > best_coarse {
-                best_coarse = corr;
-                best_coarse_lag = lag;
-            }
-        }
-
-        let coarse_samples = best_coarse_lag * df;
-        let fine_window = (df * 2).min(64);
-        let fine_start = coarse_samples.saturating_sub(fine_window);
-        let fine_end = (coarse_samples + fine_window).min(self.max_delay);
-        let fine_search_len = fine_end.saturating_sub(fine_start);
-
-        if fine_search_len == 0 || fine_search_len + AEC_HOP_LEN > self.fine_far.len() {
-            let new_delay = coarse_samples as f32;
-            self.smoothed_delay = self.alpha * self.smoothed_delay + (1.0 - self.alpha) * new_delay;
-            return;
-        }
-
-        let far_start = (self.write_pos + self.far_history.len() - self.max_delay - AEC_HOP_LEN
-            + fine_start)
-            % self.far_history.len();
-        let needed = fine_search_len + AEC_HOP_LEN;
-        let far_len = self.far_history.len();
-        for i in 0..needed {
-            self.fine_far[i] = self.far_history[(far_start + i) % far_len];
-        }
-
-        let mut best_fine = f32::NEG_INFINITY;
-        let mut best_fine_lag = 0usize;
-        for lag in 0..fine_search_len {
-            let mut corr = 0.0f32;
-            for i in 0..AEC_HOP_LEN {
-                corr += mic_chunk[i] * self.fine_far[lag + i];
-            }
-            if corr > best_fine {
-                best_fine = corr;
-                best_fine_lag = lag;
-            }
-        }
-
-        let new_delay = (fine_start + best_fine_lag) as f32;
-        self.smoothed_delay = self.alpha * self.smoothed_delay + (1.0 - self.alpha) * new_delay;
     }
 }
 
@@ -1261,21 +1137,17 @@ pub struct DspProcessor {
     #[cfg(feature = "noise-suppression")]
     purevox_load_failed: bool,
 
-    // AEC7 ONNX acoustic echo cancellation - separate per channel
-    // to avoid state cross-contamination (cache tensors, OLAs, histories).
+    // AEC7 ONNX acoustic echo cancellation.
+    // Stereo is downmixed to mono before AEC, then upmixed back (reference pattern).
     #[cfg(feature = "noise-suppression")]
-    aec_left: Option<AecProcessor>,
-    #[cfg(feature = "noise-suppression")]
-    aec_right: Option<AecProcessor>,
+    aec: Option<AecProcessor>,
     #[cfg(feature = "noise-suppression")]
     aec_model_path: Option<PathBuf>,
     #[cfg(feature = "noise-suppression")]
     aec_load_failed: bool,
-    /// Far-end delay estimator + alignment for AEC.
-    /// Cross-correlates mic with far-end history to estimate and compensate
-    /// for speaker-to-mic acoustic delay.
+    /// Far-end buffer for AEC.
     #[cfg(feature = "noise-suppression")]
-    delay_estimator: DelayEstimator,
+    far_end: FarEndBuffer,
 
     // Speexdsp-style NS
     #[cfg(feature = "dsp")]
@@ -1337,14 +1209,13 @@ impl DspProcessor {
             purevox_load_failed: false,
 
             #[cfg(feature = "noise-suppression")]
-            aec_left: None,
-            #[cfg(feature = "noise-suppression")]
-            aec_right: None,
+            aec: None,
             #[cfg(feature = "noise-suppression")]
             aec_model_path: _model_dir.as_ref().map(|d| d.join("aec7_ep0185.onnx")),
             #[cfg(feature = "noise-suppression")]
             aec_load_failed: false,
-            delay_estimator: DelayEstimator::new(500.0, 48000),
+            #[cfg(feature = "noise-suppression")]
+            far_end: FarEndBuffer::new(),
 
             #[cfg(feature = "dsp")]
             speex_ns: SpeexStyleNS::new(),
@@ -1480,101 +1351,93 @@ impl DspProcessor {
         (self.raw_spectrum.clone(), self.processed_spectrum.clone())
     }
 
-    /// Feed far-end (speaker) audio for AEC synchronization.
-    /// The far-end buffer is consumed during `apply_aec` to match mic frame boundaries.
+    /// Feed far-end (speaker) audio for AEC.
     pub fn set_far_end_audio(&mut self, far_end: &[f32]) {
-        self.delay_estimator.feed_far(far_end);
+        self.far_end.feed(far_end);
     }
 
     // ── AEC Acoustic Echo Cancellation ────────────────────────────────────
 
     #[cfg(feature = "noise-suppression")]
     fn apply_aec(&mut self, data: &mut Vec<f32>, channels: usize) {
-        // Lazy init — only attempt once per channel; mark failed to avoid retries
-        let mut init = |slot: &mut Option<AecProcessor>, label: &str| -> bool {
-            if slot.is_some() || self.aec_load_failed {
-                return slot.is_some();
-            }
+        // Lazy init — only load model once; mark failed to avoid retries
+        if self.aec.is_none() && !self.aec_load_failed {
             if let Some(path) = &self.aec_model_path {
                 if path.exists() {
                     match AecProcessor::new(path.to_str().unwrap_or("")) {
                         Ok(proc) => {
-                            log::info!("[DSP] AEC7 ONNX model loaded ({}): {:?}", label, path);
-                            *slot = Some(proc);
-                            return true;
+                            log::info!("[DSP] AEC7 ONNX model loaded: {:?}", path);
+                            self.aec = Some(proc);
                         }
                         Err(e) => {
-                            log::error!("[DSP] Failed to load AEC7 model ({}): {}", label, e);
+                            log::error!("[DSP] Failed to load AEC7 model: {}", e);
                             self.aec_load_failed = true;
-                            return false;
+                            return;
                         }
                     }
                 } else {
                     log::warn!("[DSP] AEC7 model not found at {:?}, disabling AEC", path);
                     self.aec_load_failed = true;
-                    return false;
+                    return;
                 }
             } else {
                 self.aec_load_failed = true;
-                return false;
+                return;
             }
-        };
-
-        if !init(&mut self.aec_left, "L") {
-            return;
         }
-        if channels >= 2 {
-            init(&mut self.aec_right, "R");
+
+        if self.aec.is_none() {
+            return;
         }
 
         let hop = AEC_HOP_LEN; // 480
 
+        // Reference pattern: stereo → mono downmix → AEC → mono → stereo upmix.
+        // The AEC model operates on mono signals only. For stereo input, we
+        // downmix to mono, process echo cancellation, then upmix the result
+        // back to the original channel count by duplicating the mono output.
         if channels >= 2 {
-            // Stereo: process left and right in lockstep.
-            // Delay estimator provides time-aligned far-end chunks — no
-            // manual drain needed; alignment is handled internally.
-            let frames = data.len() / 2;
-            let mut out: Vec<f32> = Vec::with_capacity(data.len());
-
-            let mut left_offset = 0usize;
-            let mut right_offset = 0usize;
-
-            while left_offset + hop <= frames && right_offset + hop <= frames {
-                // Process left channel hop
-                let mic_left: Vec<f32> = (0..hop).map(|i| data[(left_offset + i) * 2]).collect();
-                let far_chunk = self.delay_estimator.aligned_far(&mic_left);
-                let clean_left = match &mut self.aec_left {
-                    Some(proc) => proc.process(&mic_left, &far_chunk),
-                    None => mic_left.clone(),
-                };
-
-                // Process right channel hop (same far-end reference)
-                let mic_right: Vec<f32> =
-                    (0..hop).map(|i| data[(right_offset + i) * 2 + 1]).collect();
-                let clean_right = match &mut self.aec_right {
-                    Some(proc) => proc.process(&mic_right, &far_chunk),
-                    None => mic_right.clone(),
-                };
-
-                // Interleave back
-                for i in 0..hop {
-                    out.push(clean_left[i]);
-                    out.push(clean_right[i]);
+            // ── Stereo → mono downmix ──
+            let frames = data.len() / channels;
+            let mut mono_data: Vec<f32> = Vec::with_capacity(frames);
+            for i in 0..frames {
+                let mut sum = 0.0f32;
+                for ch in 0..channels {
+                    sum += data[i * channels + ch];
                 }
-
-                left_offset += hop;
-                right_offset += hop;
+                mono_data.push(sum / channels as f32);
             }
 
+            // ── AEC on mono signal ──
+            let mut mono_output = Vec::with_capacity(mono_data.len());
+            for chunk in mono_data.chunks(hop) {
+                if chunk.len() == hop {
+                    let far_chunk = self.far_end.read_last_hop();
+                    let clean = match &mut self.aec {
+                        Some(proc) => proc.process(chunk, &far_chunk),
+                        None => chunk.to_vec(),
+                    };
+                    mono_output.extend_from_slice(&clean);
+                } else {
+                    mono_output.extend_from_slice(chunk);
+                }
+            }
+
+            // ── Mono → stereo upmix (duplicate mono to all channels) ──
             data.clear();
-            data.extend_from_slice(&out);
+            data.reserve(mono_output.len() * channels);
+            for &sample in &mono_output {
+                for _ in 0..channels {
+                    data.push(sample);
+                }
+            }
         } else {
-            // Mono: single channel through left AEC instance
+            // ── Mono: single channel through AEC ──
             let mut output = Vec::with_capacity(data.len());
             for chunk in data.chunks(hop) {
                 if chunk.len() == hop {
-                    let far_chunk = self.delay_estimator.aligned_far(chunk);
-                    let clean = match &mut self.aec_left {
+                    let far_chunk = self.far_end.read_last_hop();
+                    let clean = match &mut self.aec {
                         Some(proc) => proc.process(chunk, &far_chunk),
                         None => chunk.to_vec(),
                     };

--- a/tauri-app/crates/micyou-audio/src/lib.rs
+++ b/tauri-app/crates/micyou-audio/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod engine;
 #[cfg(feature = "dsp")]
 pub mod dsp;
+pub mod loopback;
 
 pub use engine::{AudioOutputManager, RubatoResampler};
 #[cfg(feature = "dsp")]
 pub use dsp::{AudioDspSettings, DspProcessor, EqualizerConfig};
+pub use loopback::LoopbackCapture;
 
 pub fn init_onnx_runtime() {
     #[cfg(feature = "noise-suppression")]

--- a/tauri-app/crates/micyou-audio/src/loopback.rs
+++ b/tauri-app/crates/micyou-audio/src/loopback.rs
@@ -1,0 +1,341 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use ringbuf::{HeapRb, Rb};
+
+const RING_BUF_SEC: usize = 2;
+const TARGET_RATE: u32 = 48000;
+
+/// Cross-platform speaker loopback capture for AEC far-end reference.
+///
+/// - Windows: WASAPI loopback on default render device (no virtual device needed)
+/// - macOS: cpal input from BlackHole
+/// - Linux: cpal input from PipeWire virtual mic
+pub struct LoopbackCapture {
+    active: Arc<AtomicBool>,
+    buffer: Arc<Mutex<HeapRb<f32>>>,
+}
+
+impl LoopbackCapture {
+    pub fn new() -> Self {
+        Self {
+            active: Arc::new(AtomicBool::new(false)),
+            buffer: Arc::new(Mutex::new(HeapRb::new(TARGET_RATE as usize * RING_BUF_SEC))),
+        }
+    }
+
+    pub fn start(&self) -> bool {
+        if self.active.load(Ordering::Relaxed) {
+            return true;
+        }
+        self.active.store(true, Ordering::Relaxed);
+
+        let active = self.active.clone();
+        let buffer = self.buffer.clone();
+
+        std::thread::Builder::new()
+            .name("SpeakerLoopback".into())
+            .spawn(move || {
+                #[cfg(target_os = "windows")]
+                wasapi_loopback_thread(active, buffer);
+                #[cfg(not(target_os = "windows"))]
+                cpal_capture_thread(active, buffer);
+            })
+            .is_ok()
+    }
+
+    pub fn stop(&self) {
+        self.active.store(false, Ordering::Relaxed);
+    }
+
+    /// Read n_samples from the loopback buffer, consuming them.
+    /// Returns None if insufficient data.
+    pub fn read(&self, n_samples: usize) -> Option<Vec<f32>> {
+        let mut buf = self.buffer.lock().ok()?;
+        if buf.len() < n_samples {
+            return None;
+        }
+        let mut out = Vec::with_capacity(n_samples);
+        for _ in 0..n_samples {
+            out.push(buf.pop().unwrap());
+        }
+        Some(out)
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::Relaxed)
+    }
+}
+
+// ─── Helper: downmix + resample + push to buffer ─────────────────────────
+
+fn push_to_buffer(
+    data: &[f32],
+    channels: usize,
+    _device_rate: u32,
+    resampler: &Option<Arc<Mutex<crate::engine::RubatoResampler>>>,
+    buffer: &Mutex<HeapRb<f32>>,
+) {
+    // Downmix to mono
+    let mono: Vec<f32> = if channels > 1 {
+        data.chunks(channels)
+            .map(|frame| frame.iter().sum::<f32>() / channels as f32)
+            .collect()
+    } else {
+        data.to_vec()
+    };
+
+    // Resample to 48kHz if needed
+    let resampled = if let Some(ref r) = resampler {
+        if let Ok(mut resampler) = r.lock() {
+            let mut out = Vec::new();
+            resampler.resample(&mono, 1, &mut out);
+            out
+        } else {
+            mono
+        }
+    } else {
+        mono
+    };
+
+    if let Ok(mut buf) = buffer.lock() {
+        for &s in &resampled {
+            buf.push_overwrite(s);
+        }
+    }
+}
+
+// ─── Windows: WASAPI loopback on default render device ────────────────────
+//
+// The trick: get the default render (speaker) device, then initialize its
+// IAudioClient with Direction::Capture + ShareMode::Shared.  The wasapi crate
+// automatically adds AUDCLNT_STREAMFLAGS_LOOPBACK in this combination
+// (see api.rs line 832-835).
+
+#[cfg(target_os = "windows")]
+fn wasapi_loopback_thread(active: Arc<AtomicBool>, buffer: Arc<Mutex<HeapRb<f32>>>) {
+    use std::collections::VecDeque;
+    use wasapi::*;
+
+    let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+        initialize_mta().ok()?;
+
+        let device = get_default_device(&Direction::Render)?;
+        let device_name = device.get_friendlyname().unwrap_or_default();
+        log::info!("[Loopback] WASAPI: capturing from '{}'", device_name);
+
+        let mut audio_client = device.get_iaudioclient()?;
+        let mix_format = audio_client.get_mixformat()?;
+        let channels = mix_format.get_nchannels() as usize;
+        let device_rate = mix_format.get_samplespersec();
+
+        log::info!(
+            "[Loopback] WASAPI device format: {}Hz {}ch",
+            device_rate, channels
+        );
+
+        let (_def_time, min_time) = audio_client.get_periods()?;
+
+        // Direction::Capture on a Render device = loopback (auto loopback flag)
+        audio_client.initialize_client(
+            &mix_format,
+            min_time,
+            &Direction::Capture,
+            &ShareMode::Shared,
+            true,
+        )?;
+
+        let h_event = audio_client.set_get_eventhandle()?;
+        let capture_client = audio_client.get_audiocaptureclient()?;
+
+        // Create resampler if device is not 48kHz
+        let resampler = if device_rate != TARGET_RATE {
+            match crate::engine::RubatoResampler::new(device_rate, TARGET_RATE, 1) {
+                Ok(r) => Some(Arc::new(Mutex::new(r))),
+                Err(e) => {
+                    log::error!("[Loopback] Failed to create resampler: {}", e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        audio_client.start_stream()?;
+        log::info!("[Loopback] WASAPI loopback started");
+
+        let bytes_per_frame = mix_format.get_blockalign() as usize;
+        let mut total_frames: u64 = 0;
+
+        while active.load(Ordering::Relaxed) {
+            let available = audio_client.get_available_space_in_frames()?;
+            if available == 0 {
+                h_event.wait_for_event(100)?;
+                continue;
+            }
+
+            let mut deque: VecDeque<u8> =
+                VecDeque::with_capacity(available as usize * bytes_per_frame);
+            let _flags = capture_client.read_from_device_to_deque(&mut deque)?;
+
+            if !deque.is_empty() {
+                let slice = deque.make_contiguous();
+                let f32_samples: Vec<f32> = slice
+                    .chunks_exact(4)
+                    .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                    .collect();
+
+                if !f32_samples.is_empty() {
+                    push_to_buffer(
+                        &f32_samples, channels, device_rate, &resampler, &buffer,
+                    );
+                    total_frames += (f32_samples.len() / channels) as u64;
+                }
+            }
+
+            h_event.wait_for_event(100)?;
+        }
+
+        audio_client.stop_stream()?;
+        log::info!(
+            "[Loopback] WASAPI loopback stopped, {} frames captured",
+            total_frames
+        );
+        Ok(())
+    })();
+
+    if let Err(e) = result {
+        log::error!("[Loopback] WASAPI error: {}", e);
+    }
+    active.store(false, Ordering::Relaxed);
+}
+
+// ─── macOS/Linux: cpal capture from virtual audio device ──────────────────
+
+#[cfg(not(target_os = "windows"))]
+fn cpal_capture_thread(active: Arc<AtomicBool>, buffer: Arc<Mutex<HeapRb<f32>>>) {
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+    let host = cpal::default_host();
+
+    // Find virtual audio device by name hint
+    let hints: &[&str] = &[
+        "monitor",      // Linux: PulseAudio/PipeWire monitor sources
+        "blackhole",    // macOS
+        "pipewire",     // Linux fallback
+        "virtual",      // Linux fallback
+    ];
+
+    let device = {
+        let mut found = None;
+        if let Ok(devices) = host.input_devices() {
+            'outer: for dev in devices {
+                if let Ok(name) = dev.name() {
+                    let lower = name.to_lowercase();
+                    for hint in hints {
+                        if lower.contains(hint) {
+                            log::info!("[Loopback] Found virtual device: '{}'", name);
+                            found = Some(dev);
+                            break 'outer;
+                        }
+                    }
+                }
+            }
+        }
+        match found {
+            Some(d) => d,
+            None => {
+                log::error!(
+                    "[Loopback] No virtual audio device found. \
+                     Install BlackHole (macOS) or PipeWire (Linux)."
+                );
+                active.store(false, Ordering::Relaxed);
+                return;
+            }
+        }
+    };
+
+    let config = match device.default_input_config() {
+        Ok(c) => c,
+        Err(e) => {
+            log::error!("[Loopback] Failed to get input config: {}", e);
+            active.store(false, Ordering::Relaxed);
+            return;
+        }
+    };
+
+    let channels = config.channels() as usize;
+    let device_rate = config.sample_rate().0;
+    let sample_format = config.sample_format();
+
+    log::info!(
+        "[Loopback] cpal capture started: {}Hz {}ch",
+        device_rate, channels
+    );
+
+    let resampler = if device_rate != TARGET_RATE {
+        match crate::engine::RubatoResampler::new(device_rate, TARGET_RATE, 1) {
+            Ok(r) => Some(Arc::new(Mutex::new(r))),
+            Err(e) => {
+                log::error!("[Loopback] Failed to create resampler: {}", e);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let err_fn = |err: cpal::StreamError| {
+        log::error!("[Loopback] Stream error: {}", err);
+    };
+
+    let buf_clone = buffer.clone();
+    let active_clone = active.clone();
+    let resampler_clone = resampler.clone();
+
+    let stream_result = match sample_format {
+        cpal::SampleFormat::F32 => device.build_input_stream(
+            &config.into(),
+            move |data: &[f32], _: &cpal::InputCallbackInfo| {
+                push_to_buffer(data, channels, device_rate, &resampler_clone, &buf_clone);
+            },
+            err_fn,
+            None,
+        ),
+        cpal::SampleFormat::I16 => device.build_input_stream(
+            &config.into(),
+            move |data: &[i16], _: &cpal::InputCallbackInfo| {
+                let f32_data: Vec<f32> = data.iter().map(|&s| s as f32 / 32768.0).collect();
+                push_to_buffer(&f32_data, channels, device_rate, &resampler_clone, &buf_clone);
+            },
+            err_fn,
+            None,
+        ),
+        fmt => {
+            log::error!("[Loopback] Unsupported sample format: {:?}", fmt);
+            active.store(false, Ordering::Relaxed);
+            return;
+        }
+    };
+
+    match stream_result {
+        Ok(stream) => {
+            if let Err(e) = stream.play() {
+                log::error!("[Loopback] Failed to start stream: {}", e);
+                active.store(false, Ordering::Relaxed);
+                return;
+            }
+
+            while active_clone.load(Ordering::Relaxed) {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+
+            drop(stream);
+            log::info!("[Loopback] Stopped");
+        }
+        Err(e) => {
+            log::error!("[Loopback] Failed to build stream: {}", e);
+            active.store(false, Ordering::Relaxed);
+        }
+    }
+}

--- a/tauri-app/src-tauri/src/commands/system.rs
+++ b/tauri-app/src-tauri/src/commands/system.rs
@@ -104,11 +104,19 @@ pub async fn start_server(
         };
         let mut jb = crate::jitter_buffer::JitterBuffer::new(12);
         let mut frame_counter = 0;
-        let mut previous_output: Vec<f32> = Vec::new(); // far-end reference for AEC
         let mut input_resampler: Option<micyou_audio::RubatoResampler> = None;
         let mut current_input_sample_rate: u32 = 0;
         let mut resample_out_buf = Vec::new();
         let mut pcm_f32 = Vec::new();
+
+        // Start speaker loopback capture for AEC far-end reference.
+        // Captures actual speaker output via WASAPI (Windows) / BlackHole (macOS) / PipeWire (Linux).
+        let loopback = micyou_audio::LoopbackCapture::new();
+        if loopback.start() {
+            log::info!("[Audio] Speaker loopback capture started for AEC");
+        } else {
+            log::warn!("[Audio] Failed to start speaker loopback, AEC far-end will be unavailable");
+        }
 
         while let Some(packet) = audio_rx.blocking_recv() {
             jb.push(packet);
@@ -207,30 +215,17 @@ pub async fn start_server(
                             let sum: f32 = pcm_f32.iter().map(|x| x * x).sum();
                             (sum / pcm_f32.len() as f32).sqrt()
                         } else {
-                            // Feed previous output as far-end reference for AEC.
-                            // Downmix stereo to mono to avoid interleaved L/R data
-                            // corrupting the AEC mono reference signal.
-                            if !previous_output.is_empty() {
-                                let far_ref: Vec<f32> = if channels >= 2 {
-                                    // Stereo → mono downmix: average L+R per sample pair
-                                    let frames = previous_output.len() / 2;
-                                    let mut mono = Vec::with_capacity(frames);
-                                    for i in 0..frames {
-                                        mono.push(
-                                            (previous_output[i * 2] + previous_output[i * 2 + 1])
-                                                * 0.5,
-                                        );
-                                    }
-                                    mono
-                                } else {
-                                    previous_output.clone()
-                                };
-                                dsp_processor.set_far_end_audio(&far_ref);
+                            // Read speaker loopback for AEC far-end reference.
+                            // This captures the ACTUAL speaker output (WASAPI/BlackHole/PipeWire),
+                            // which is the true echo source the phone mic picks up.
+                            if loopback.is_active() {
+                                let hop = 480usize;
+                                if let Some(far_data) = loopback.read(hop) {
+                                    dsp_processor.set_far_end_audio(&far_data);
+                                }
                             }
                             let (_raw, processed) =
                                 dsp_processor.process(&mut pcm_f32, channels.max(1), queued_ms);
-                            // Store output as far-end reference for next frame
-                            previous_output = pcm_f32.clone();
                             processed
                         };
 
@@ -254,6 +249,9 @@ pub async fn start_server(
                 }
             }
         }
+
+        loopback.stop();
+        log::info!("[Audio] Speaker loopback stopped");
     });
 
     ready_rx


### PR DESCRIPTION
- 新增 LoopbackCapture 模块，通过 WASAPI 捕获实际扬声器输出作为 AEC 远端参考
- 移除 DelayEstimator，用简单的 FarEndBuffer 替代
- AEC 改为单声道处理：立体声→下混→AEC→上混
- 移除 per-channel AEC 实例，改为单一 AEC 实例