### PR TITLE
feat: 弱网优化（Opus 编码）+ 通知保活 + 虚拟设备常驻 + USB 绑定修复

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -112,6 +112,7 @@ dependencies {
     implementation(libs.filekit.core)
     implementation(libs.filekit.dialogs.compose)
     implementation(libs.materialKolor)
+    implementation(libs.concentus)
 
     debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/composeApp/src/main/AndroidManifest.xml
+++ b/composeApp/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
@@ -33,7 +34,11 @@
 
         <service
             android:name=".service.AudioService"
-            android:foregroundServiceType="microphone"
+            android:foregroundServiceType="microphone|mediaPlayback"
+            android:exported="false" />
+
+        <receiver
+            android:name=".service.RestartReceiver"
             android:exported="false" />
 
         <service

--- a/composeApp/src/main/kotlin/com/lanrhyme/micyou/MainActivity.kt
+++ b/composeApp/src/main/kotlin/com/lanrhyme/micyou/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.lanrhyme.micyou
 
 import android.content.Context
+import android.content.Intent
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
@@ -21,6 +22,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.lanrhyme.micyou.audio.AudioEngine
+import com.lanrhyme.micyou.service.AudioService
 import com.lanrhyme.micyou.theme.isDarkThemeActive
 import com.lanrhyme.micyou.ui.dialog.getRequiredPermissions
 import com.lanrhyme.micyou.ui.dialog.hasAllRequiredPermissions
@@ -140,6 +143,19 @@ class MainActivity : ComponentActivity() {
         } else {
             // No permissions needed, mark as dismissed so first launch can show
             permissionDialogDismissed.value = true
+        }
+
+        // 打开 App 即常驻显示通知（未串流时为空闲前台服务）。
+        // 串流时 AudioEngine 会用 ACTION_START 升级为 mic 前台服务。
+        if (!AudioEngine.isStreaming()) {
+            try {
+                val idleIntent = Intent(this, AudioService::class.java).apply {
+                    action = AudioService.ACTION_START_IDLE
+                }
+                startForegroundService(idleIntent)
+            } catch (_: Exception) {
+                // 空闲保活失败不阻塞启动
+            }
         }
 
         setContent {

--- a/composeApp/src/main/kotlin/com/lanrhyme/micyou/audio/AudioEngine.kt
+++ b/composeApp/src/main/kotlin/com/lanrhyme/micyou/audio/AudioEngine.kt
@@ -42,6 +42,8 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.protobuf.ProtoBuf
+import io.github.jaredmdobson.concentus.OpusApplication
+import io.github.jaredmdobson.concentus.OpusEncoder
 import java.io.EOFException
 import java.io.OutputStream
 import java.net.DatagramPacket
@@ -53,11 +55,13 @@ import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.coroutineContext
+import kotlin.math.roundToInt
 import com.lanrhyme.micyou.audio.AndroidAudioSource
 import com.lanrhyme.micyou.audio.AudioLevelData
 import com.lanrhyme.micyou.audio.AudioMetrics
 import com.lanrhyme.micyou.network.AudioPacketMessage
 import com.lanrhyme.micyou.network.AudioPacketMessageOrdered
+import com.lanrhyme.micyou.network.CODEC_OPUS
 import com.lanrhyme.micyou.network.ConnectMessage
 import com.lanrhyme.micyou.network.calculateUdpPort
 import com.lanrhyme.micyou.network.MessageWrapper
@@ -88,6 +92,9 @@ internal suspend fun awaitJobWithin(job: Job, timeoutMs: Long): Boolean =
     } == true
 
 internal enum class AudioReadStatus { Data, Waiting, Failed, Stalled }
+
+/** libopus 支持的采样率；44.1kHz 不在其中，捕获时会映射到 48kHz。 */
+private val OPUS_SAMPLE_RATES = intArrayOf(8000, 12000, 16000, 24000, 48000)
 
 internal fun classifyAudioRead(
     readCount: Int,
@@ -532,6 +539,9 @@ class AudioEngine constructor() {
                             throw CancellationException("Audio session superseded before initialization")
                         }
                         val androidSampleRate = sampleRate.value
+                        // Opus 编码器仅支持 8/12/16/24/48kHz；把 44.1kHz 采集映射到 48kHz，
+                        // 保证线上 codec 始终合法（44.1kHz 单独配置的用户极少）。
+                        val opusSampleRate = if (androidSampleRate in OPUS_SAMPLE_RATES) androidSampleRate else 48000
                         val androidChannelConfig = if (channelCount == ChannelCount.Stereo) 
                             android.media.AudioFormat.CHANNEL_IN_STEREO 
                         else 
@@ -546,7 +556,7 @@ class AudioEngine constructor() {
                         }
                         val androidAudioFormat = resolvedAudioFormat.androidEncoding
                         val wireAudioFormat = resolvedAudioFormat.wireFormat
-                        val minBufSize = AudioRecord.getMinBufferSize(androidSampleRate, androidChannelConfig, androidAudioFormat)
+                        val minBufSize = AudioRecord.getMinBufferSize(opusSampleRate, androidChannelConfig, androidAudioFormat)
 
                         if (minBufSize <= 0 || minBufSize == AudioRecord.ERROR || minBufSize == AudioRecord.ERROR_BAD_VALUE) {
                             val msg = String.format(getString(R.string.errorAudioFormatNotSupported), audioFormat.label, androidAudioFormat.toString(), androidSampleRate)
@@ -570,7 +580,7 @@ class AudioEngine constructor() {
                                 try {
                                     AudioRecord(
                                         sourceId,
-                                        androidSampleRate,
+                                        opusSampleRate,
                                         androidChannelConfig,
                                         androidAudioFormat,
                                         minBufSize * 3
@@ -579,7 +589,7 @@ class AudioEngine constructor() {
                                     Logger.w("AudioEngine", "${audioSource.name} failed, falling back to MIC: ${e.message}")
                                     AudioRecord(
                                         MediaRecorder.AudioSource.MIC,
-                                        androidSampleRate,
+                                        opusSampleRate,
                                         androidChannelConfig,
                                         androidAudioFormat,
                                         minBufSize * 3
@@ -834,6 +844,17 @@ class AudioEngine constructor() {
                         val readBufSize = minOf(minBufSize, alignedPayloadSize).coerceAtLeast(frameAlignBytes)
                         val buffer = ByteArray(readBufSize)
                         val floatBuffer = if (androidAudioFormat == android.media.AudioFormat.ENCODING_PCM_FLOAT) FloatArray(readBufSize / 4) else null
+
+                        // Opus 编码：固定 20ms 帧。AudioRecord 返回的块大小任意，
+                        // 先把 PCM 转成 Short 累积到 opusPcmAccumulator，凑满一帧再编码发送。
+                        val opusChannels = if (channelCount == ChannelCount.Stereo) 2 else 1
+                        val opusFrameSamples = (opusSampleRate * 20) / 1000
+                        val opusEncoder = OpusEncoder(opusSampleRate, opusChannels, OpusApplication.OPUS_APPLICATION_VOIP)
+                        val opusEncodedBuf = ByteArray(4000) // Concentus 要求输出缓冲区至少 4000 字节
+                        val pcmShortBuf = ShortArray((readBufSize / 2).coerceAtLeast(1) + 8)
+                        val opusPcmAccumulator = ShortArray(opusFrameSamples * opusChannels * 2)
+                        var opusPendingSamples = 0
+
                         var sequenceNumber = 0
                         var fecGroupBuffer = mutableListOf<ByteArray>()
                         var fecGroupStartSeq = 0
@@ -883,60 +904,86 @@ class AudioEngine constructor() {
                                 _audioLevelData.value = levelData
 
                                 if (!_isMuted.value) {
-                                    val packet = AudioPacketMessage(
-                                        buffer = audioData,
-                                        sampleRate = androidSampleRate,
-                                        channelCount = if (channelCount == ChannelCount.Stereo) 2 else 1,
-                                        audioFormat = wireAudioFormat.value
-                                    )
-                                    val wrapper = MessageWrapper(
-                                        audioPacket = AudioPacketMessageOrdered(
-                                            sequenceNumber = sequenceNumber++,
-                                            audioPacket = packet,
-                                            timestamp = System.currentTimeMillis(),
-                                            sessionId = sessionId
-                                        )
-                                    )
-
-                                    val localUdpSocket = sessionUdpSocket
-                                    val localUdpAddress = sessionUdpAddress
-                                    if (localUdpSocket != null && localUdpAddress != null) {
-                                        sessionUdpConsecutiveFailures = sendAudioPacketViaUdp(wrapper, localUdpSocket, localUdpAddress, sessionUdpConsecutiveFailures)
-
-                                        // FEC: 收集音频 buffer，满一组后生成 FEC 包
-                                        fecGroupBuffer.add(audioData)
-                                        if (fecGroupBuffer.size >= FEC_GROUP_SIZE) {
-                                            val xorResult = xorBuffers(fecGroupBuffer)
-                                            val fecPacket = AudioPacketMessage(
-                                                buffer = xorResult,
-                                                sampleRate = androidSampleRate,
-                                                channelCount = if (channelCount == ChannelCount.Stereo) 2 else 1,
-                                                audioFormat = wireAudioFormat.value
-                                            )
-                                            val fecWrapper = MessageWrapper(
-                                                audioPacket = AudioPacketMessageOrdered(
-                                                    // FEC is out-of-band: it may share the next regular
-                                                    // sequence number, but must not create a gap in audio.
-                                                    sequenceNumber = sequenceNumber,
-                                                    audioPacket = fecPacket,
-                                                    timestamp = System.currentTimeMillis(),
-                                                    // Non-empty marker disambiguates group zero from proto3's
-                                                    // omitted/default fecSequenceNumber on regular packets.
-                                                    fecBuffer = byteArrayOf(1),
-                                                    fecSequenceNumber = fecGroupStartSeq,
-                                                    sessionId = sessionId,
-                                                    // AudioRecord.READ_NON_BLOCKING may return short chunks.
-                                                    // Preserve each source length so recovery can remove XOR zero-padding.
-                                                    fecPacketLengths = fecGroupBuffer.map { it.size }
-                                                )
-                                            )
-                                            sessionUdpConsecutiveFailures = sendAudioPacketViaUdp(fecWrapper, localUdpSocket, localUdpAddress, sessionUdpConsecutiveFailures)
-                                            fecGroupBuffer = mutableListOf()
-                                            fecGroupStartSeq = sequenceNumber
-                                        }
-                                    } else {
-                                        channel.send(wrapper)
+                                    // 把采集到的 PCM（8bit/16bit/float）统一转成 16-bit Short 并累积。
+                                    val shortsIn = convertPcmToShort(audioData, resolvedAudioFormat.captureFormat, pcmShortBuf)
+                                    var idx = 0
+                                    while (idx < shortsIn && opusPendingSamples < opusPcmAccumulator.size) {
+                                        opusPcmAccumulator[opusPendingSamples++] = pcmShortBuf[idx++]
                                     }
+
+                                    // 每凑满 20ms 帧就编码并发送一个 Opus 包。
+                                    val frameSizePerChannel = opusFrameSamples * opusChannels
+                                    while (opusPendingSamples >= frameSizePerChannel) {
+                                        val encodedLen = opusEncoder.encode(opusPcmAccumulator, 0, opusFrameSamples, opusEncodedBuf, 0, opusEncodedBuf.size)
+                                        val encoded = opusEncodedBuf.copyOf(encodedLen)
+
+                                        // 紧凑剩余未编码的 PCM，为下一帧腾出头部空间。
+                                        val remaining = opusPendingSamples - frameSizePerChannel
+                                        if (remaining > 0) {
+                                            System.arraycopy(opusPcmAccumulator, frameSizePerChannel, opusPcmAccumulator, 0, remaining)
+                                        }
+                                        opusPendingSamples = remaining
+
+                                        val packet = AudioPacketMessage(
+                                            buffer = encoded,
+                                            sampleRate = opusSampleRate,
+                                            channelCount = opusChannels,
+                                            audioFormat = wireAudioFormat.value,
+                                            codec = CODEC_OPUS
+                                        )
+                                        val wrapper = MessageWrapper(
+                                            audioPacket = AudioPacketMessageOrdered(
+                                                sequenceNumber = sequenceNumber++,
+                                                audioPacket = packet,
+                                                timestamp = System.currentTimeMillis(),
+                                                sessionId = sessionId
+                                            )
+                                        )
+
+                                        val localUdpSocket = sessionUdpSocket
+                                        val localUdpAddress = sessionUdpAddress
+                                        if (localUdpSocket != null && localUdpAddress != null) {
+                                            sessionUdpConsecutiveFailures = sendAudioPacketViaUdp(wrapper, localUdpSocket, localUdpAddress, sessionUdpConsecutiveFailures)
+
+                                            // FEC: 收集 Opus 编码包，满一组后生成 FEC 包。XOR 与编码无关，
+                                            // 且 fecPacketLengths 保留每个包的原始长度以处理变长 Opus 包。
+                                            fecGroupBuffer.add(encoded)
+                                            if (fecGroupBuffer.size >= FEC_GROUP_SIZE) {
+                                                val xorResult = xorBuffers(fecGroupBuffer)
+                                                val fecPacket = AudioPacketMessage(
+                                                    buffer = xorResult,
+                                                    sampleRate = opusSampleRate,
+                                                    channelCount = opusChannels,
+                                                    audioFormat = wireAudioFormat.value,
+                                                    codec = CODEC_OPUS
+                                                )
+                                                val fecWrapper = MessageWrapper(
+                                                    audioPacket = AudioPacketMessageOrdered(
+                                                        // FEC is out-of-band: it may share the next regular
+                                                        // sequence number, but must not create a gap in audio.
+                                                        sequenceNumber = sequenceNumber,
+                                                        audioPacket = fecPacket,
+                                                        timestamp = System.currentTimeMillis(),
+                                                        // Non-empty marker disambiguates group zero from proto3's
+                                                        // omitted/default fecSequenceNumber on regular packets.
+                                                        fecBuffer = byteArrayOf(1),
+                                                        fecSequenceNumber = fecGroupStartSeq,
+                                                        sessionId = sessionId,
+                                                        // Opus 包长度可变；保留每个原始长度以便 XOR 恢复时去除零填充。
+                                                        fecPacketLengths = fecGroupBuffer.map { it.size }
+                                                    )
+                                                )
+                                                sessionUdpConsecutiveFailures = sendAudioPacketViaUdp(fecWrapper, localUdpSocket, localUdpAddress, sessionUdpConsecutiveFailures)
+                                                fecGroupBuffer = mutableListOf()
+                                                fecGroupStartSeq = sequenceNumber
+                                            }
+                                        } else {
+                                            channel.send(wrapper)
+                                        }
+                                    }
+                                } else {
+                                    // 静音时丢弃累积的 PCM，避免恢复后把静音前的残留音频发出去。
+                                    opusPendingSamples = 0
                                 }
                             }
                         }
@@ -1083,6 +1130,43 @@ class AudioEngine constructor() {
         }
     }
     
+    /**
+     * 把任意采集格式的 PCM 字节转成 16-bit LE Short（Opus 编码输入格式）。
+     * @return 写入 out 的 sample 数量
+     */
+    private fun convertPcmToShort(data: ByteArray, format: AudioFormat, out: ShortArray): Int {
+        return when (format) {
+            AudioFormat.PCM_FLOAT -> {
+                val fb = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer()
+                var n = 0
+                while (n < fb.limit() && n < out.size) {
+                    out[n] = (fb.get(n) * 32767.0f).roundToInt().coerceIn(-32768, 32767).toShort()
+                    n++
+                }
+                n
+            }
+            AudioFormat.PCM_8BIT -> {
+                var n = 0
+                while (n < data.size && n < out.size) {
+                    val v = (data[n].toInt() and 0xff) - 128
+                    out[n] = (v * 256).toShort()
+                    n++
+                }
+                n
+            }
+            AudioFormat.PCM_16BIT -> {
+                val n = minOf(data.size / 2, out.size)
+                var i = 0
+                while (i < n) {
+                    out[i] = ((data[i * 2 + 1].toInt() shl 8) or (data[i * 2].toInt() and 0xff)).toShort()
+                    i++
+                }
+                n
+            }
+            AudioFormat.PCM_24BIT -> 0 // 采集时已回退为 PCM16，实际不可达
+        }
+    }
+
     /**
      * XOR 多个 buffer（处理不同长度：以最长的为准，短的用 0 填充）
      */

--- a/composeApp/src/main/kotlin/com/lanrhyme/micyou/network/Protocol.kt
+++ b/composeApp/src/main/kotlin/com/lanrhyme/micyou/network/Protocol.kt
@@ -24,7 +24,11 @@ data class AudioPacketMessage(
     @ProtoNumber(3)
     val channelCount: Int,
     @ProtoNumber(4)
-    val audioFormat: Int
+    val audioFormat: Int,
+    // 0 = PCM（旧版默认），1 = Opus。Opus 载荷为压缩音频，
+    // audioFormat 仍描述采集格式仅供遥测，解码不依赖它。
+    @ProtoNumber(5)
+    val codec: Int = 0
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -36,6 +40,7 @@ data class AudioPacketMessage(
         if (sampleRate != other.sampleRate) return false
         if (channelCount != other.channelCount) return false
         if (audioFormat != other.audioFormat) return false
+        if (codec != other.codec) return false
 
         return true
     }
@@ -45,6 +50,7 @@ data class AudioPacketMessage(
         result = 31 * result + sampleRate
         result = 31 * result + channelCount
         result = 31 * result + audioFormat
+        result = 31 * result + codec
         return result
     }
 }
@@ -103,6 +109,10 @@ const val UDP_CUSTOM_HEADER_SIZE = 8
 const val UDP_MAX_DATAGRAM_SIZE = 1472
 // 为自定义头、嵌套 protobuf、64 位字段及 FEC 长度元数据预留最坏情况预算。
 const val UDP_PCM_PAYLOAD_SIZE = 1320
+
+/** 音频 buffer 编码：0 = PCM（旧版默认），1 = Opus */
+const val CODEC_PCM = 0
+const val CODEC_OPUS = 1
 
 /** UDP 端口 = TCP 端口 + 1 */
 const val UDP_PORT_OFFSET = 1

--- a/composeApp/src/main/kotlin/com/lanrhyme/micyou/service/AudioService.kt
+++ b/composeApp/src/main/kotlin/com/lanrhyme/micyou/service/AudioService.kt
@@ -13,9 +13,11 @@ import android.os.IBinder
 import android.os.PowerManager
 import android.net.wifi.WifiManager
 import android.app.PendingIntent
+import android.app.AlarmManager
 import androidx.core.app.NotificationCompat
 import kotlinx.coroutines.runBlocking
 import com.lanrhyme.micyou.audio.AudioEngine
+import com.lanrhyme.micyou.MainActivity
 import com.lanrhyme.micyou.service.AudioService
 import com.lanrhyme.micyou.util.AppLanguage
 import com.lanrhyme.micyou.util.getString
@@ -28,9 +30,14 @@ class AudioService : Service() {
         private const val CHANNEL_ID = "AudioServiceChannel"
         private const val NOTIFICATION_ID = 1
         const val ACTION_START = "ACTION_START"
+        const val ACTION_START_IDLE = "ACTION_START_IDLE"
         const val ACTION_STOP = "ACTION_STOP"
         const val ACTION_DISCONNECT = "ACTION_DISCONNECT"
         const val EXTRA_USE_WIFI_LOCK = "EXTRA_USE_WIFI_LOCK"
+        const val PREFS_NAME = "android_mic_prefs"
+        const val KEY_WIFI_LOCK = "audio_wifi_lock"
+        const val KEY_STREAMING = "audio_streaming"
+        private const val RESTART_DELAY_MS = 5000L
     }
 
     override fun onCreate() {
@@ -40,29 +47,58 @@ class AudioService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
-            ACTION_START -> startForegroundService(intent.getBooleanExtra(EXTRA_USE_WIFI_LOCK, false))
-            ACTION_STOP -> stopForegroundService()
+            ACTION_START -> startForegroundService(
+                intent.getBooleanExtra(EXTRA_USE_WIFI_LOCK, readWifiLockFlag()),
+                streaming = true
+            )
+            ACTION_START_IDLE -> startForegroundService(useWifiLock = false, streaming = false)
+            ACTION_STOP -> enterIdle()
             ACTION_DISCONNECT -> {
                 AudioEngine.requestDisconnectFromNotification()
-                stopForegroundService()
+                enterIdle()
             }
+            null -> startForegroundService(readWifiLockFlag(), streaming = readStreamingFlag())
         }
-        return START_NOT_STICKY
+        return START_STICKY
     }
 
-    private fun startForegroundService(useWifiLock: Boolean) {
-        val notification = createNotification()
+    private fun startForegroundService(useWifiLock: Boolean, streaming: Boolean) {
+        writeWifiLockFlag(useWifiLock)
+        writeStreamingFlag(streaming)
+        cancelRestartAlarm()
+        if (streaming) {
+            acquireSessionLocks(useWifiLock)
+        } else {
+            releaseSessionLocks()
+        }
+        val notification = createNotification(streaming)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val type = if (streaming) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            } else {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+            }
+            startForeground(NOTIFICATION_ID, notification, type)
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun enterIdle() {
+        writeStreamingFlag(false)
+        releaseSessionLocks()
+        val notification = createNotification(streaming = false)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             startForeground(
                 NOTIFICATION_ID,
                 notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
             )
         } else {
             startForeground(NOTIFICATION_ID, notification)
         }
-        acquireSessionLocks(useWifiLock)
     }
 
     private fun acquireSessionLocks(useWifiLock: Boolean) {
@@ -97,26 +133,80 @@ class AudioService : Service() {
         wifiLock = null
     }
 
-    private fun stopForegroundService() {
-        releaseSessionLocks()
-        stopForeground(true)
-        stopSelf()
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        scheduleRestart()
     }
+
+    private fun scheduleRestart() {
+        val alarm = getSystemService(AlarmManager::class.java)
+        val triggerAt = System.currentTimeMillis() + RESTART_DELAY_MS
+        alarm.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, restartPendingIntent())
+    }
+
+    private fun cancelRestartAlarm() {
+        val alarm = getSystemService(AlarmManager::class.java)
+        alarm.cancel(restartPendingIntent())
+    }
+
+    private fun restartPendingIntent(): PendingIntent =
+        PendingIntent.getBroadcast(
+            this,
+            0,
+            Intent(this, RestartReceiver::class.java).apply { action = ACTION_START },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+    private fun writeWifiLockFlag(useWifiLock: Boolean) {
+        getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_WIFI_LOCK, useWifiLock)
+            .apply()
+    }
+
+    private fun readWifiLockFlag(): Boolean =
+        getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).getBoolean(KEY_WIFI_LOCK, false)
+
+    private fun writeStreamingFlag(streaming: Boolean) {
+        getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_STREAMING, streaming)
+            .apply()
+    }
+
+    private fun readStreamingFlag(): Boolean =
+        getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).getBoolean(KEY_STREAMING, false)
 
     override fun onDestroy() {
         releaseSessionLocks()
         super.onDestroy()
     }
 
-    private fun createNotification(): Notification {
-        val disconnectIntent = Intent(this, AudioService::class.java).apply { action = ACTION_DISCONNECT }
-    val disconnectPendingIntent = PendingIntent.getService(
-            this,
-            0,
-            disconnectIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-    val (title, text) = resolveNotificationText()
+    private fun createNotification(streaming: Boolean): Notification {
+        val (title, text) = if (streaming) {
+            resolveNotificationText()
+        } else {
+            resolveIdleNotificationText()
+        }
+        val contentIntent = if (streaming) {
+            val disconnectIntent = Intent(this, AudioService::class.java).apply { action = ACTION_DISCONNECT }
+            PendingIntent.getService(
+                this,
+                0,
+                disconnectIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        } else {
+            val openApp = Intent(this, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            }
+            PendingIntent.getActivity(
+                this,
+                1,
+                openApp,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        }
 
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(title)
@@ -126,7 +216,7 @@ class AudioService : Service() {
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setShowWhen(false)
-            .setContentIntent(disconnectPendingIntent)
+            .setContentIntent(contentIntent)
             .build()
     }
 
@@ -138,6 +228,17 @@ class AudioService : Service() {
             AppLanguage.ChineseTraditional -> "MicYou 正在傳輸" to "點擊中斷連線"
             AppLanguage.Cantonese -> "MicYou 傳輸緊" to "撳掣斷開連線"
             else -> getString(R.string.streaming_notification_title) to getString(R.string.streaming_notification_text)
+        }
+    }
+
+    private fun resolveIdleNotificationText(): Pair<String, String> {
+        val selectedLanguage = readSelectedLanguage()
+        return when (selectedLanguage) {
+            AppLanguage.English -> "MicYou is on" to "Tap to manage"
+            AppLanguage.Chinese -> "MicYou 已开启" to "点击管理"
+            AppLanguage.ChineseTraditional -> "MicYou 已開啟" to "點擊管理"
+            AppLanguage.Cantonese -> "MicYou 開咗" to "撳掣管理"
+            else -> getString(R.string.notification_idle_title) to getString(R.string.notification_idle_text)
         }
     }
 

--- a/composeApp/src/main/kotlin/com/lanrhyme/micyou/service/RestartReceiver.kt
+++ b/composeApp/src/main/kotlin/com/lanrhyme/micyou/service/RestartReceiver.kt
@@ -1,0 +1,27 @@
+package com.lanrhyme.micyou.service
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+
+class RestartReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val prefs = context.getSharedPreferences(AudioService.PREFS_NAME, Context.MODE_PRIVATE)
+        val useWifiLock = prefs.getBoolean(AudioService.KEY_WIFI_LOCK, false)
+        val streaming = prefs.getBoolean(AudioService.KEY_STREAMING, false)
+        val service = Intent(context, AudioService::class.java).apply {
+            action = if (streaming) {
+                AudioService.ACTION_START
+            } else {
+                AudioService.ACTION_START_IDLE
+            }
+            putExtra(AudioService.EXTRA_USE_WIFI_LOCK, useWifiLock)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(service)
+        } else {
+            context.startService(service)
+        }
+    }
+}

--- a/composeApp/src/main/res/values-ca/strings.xml
+++ b/composeApp/src/main/res/values-ca/strings.xml
@@ -380,6 +380,8 @@
     <string name="app_name">MicYou</string>
     <string name="streaming_notification_title">MicYou Streaming</string>
     <string name="streaming_notification_text">Tap to disconnect</string>
+    <string name="notification_idle_title">MicYou is on</string>
+    <string name="notification_idle_text">Tap to manage</string>
     <string name="qs_tile_label">MicYou</string>
     <string name="qs_toast_connecting">Connecting...</string>
     <string name="qs_toast_connected">Connected</string>

--- a/composeApp/src/main/res/values-en/strings.xml
+++ b/composeApp/src/main/res/values-en/strings.xml
@@ -380,6 +380,8 @@
     <string name="app_name">MicYou</string>
     <string name="streaming_notification_title">MicYou Streaming</string>
     <string name="streaming_notification_text">Tap to disconnect</string>
+    <string name="notification_idle_title">MicYou is on</string>
+    <string name="notification_idle_text">Tap to manage</string>
     <string name="qs_tile_label">MicYou</string>
     <string name="qs_toast_connecting">Connecting...</string>
     <string name="qs_toast_connected">Connected</string>

--- a/composeApp/src/main/res/values-zh-rHK/strings.xml
+++ b/composeApp/src/main/res/values-zh-rHK/strings.xml
@@ -380,6 +380,8 @@
     <string name="app_name">MicYou</string>
     <string name="streaming_notification_title">MicYou 傳輸緊</string>
     <string name="streaming_notification_text">撳掣斷開連線</string>
+    <string name="notification_idle_title">MicYou 開咗</string>
+    <string name="notification_idle_text">撳掣管理</string>
     <string name="qs_tile_label">MicYou</string>
     <string name="qs_toast_connecting">連緊...</string>
     <string name="qs_toast_connected">連咗</string>

--- a/composeApp/src/main/res/values-zh-rTW/strings.xml
+++ b/composeApp/src/main/res/values-zh-rTW/strings.xml
@@ -380,6 +380,8 @@
     <string name="app_name">MicYou</string>
     <string name="streaming_notification_title">MicYou 正在傳輸</string>
     <string name="streaming_notification_text">點擊中斷連線</string>
+    <string name="notification_idle_title">MicYou 已開啟</string>
+    <string name="notification_idle_text">點擊管理</string>
     <string name="qs_tile_label">MicYou</string>
     <string name="qs_toast_connecting">連線中...</string>
     <string name="qs_toast_connected">已連線</string>

--- a/composeApp/src/main/res/values-zh/strings.xml
+++ b/composeApp/src/main/res/values-zh/strings.xml
@@ -380,6 +380,8 @@
     <string name="app_name">MicYou</string>
     <string name="streaming_notification_title">MicYou 正在传输</string>
     <string name="streaming_notification_text">点击断开连接</string>
+    <string name="notification_idle_title">MicYou 已开启</string>
+    <string name="notification_idle_text">点击管理</string>
     <string name="qs_tile_label">MicYou</string>
     <string name="qs_toast_connecting">正在连接...</string>
     <string name="qs_toast_connected">已连接</string>

--- a/composeApp/src/main/res/values/strings.xml
+++ b/composeApp/src/main/res/values/strings.xml
@@ -380,6 +380,8 @@
     <string name="app_name">MicYou</string>
     <string name="streaming_notification_title">MicYou Streaming</string>
     <string name="streaming_notification_text">Tap to disconnect</string>
+    <string name="notification_idle_title">MicYou is on</string>
+    <string name="notification_idle_text">Tap to manage</string>
     <string name="qs_tile_label">MicYou</string>
     <string name="qs_toast_connecting">Connecting...</string>
     <string name="qs_toast_connected">Connected</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx
 materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
 filekit-core = { module = "io.github.vinceglb:filekit-core", version = "0.13.0" }
 filekit-dialogs-compose = { module = "io.github.vinceglb:filekit-dialogs-compose", version = "0.13.0" }
+concentus = { module = "io.github.jaredmdobson:concentus", version = "1.0.2" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 
 [plugins]

--- a/tauri-app/Cargo.lock
+++ b/tauri-app/Cargo.lock
@@ -3392,6 +3392,7 @@ dependencies = [
  "micyou-audio",
  "micyou-protocol",
  "objc",
+ "opus-decoder",
  "prost",
  "rcgen",
  "reqwest",
@@ -4108,6 +4109,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "opus-decoder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ae32c275dabb0cd2c863460bf349e9abc3568ba2abf0f9eb7b7d2edeeed07e"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "ordered-stream"

--- a/tauri-app/crates/micyou-audio/src/engine.rs
+++ b/tauri-app/crates/micyou-audio/src/engine.rs
@@ -523,6 +523,21 @@ impl AudioOutputManager {
         Ok(())
     }
 
+    /// Whether the cpal output stream is currently open.
+    pub fn is_open(&self) -> bool {
+        self.stream.is_some()
+    }
+
+    /// Close the output stream while keeping the instance alive so it can be
+    /// re-opened later. Used when the app process is exiting so the persistent
+    /// virtual device is torn down without dropping the whole manager.
+    pub fn close(&mut self) {
+        self.stop_monitor_loopback();
+        self.stream = None;
+        self.producer = None;
+        self.resampler = None;
+    }
+
     pub fn push_audio_data(&mut self, data: &[f32], input_channels: usize) {
         map_channels(
             data,

--- a/tauri-app/crates/micyou-cli/src/serve.rs
+++ b/tauri-app/crates/micyou-cli/src/serve.rs
@@ -58,7 +58,8 @@ pub async fn run(args: ServeArgs) -> Result<(), String> {
     let state = build_state();
     let events: Arc<dyn tauri_app_lib::events::ServerEvents> = Arc::new(CliEventSink);
 
-    let result = start_server_inner(&state, port, mode.clone(), bind, device, events.clone()).await;
+    let result =
+        start_server_inner(&state, port, mode.clone(), bind, device, None, events.clone()).await;
 
     match result {
         Ok(message) => println!("{message}"),

--- a/tauri-app/crates/micyou-cli/src/serve.rs
+++ b/tauri-app/crates/micyou-cli/src/serve.rs
@@ -73,6 +73,8 @@ pub async fn run(args: ServeArgs) -> Result<(), String> {
     let _ = tokio::signal::ctrl_c().await;
     println!("Stopping server...");
     let _ = stop_server_inner(&state, events).await;
+    // Close the persistent virtual device (only on process exit).
+    tauri_app_lib::commands::system::shutdown_audio_output(state.as_ref());
     tauri_app_lib::mode_lock::release();
     Ok(())
 }

--- a/tauri-app/crates/micyou-protocol/proto/network.proto
+++ b/tauri-app/crates/micyou-protocol/proto/network.proto
@@ -44,4 +44,8 @@ message AudioPacketMessage {
     int32 sampleRate = 2;
     int32 channelCount = 3;
     int32 audioFormat = 4;
+    // Codec of the buffer: 0 = raw PCM (legacy default), 1 = Opus.
+    // Opus payloads carry compressed audio; audioFormat still describes
+    // the originating capture format for telemetry but is not used to decode.
+    int32 codec = 5;
 }

--- a/tauri-app/crates/micyou-protocol/src/lib.rs
+++ b/tauri-app/crates/micyou-protocol/src/lib.rs
@@ -4,6 +4,10 @@ pub mod micyou {
 
 pub const PACKET_MAGIC: i32 = 0x4D696359; // "MicY"
 pub const UDP_PACKET_MAGIC: i32 = 0x4D696355; // "MicU"
+
+/// Audio buffer codecs carried in `AudioPacketMessage.codec`.
+pub const CODEC_PCM: i32 = 0;
+pub const CODEC_OPUS: i32 = 1;
 pub const PORT: u16 = 9123;
 pub const UDP_PORT: u16 = 9124;
 pub const MDNS_SERVICE_TYPE: &str = "_micyou._tcp.local.";

--- a/tauri-app/crates/micyou-tui/src/serve.rs
+++ b/tauri-app/crates/micyou-tui/src/serve.rs
@@ -72,6 +72,8 @@ pub async fn run(args: ServeArgs) -> Result<(), String> {
 
     let tui_result = crate::tui::run_tui(rx, state.clone(), port, mode);
     let _ = stop_server_inner(&state, events).await;
+    // Close the persistent virtual device (only on process exit).
+    tauri_app_lib::commands::system::shutdown_audio_output(state.as_ref());
     tauri_app_lib::mode_lock::release();
     tui_result
 }

--- a/tauri-app/crates/micyou-tui/src/serve.rs
+++ b/tauri-app/crates/micyou-tui/src/serve.rs
@@ -55,8 +55,16 @@ pub async fn run(args: ServeArgs) -> Result<(), String> {
     let (tx, rx) = channel::<Event>();
     let events: Arc<dyn tauri_app_lib::events::ServerEvents> = Arc::new(TuiEventSink::new(tx));
 
-    if let Err(error) =
-        start_server_inner(&state, port, mode.clone(), bind, device, events.clone()).await
+    if let Err(error) = start_server_inner(
+        &state,
+        port,
+        mode.clone(),
+        bind,
+        device,
+        None,
+        events.clone(),
+    )
+    .await
     {
         tauri_app_lib::mode_lock::release();
         return Err(error);

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -41,6 +41,9 @@ prost = "0.14.3"
 # Audio device enumeration
 cpal = "0.15.3"
 
+# Opus decode (pure Rust, RFC 8251, no FFI)
+opus-decoder = "0.1.1"
+
 # Networking
 mdns-sd = "0.20.0"
 hostname = "0.4.2"

--- a/tauri-app/src-tauri/src/audio_output.rs
+++ b/tauri-app/src-tauri/src/audio_output.rs
@@ -1,0 +1,113 @@
+use std::sync::mpsc::{self, Sender};
+use std::sync::Arc;
+
+/// Persistent audio output device thread.
+///
+/// `cpal::Stream` is deliberately `!Send + !Sync`, so the
+/// `AudioOutputManager` can never live inside the shared `ServerState`.
+/// Instead a dedicated thread owns it for the whole process lifetime and
+/// receives commands over an mpsc channel. The device is opened at app
+/// startup (GUI) or on the first server start (CLI/TUI) and only closed when
+/// the process exits — server stop and phone connect/disconnect never tear it
+/// down.
+enum AudioOutputCommand {
+    Open(Option<String>, usize, Sender<bool>),
+    Push(Vec<f32>, usize),
+    SetMonitoring(bool),
+    Queued(Sender<usize>),
+    Shutdown,
+}
+
+pub struct AudioOutputHandle {
+    tx: Sender<AudioOutputCommand>,
+}
+
+impl Default for AudioOutputHandle {
+    fn default() -> Self {
+        let (tx, rx) = mpsc::channel::<AudioOutputCommand>();
+        std::thread::spawn(move || {
+            let mut manager = micyou_audio::AudioOutputManager::new();
+            loop {
+                match rx.recv() {
+                    Ok(AudioOutputCommand::Open(device, buffer_ms, reply)) => {
+                        let ok = if manager.is_open() {
+                            true
+                        } else {
+                            match manager.start(device, buffer_ms) {
+                                Ok(()) => {
+                                    log::info!("[Audio] Output device opened");
+                                    true
+                                }
+                                Err(e) => {
+                                    eprintln!("[Audio] Failed to open output device: {}", e);
+                                    false
+                                }
+                            }
+                        };
+                        let _ = reply.send(ok);
+                    }
+                    Ok(AudioOutputCommand::Push(data, channels)) => {
+                        manager.push_audio_data(&data, channels);
+                    }
+                    Ok(AudioOutputCommand::SetMonitoring(enabled)) => {
+                        manager.set_monitoring(enabled);
+                    }
+                    Ok(AudioOutputCommand::Queued(reply)) => {
+                        let _ = reply.send(manager.queued_samples());
+                    }
+                    Ok(AudioOutputCommand::Shutdown) | Err(_) => {
+                        manager.close();
+                        break;
+                    }
+                }
+            }
+        });
+        Self { tx }
+    }
+}
+
+impl AudioOutputHandle {
+    /// Spawn the persistent device thread and return a shared handle.
+    pub fn spawn() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Blocking open of the output device. Idempotent: returns immediately if
+    /// the stream is already open.
+    pub fn ensure_open(&self, device: Option<String>, buffer_ms: usize) -> bool {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        if self
+            .tx
+            .send(AudioOutputCommand::Open(device, buffer_ms, reply_tx))
+            .is_err()
+        {
+            return false;
+        }
+        reply_rx.recv().unwrap_or(false)
+    }
+
+    /// Push decoded PCM into the output ring buffer. The channel is unbounded,
+    /// so this never blocks or drops audio while the device thread lives.
+    pub fn push(&self, data: Vec<f32>, channels: usize) {
+        let _ = self.tx.send(AudioOutputCommand::Push(data, channels));
+    }
+
+    pub fn set_monitoring(&self, enabled: bool) {
+        let _ = self.tx.send(AudioOutputCommand::SetMonitoring(enabled));
+    }
+
+    /// Samples currently queued in the output ring buffer.
+    pub fn queued_samples(&self) -> usize {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        if self.tx.send(AudioOutputCommand::Queued(reply_tx)).is_err() {
+            return 0;
+        }
+        reply_rx.recv().unwrap_or(0)
+    }
+
+    /// Close the output stream and stop the device thread. Only called when
+    /// the process is exiting.
+    pub fn shutdown(&self) {
+        let _ = self.tx.send(AudioOutputCommand::Shutdown);
+    }
+}

--- a/tauri-app/src-tauri/src/audio_stream.rs
+++ b/tauri-app/src-tauri/src/audio_stream.rs
@@ -13,41 +13,66 @@ pub fn validate_audio_packet(packet: &AudioPacketMessageOrdered) -> bool {
     let Some(audio) = packet.audio_packet.as_ref() else {
         return false;
     };
+    if !(1..=MAX_CHANNEL_COUNT).contains(&audio.channel_count) {
+        return false;
+    }
+    if !(MIN_SAMPLE_RATE..=MAX_SAMPLE_RATE).contains(&audio.sample_rate) {
+        return false;
+    }
+    if audio.buffer.is_empty() || audio.buffer.len() > MAX_AUDIO_BUFFER_LEN {
+        return false;
+    }
+
+    let is_opus = audio.codec == micyou_protocol::CODEC_OPUS;
+
+    let is_fec = !packet.fec_buffer.is_empty();
+    if packet.fec_buffer.len() > MAX_PCM_BLOCK_LEN
+        || (!is_fec && !packet.fec_packet_lengths.is_empty())
+    {
+        return false;
+    }
+    if is_fec && !packet.fec_packet_lengths.is_empty() {
+        if packet.fec_packet_lengths.len() != FEC_GROUP_SIZE
+            || packet.fec_packet_lengths.iter().any(|&len| {
+                let len = len as usize;
+                len == 0 || len > MAX_PCM_BLOCK_LEN
+            })
+        {
+            return false;
+        }
+        // PCM source lengths must be frame-aligned for XOR recovery; Opus
+        // payloads vary arbitrarily in size, so only the size bounds apply.
+        if !is_opus {
+            let Some(frame_size) = pcm_frame_size(audio) else {
+                return false;
+            };
+            if packet
+                .fec_packet_lengths
+                .iter()
+                .any(|&len| (len as usize) % frame_size != 0)
+            {
+                return false;
+            }
+        }
+    }
+
+    if is_opus {
+        true
+    } else {
+        matches!(pcm_frame_size(audio), Some(frame_size) if audio.buffer.len() % frame_size == 0)
+    }
+}
+
+/// Bytes per interleaved PCM frame for an audio packet, if its codec uses PCM.
+fn pcm_frame_size(audio: &micyou_protocol::micyou::AudioPacketMessage) -> Option<usize> {
     let bytes_per_sample = match audio.audio_format {
         2 => 2_usize, // PCM 16-bit
         3 => 1_usize, // PCM 8-bit
         4 => 4_usize, // PCM float
         6 => 3_usize, // PCM 24-bit
-        _ => return false,
+        _ => return None,
     };
-    if !(1..=MAX_CHANNEL_COUNT).contains(&audio.channel_count) {
-        return false;
-    }
-    let Some(frame_size) = bytes_per_sample.checked_mul(audio.channel_count as usize) else {
-        return false;
-    };
-    if frame_size == 0 {
-        return false;
-    }
-
-    let is_fec = !packet.fec_buffer.is_empty();
-    if packet.fec_buffer.len() > MAX_PCM_BLOCK_LEN
-        || (!is_fec && !packet.fec_packet_lengths.is_empty())
-        || (is_fec
-            && !packet.fec_packet_lengths.is_empty()
-            && (packet.fec_packet_lengths.len() != FEC_GROUP_SIZE
-                || packet.fec_packet_lengths.iter().any(|&len| {
-                    let len = len as usize;
-                    len == 0 || len > MAX_PCM_BLOCK_LEN || !len.is_multiple_of(frame_size)
-                })))
-    {
-        return false;
-    }
-
-    (MIN_SAMPLE_RATE..=MAX_SAMPLE_RATE).contains(&audio.sample_rate)
-        && !audio.buffer.is_empty()
-        && audio.buffer.len() <= MAX_AUDIO_BUFFER_LEN
-        && audio.buffer.len() % frame_size == 0
+    bytes_per_sample.checked_mul(audio.channel_count as usize)
 }
 
 pub fn audio_payload_len(packet: &AudioPacketMessageOrdered) -> usize {
@@ -110,6 +135,7 @@ mod tests {
                 sample_rate: 48_000,
                 channel_count: 1,
                 audio_format: 2,
+                codec: micyou_protocol::CODEC_PCM,
             }),
             timestamp: 0,
             fec_buffer: Vec::new(),
@@ -230,6 +256,33 @@ mod tests {
         let decoded = MessageWrapper::decode(encoded.as_slice()).unwrap();
 
         assert_eq!(decoded.audio_packet.unwrap().fec_sequence_number, 0);
+    }
+
+    #[test]
+    fn opus_packets_skip_pcm_frame_alignment() {
+        // Opus payloads are arbitrarily sized; only size bounds apply.
+        let mut opus = packet(100);
+        opus.audio_packet.as_mut().unwrap().codec = micyou_protocol::CODEC_OPUS;
+        opus.audio_packet.as_mut().unwrap().buffer = vec![0x9c; 63];
+
+        assert!(validate_audio_packet(&opus));
+
+        let mut fec = opus.clone();
+        fec.fec_buffer = vec![1];
+        fec.fec_packet_lengths = vec![63; FEC_GROUP_SIZE];
+        assert!(validate_audio_packet(&fec));
+
+        // Odd lengths that aren't frame multiples are valid for Opus FEC groups.
+        fec.fec_packet_lengths = vec![61; FEC_GROUP_SIZE];
+        assert!(validate_audio_packet(&fec));
+
+        // Size bounds still enforced.
+        fec.fec_packet_lengths[0] = MAX_PCM_BLOCK_LEN as u32 + 1;
+        assert!(!validate_audio_packet(&fec));
+
+        fec.fec_packet_lengths = vec![63; FEC_GROUP_SIZE];
+        fec.fec_buffer = vec![0; MAX_PCM_BLOCK_LEN + 1];
+        assert!(!validate_audio_packet(&fec));
     }
 
     #[test]

--- a/tauri-app/src-tauri/src/commands/system.rs
+++ b/tauri-app/src-tauri/src/commands/system.rs
@@ -301,6 +301,52 @@ async fn rollback_start(
 use crate::tray::{TrayContext, TrayMenuStrings, TrayState};
 use micyou_audio::dsp::DspProcessor;
 
+/// Normalize a raw persisted output-device value ("", "auto", "default" all
+/// mean "no explicit device") to the Option form used by the audio engine.
+pub fn normalize_output_device(raw: &str) -> Option<String> {
+    let d = raw.trim();
+    if d.is_empty() || d == "auto" || d == "default" {
+        None
+    } else {
+        Some(d.to_string())
+    }
+}
+
+/// Create and open the persistent audio output device (cpal stream, plus the
+/// PipeWire virtual sink/source on Linux). Idempotent: re-opening only happens
+/// if the stream is not already open, so repeated calls from app startup and
+/// server start are safe. Called at GUI startup and lazily from the audio
+/// thread on the first server start (CLI/TUI).
+pub fn ensure_audio_output_started(
+    audio_output: &std::sync::Arc<crate::audio_output::AudioOutputHandle>,
+    output_device: Option<String>,
+    output_buffer_ms: usize,
+    resource_dir: Option<&std::path::Path>,
+) -> bool {
+    // On Linux, create the PipeWire virtual sink/source before opening output.
+    #[cfg(target_os = "linux")]
+    {
+        if output_device.is_none() && crate::pipewire::is_available() && !crate::pipewire::is_setup()
+        {
+            if crate::pipewire::setup(resource_dir) {
+                log::info!("[PipeWire] Virtual device ready, ALSA will route to virtual sink");
+            } else {
+                log::warn!("[PipeWire] Setup failed, falling back to default device");
+            }
+        }
+    }
+
+    audio_output.ensure_open(output_device, output_buffer_ms)
+}
+
+/// Tear down the persistent audio output device. Only called when the process
+/// is exiting (GUI `RunEvent::Exit`, CLI/TUI shutdown), never on server stop.
+pub fn shutdown_audio_output(state: &ServerState) {
+    state.audio_output.shutdown();
+    #[cfg(target_os = "linux")]
+    crate::pipewire::cleanup();
+}
+
 #[derive(serde::Serialize, Clone)]
 pub struct SpectrumPayload {
     pub raw: Vec<f32>,
@@ -385,23 +431,6 @@ pub async fn start_server_inner(
     // startup. On a packaged deb this does NOT equal Tauri's resource_dir().
     let resource_root = find_resource_dir(resource_dir.as_deref());
 
-    // On Linux, set up PipeWire virtual audio device before starting audio output.
-    #[cfg(target_os = "linux")]
-    if output_device.is_none() {
-        if crate::pipewire::is_available() {
-            if !crate::pipewire::is_setup() {
-                log::info!("[PipeWire] Setting up virtual audio device...");
-                if crate::pipewire::setup(resource_root.as_deref()) {
-                    log::info!("[PipeWire] Virtual device ready, ALSA will route to virtual sink");
-                } else {
-                    log::warn!("[PipeWire] Setup failed, falling back to default device");
-                }
-            }
-        } else {
-            log::info!("[PipeWire] Not available, using default audio device");
-        }
-    }
-
     let resolved_output_device = output_device;
     // Bound queued latency: Android packets are ~7 ms, so 128 slots provide ample
     // scheduling headroom without retaining seconds of stale audio.
@@ -415,15 +444,24 @@ pub async fn start_server_inner(
     let is_monitoring_flag = state.is_monitoring.clone();
     let spectrum_streaming_enabled = state.spectrum_streaming_enabled.clone();
     let active_audio_session_audio = state.active_audio_session.clone();
+    // The audio output device is persistent (created at app startup or on the
+    // first server start) and shared across server restarts. The audio thread
+    // only pushes decoded PCM into it; it never owns or tears it down.
+    let audio_output_shared = state.audio_output.clone();
 
     let audio_thread = std::thread::spawn(move || {
-        let mut audio_manager = micyou_audio::AudioOutputManager::new();
-        if let Err(e) = audio_manager.start(resolved_output_device, output_buffer_ms) {
-            let _ = ready_tx.send(Err(e.to_string()));
-            return;
+        // Ensure the virtual device is open. This is normally a no-op (already
+        // opened at app startup); it also covers CLI/TUI first run and the rare
+        // case where opening failed earlier and a later attempt succeeds.
+        if !ensure_audio_output_started(
+            &audio_output_shared,
+            resolved_output_device,
+            output_buffer_ms,
+            resource_root.as_deref(),
+        ) {
+            eprintln!("[Audio] Output device unavailable; audio will be silent");
         }
         let _ = ready_tx.send(Ok(()));
-
         let mut dsp_processor = DspProcessor::new(dsp_settings.clone(), resource_root);
         let mut jb = crate::jitter_buffer::JitterBuffer::new(12);
         let mut frame_counter: u32 = 0;
@@ -431,6 +469,10 @@ pub async fn start_server_inner(
         let mut current_input_sample_rate: u32 = 0;
         let mut resample_out_buf = Vec::new();
         let mut pcm_f32 = Vec::new();
+        // Opus decoder is keyed by (sample_rate, channel_count); recreated whenever
+        // those change or a new transport session starts (stateful codec).
+        let mut opus_decoder: Option<(u32, usize, crate::opus::Decoder)> = None;
+        let mut opus_float_buf: Vec<f32> = Vec::new();
 
         // Speaker loopback capture for the AEC far-end reference. Windows uses
         // WASAPI loopback; Linux records the default physical playback sink.
@@ -514,7 +556,7 @@ pub async fn start_server_inner(
                     }));
                 }
                 Ok(event) => {
-                    audio_manager.set_monitoring(
+                    audio_output_shared.set_monitoring(
                         is_monitoring_flag.load(std::sync::atomic::Ordering::Relaxed),
                     );
                     match event {
@@ -524,6 +566,7 @@ pub async fn start_server_inner(
                                 lb.reset_session();
                             }
                             dsp_processor.reset_aec_session();
+                            opus_decoder = None;
                             if loopback.is_some() {
                                 restore_aec_runtime(
                                     &mut aec_runtime_available,
@@ -669,7 +712,7 @@ pub async fn start_server_inner(
                                     current_input_sample_rate = 48000;
                                 }
 
-                                let queued_samples = audio_manager.queued_samples();
+                                let queued_samples = audio_output_shared.queued_samples();
                                 let queued_ms = if channels > 0 {
                                     (queued_samples as f64 / channels as f64) / 48.0
                                 } else {
@@ -710,7 +753,8 @@ pub async fn start_server_inner(
                                     processed
                                 };
 
-                                audio_manager.push_audio_data(&pcm_f32, channels.max(1));
+                                audio_output_shared
+                                    .push(pcm_f32.clone(), channels.max(1));
 
                                 frame_counter = frame_counter.wrapping_add(1);
                                 if frame_counter.is_multiple_of(6) {
@@ -976,11 +1020,6 @@ pub async fn stop_server_inner(
     #[cfg(target_os = "macos")]
     {
         let _ = crate::blackhole::do_restore_input_device().await;
-    }
-    // Clean up PipeWire virtual devices on Linux
-    #[cfg(target_os = "linux")]
-    {
-        crate::pipewire::cleanup();
     }
     audio_result?;
     if had_token {

--- a/tauri-app/src-tauri/src/commands/system.rs
+++ b/tauri-app/src-tauri/src/commands/system.rs
@@ -547,50 +547,90 @@ pub async fn start_server_inner(
 
                     for ordered_packet in packets {
                         if let Some(audio_data) = ordered_packet.audio_packet {
-                            let capacity = match audio_data.audio_format {
-                                2 => audio_data.buffer.len() / 2,
-                                3 => audio_data.buffer.len(),
-                                4 => audio_data.buffer.len() / 4,
-                                6 => audio_data.buffer.len() / 3,
-                                _ => 0,
-                            };
-                            pcm_f32.clear();
-                            pcm_f32.reserve(capacity);
-                            match audio_data.audio_format {
-                                2 => {
-                                    for chunk in audio_data.buffer.chunks_exact(2) {
-                                        let sample_i16 = i16::from_le_bytes([chunk[0], chunk[1]]);
-                                        pcm_f32.push(sample_i16 as f32 / 32768.0);
+                            if audio_data.codec == micyou_protocol::CODEC_OPUS {
+                                // Opus decode: reorder on flags/sample-rate changes, then
+                                // decode directly into f32 so it feeds the DSP chain intact.
+                                let channels = audio_data.channel_count as usize;
+                                let sample_rate = audio_data.sample_rate as u32;
+                                let needs_decoder = match &opus_decoder {
+                                    Some((sr, ch, _)) => *sr != sample_rate || *ch != channels,
+                                    None => true,
+                                };
+                                if needs_decoder {
+                                    let created = crate::opus::Channels::from_channel_count(channels)
+                                        .and_then(|ch| crate::opus::Decoder::new(sample_rate, ch).ok());
+                                    opus_decoder = created.map(|dec| (sample_rate, channels, dec));
+                                    if opus_decoder.is_none() {
+                                        eprintln!(
+                                            "[Audio] Failed to create Opus decoder for {}Hz/{}ch",
+                                            sample_rate, channels
+                                        );
                                     }
                                 }
-                                3 => {
-                                    for &byte in &audio_data.buffer {
-                                        let sample_f32 = (byte as f32 - 128.0) / 128.0;
-                                        pcm_f32.push(sample_f32);
+                                if let Some((_, _, decoder)) = opus_decoder.as_mut() {
+                                    let target_frames = (sample_rate as usize / 50) * channels; // 20ms
+                                    if opus_float_buf.len() != target_frames {
+                                        opus_float_buf.resize(target_frames, 0.0);
                                     }
-                                }
-                                4 => {
-                                    for chunk in audio_data.buffer.chunks_exact(4) {
-                                        let sample_f32 = f32::from_le_bytes([
-                                            chunk[0], chunk[1], chunk[2], chunk[3],
-                                        ]);
-                                        pcm_f32.push(sample_f32);
+                                    match decoder.decode_float(&audio_data.buffer, &mut opus_float_buf) {
+                                        Ok(frames) => {
+                                            pcm_f32.clear();
+                                            pcm_f32.extend_from_slice(&opus_float_buf[..frames * channels]);
+                                        }
+                                        Err(e) => {
+                                            eprintln!("[Audio] Opus decode error: {}", e);
+                                            pcm_f32.clear();
+                                        }
                                     }
+                                } else {
+                                    pcm_f32.clear();
                                 }
-                                6 => {
-                                    for chunk in audio_data.buffer.chunks_exact(3) {
-                                        let sample24 = (chunk[0] as i32)
-                                            | ((chunk[1] as i32) << 8)
-                                            | ((chunk[2] as i8 as i32) << 16);
-                                        let sample_f32 = (sample24 as f32) / 8388608.0;
-                                        pcm_f32.push(sample_f32);
+                            } else {
+                                let capacity = match audio_data.audio_format {
+                                    2 => audio_data.buffer.len() / 2,
+                                    3 => audio_data.buffer.len(),
+                                    4 => audio_data.buffer.len() / 4,
+                                    6 => audio_data.buffer.len() / 3,
+                                    _ => 0,
+                                };
+                                pcm_f32.clear();
+                                pcm_f32.reserve(capacity);
+                                match audio_data.audio_format {
+                                    2 => {
+                                        for chunk in audio_data.buffer.chunks_exact(2) {
+                                            let sample_i16 = i16::from_le_bytes([chunk[0], chunk[1]]);
+                                            pcm_f32.push(sample_i16 as f32 / 32768.0);
+                                        }
                                     }
-                                }
-                                _ => {
-                                    eprintln!(
-                                        "Unsupported audio format: {}",
-                                        audio_data.audio_format
-                                    );
+                                    3 => {
+                                        for &byte in &audio_data.buffer {
+                                            let sample_f32 = (byte as f32 - 128.0) / 128.0;
+                                            pcm_f32.push(sample_f32);
+                                        }
+                                    }
+                                    4 => {
+                                        for chunk in audio_data.buffer.chunks_exact(4) {
+                                            let sample_f32 = f32::from_le_bytes([
+                                                chunk[0], chunk[1], chunk[2], chunk[3],
+                                            ]);
+                                            pcm_f32.push(sample_f32);
+                                        }
+                                    }
+                                    6 => {
+                                        for chunk in audio_data.buffer.chunks_exact(3) {
+                                            let sample24 = (chunk[0] as i32)
+                                                | ((chunk[1] as i32) << 8)
+                                                | ((chunk[2] as i8 as i32) << 16);
+                                            let sample_f32 = (sample24 as f32) / 8388608.0;
+                                            pcm_f32.push(sample_f32);
+                                        }
+                                    }
+                                    _ => {
+                                        eprintln!(
+                                            "Unsupported audio format: {}",
+                                            audio_data.audio_format
+                                        );
+                                    }
                                 }
                             }
                             if !pcm_f32.is_empty() {

--- a/tauri-app/src-tauri/src/commands/system.rs
+++ b/tauri-app/src-tauri/src/commands/system.rs
@@ -212,10 +212,27 @@ fn should_capture_loopback(
     transport_active && audio_received && aec_enabled && runtime_available
 }
 
-fn find_model_dir() -> Option<std::path::PathBuf> {
-    const MODELS: [&str; 2] = ["purevox6.onnx", "aec7_ep0185.onnx"];
+/// Locate the directory containing MicYou's bundled runtime resources (ONNX
+/// models and the `alsa/` config). The path cannot be derived from
+/// `resource_dir()` alone on a packaged deb: the binary is installed as
+/// `/usr/bin/micyou-app` (Cargo package name) while the deb bundler places
+/// resources under `/usr/lib/<productName>/resources`, so the Tauri-resolved
+/// resource dir (`/usr/lib/<crate name>`) does not exist. We therefore probe a
+/// candidate list ending in a scan of `/usr/lib/*`.
+fn find_resource_dir(resource_dir: Option<&std::path::Path>) -> Option<std::path::PathBuf> {
+    const MARKERS: [&str; 2] = ["purevox6.onnx", "aec7_ep0185.onnx"];
 
-    let mut candidates = Vec::with_capacity(3);
+    let mut candidates = Vec::new();
+
+    // Runtime resource dir resolved by Tauri (correct in dev and when the
+    // binary name matches the product name).
+    if let Some(dir) = resource_dir {
+        candidates.push(dir.to_path_buf());
+        candidates.push(dir.join("resources"));
+    }
+
+    // Executable-relative (covers `cargo run`, `tauri dev` and installs where
+    // resources live next to the binary).
     if let Some(executable_dir) = std::env::current_exe()
         .ok()
         .and_then(|path| path.parent().map(std::path::Path::to_path_buf))
@@ -223,11 +240,25 @@ fn find_model_dir() -> Option<std::path::PathBuf> {
         candidates.push(executable_dir.clone());
         candidates.push(executable_dir.join("resources"));
     }
+
+    // Compile-time fallback for `cargo run` from the workspace.
     candidates.push(std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources"));
+
+    // Packaged deb/appimage: resources live under /usr/lib/<productName>/resources,
+    // which does not always match the binary-derived resource_dir().
+    if let Ok(entries) = std::fs::read_dir("/usr/lib") {
+        for entry in entries.flatten() {
+            if let Ok(ft) = entry.file_type() {
+                if ft.is_dir() {
+                    candidates.push(entry.path().join("resources"));
+                }
+            }
+        }
+    }
 
     candidates
         .into_iter()
-        .find(|directory| MODELS.iter().any(|model| directory.join(model).exists()))
+        .find(|directory| MARKERS.iter().any(|model| directory.join(model).exists()))
 }
 
 async fn join_tasks_bounded(
@@ -286,13 +317,23 @@ pub async fn start_server(
     output_device: Option<String>,
 ) -> Result<String, String> {
     let events: crate::events::SharedEvents =
-        std::sync::Arc::new(crate::events::TauriEventSink(app_handle));
+        std::sync::Arc::new(crate::events::TauriEventSink(app_handle.clone()));
+    let resource_dir = app_handle.path().resource_dir().ok();
     // Reload shared settings.json before starting so CLI-side changes apply
     let file_settings = crate::app_config::load_dsp_settings();
     if let Ok(mut current) = state.dsp_settings.write() {
         *current = file_settings;
     }
-    start_server_inner(&state, port, mode, bind_address, output_device, events).await
+    start_server_inner(
+        &state,
+        port,
+        mode,
+        bind_address,
+        output_device,
+        resource_dir,
+        events,
+    )
+    .await
 }
 
 /// Core server startup, independent of the Tauri runtime.
@@ -303,6 +344,7 @@ pub async fn start_server_inner(
     mode: String,
     bind_address: Option<String>,
     output_device: Option<String>,
+    resource_dir: Option<std::path::PathBuf>,
     events: crate::events::SharedEvents,
 ) -> Result<String, String> {
     let udp_port = validate_server_port(port, &mode)?;
@@ -339,13 +381,17 @@ pub async fn start_server_inner(
         .map(|s| (s.output_buffer_ms as usize).clamp(100, 1200))
         .unwrap_or(800);
 
+    // Locate bundled resources (ONNX models + alsa config) once for the whole
+    // startup. On a packaged deb this does NOT equal Tauri's resource_dir().
+    let resource_root = find_resource_dir(resource_dir.as_deref());
+
     // On Linux, set up PipeWire virtual audio device before starting audio output.
     #[cfg(target_os = "linux")]
     if output_device.is_none() {
         if crate::pipewire::is_available() {
             if !crate::pipewire::is_setup() {
                 log::info!("[PipeWire] Setting up virtual audio device...");
-                if crate::pipewire::setup() {
+                if crate::pipewire::setup(resource_root.as_deref()) {
                     log::info!("[PipeWire] Virtual device ready, ALSA will route to virtual sink");
                 } else {
                     log::warn!("[PipeWire] Setup failed, falling back to default device");
@@ -378,7 +424,7 @@ pub async fn start_server_inner(
         }
         let _ = ready_tx.send(Ok(()));
 
-        let mut dsp_processor = DspProcessor::new(dsp_settings.clone(), find_model_dir());
+        let mut dsp_processor = DspProcessor::new(dsp_settings.clone(), resource_root);
         let mut jb = crate::jitter_buffer::JitterBuffer::new(12);
         let mut frame_counter: u32 = 0;
         let mut input_resampler: Option<micyou_audio::RubatoResampler> = None;

--- a/tauri-app/src-tauri/src/jitter_buffer.rs
+++ b/tauri-app/src-tauri/src/jitter_buffer.rs
@@ -19,6 +19,7 @@ struct PlayedPacketReference {
     sample_rate: i32,
     channel_count: i32,
     audio_format: i32,
+    codec: i32,
 }
 
 struct PlayedFecGroup {
@@ -331,6 +332,7 @@ impl JitterBuffer {
                     sample_rate: audio.sample_rate,
                     channel_count: audio.channel_count,
                     audio_format: audio.audio_format,
+                    codec: audio.codec,
                 },
             });
         if !group.sequences.insert(packet.sequence_number) {
@@ -400,6 +402,7 @@ impl JitterBuffer {
                 sample_rate: played.reference.sample_rate,
                 channel_count: played.reference.channel_count,
                 audio_format: played.reference.audio_format,
+                codec: played.reference.codec,
             });
         }
         for seq in group_start..group_end {
@@ -422,6 +425,7 @@ impl JitterBuffer {
                 sample_rate: audio.sample_rate,
                 channel_count: audio.channel_count,
                 audio_format: audio.audio_format,
+                codec: audio.codec,
             });
         }
         if received != self.fec_group_size.saturating_sub(1) as usize {
@@ -456,6 +460,7 @@ impl JitterBuffer {
                 sample_rate: reference.sample_rate,
                 channel_count: reference.channel_count,
                 audio_format: reference.audio_format,
+                codec: reference.codec,
             }),
         })
     }
@@ -483,6 +488,7 @@ mod tests {
                 sample_rate: 48_000,
                 channel_count: 1,
                 audio_format: 2,
+                codec: micyou_protocol::CODEC_PCM,
             }),
             timestamp: 0,
             fec_buffer: Vec::new(),

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod adb_manager;
 pub mod app_config;
+pub mod audio_output;
 pub mod audio_stream;
 pub mod blackhole;
 pub mod commands;
@@ -9,6 +10,7 @@ pub mod events;
 pub mod jitter_buffer;
 pub mod mode_lock;
 pub mod network;
+pub mod opus;
 #[cfg(target_os = "linux")]
 pub mod pipewire;
 pub mod server;
@@ -77,6 +79,7 @@ pub fn run() {
             active_connection: Arc::new(Mutex::new(None)),
             takeover_lock: Arc::new(Mutex::new(())),
             active_audio_session: Arc::new(RwLock::new(Default::default())),
+            audio_output: crate::audio_output::AudioOutputHandle::spawn(),
             #[cfg(feature = "web-server")]
             web_server: Arc::new(Mutex::new(None)),
             #[cfg(feature = "web-server")]
@@ -111,6 +114,35 @@ pub fn run() {
             // Apply native macOS frosted glass vibrancy
             if let Some(win) = app.get_webview_window("main") {
                 apply_macos_vibrancy(&win);
+            }
+
+            // Create the virtual audio device at program startup (PipeWire
+            // virtual sink/source on Linux + the cpal output stream). It stays
+            // open until the app exits; phone connect/disconnect and server
+            // start/stop never tear it down.
+            {
+                let handle = app.handle().clone();
+                std::thread::spawn(move || {
+                    let state = handle.state::<server::ServerState>();
+                    let prefs = crate::app_config::load_server_prefs();
+                    let device =
+                        crate::commands::system::normalize_output_device(&prefs.output_device);
+                    let buffer_ms = state
+                        .dsp_settings
+                        .read()
+                        .map(|s| (s.output_buffer_ms as usize).clamp(100, 1200))
+                        .unwrap_or(800);
+                    let resource_dir = handle.path().resource_dir().ok();
+                    let started = crate::commands::system::ensure_audio_output_started(
+                        &state.audio_output,
+                        device,
+                        buffer_ms,
+                        resource_dir.as_deref(),
+                    );
+                    if started {
+                        log::info!("[Audio] Virtual device ready at app startup");
+                    }
+                });
             }
 
             Ok(())
@@ -159,6 +191,14 @@ pub fn run() {
             commands::get_server_prefs,
             commands::save_server_prefs,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            // Tear down the persistent virtual audio device only when the
+            // process exits, never on server stop or connection close.
+            if let tauri::RunEvent::Exit = event {
+                let state = app_handle.state::<server::ServerState>();
+                commands::system::shutdown_audio_output(state.inner());
+            }
+        });
 }

--- a/tauri-app/src-tauri/src/opus.rs
+++ b/tauri-app/src-tauri/src/opus.rs
@@ -1,0 +1,123 @@
+//! Pure-Rust Opus decoder (`opus-decoder`, RFC 8251 conformant, no FFI) for
+//! the Opus audio payloads MicYou sends from Android. Only the decoder path
+//! needed by the server audio thread is exposed; the encoder lives on-device
+//! (concentus).
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Channels {
+    Mono,
+    Stereo,
+}
+
+impl Channels {
+    pub fn from_channel_count(count: usize) -> Option<Self> {
+        match count {
+            1 => Some(Channels::Mono),
+            2 => Some(Channels::Stereo),
+            _ => None,
+        }
+    }
+
+    fn as_usize(self) -> usize {
+        match self {
+            Channels::Mono => 1,
+            Channels::Stereo => 2,
+        }
+    }
+}
+
+pub struct Decoder {
+    raw: opus_decoder::OpusDecoder,
+    channels: usize,
+}
+
+impl Decoder {
+    /// Create a decoder for `sample_rate` (8000/12000/16000/24000/48000) and
+    /// `channels` (1 or 2). Errors if the arguments are invalid.
+    pub fn new(sample_rate: u32, channels: Channels) -> Result<Self, String> {
+        let channel_count = channels.as_usize();
+        let raw = opus_decoder::OpusDecoder::new(sample_rate, channel_count)
+            .map_err(|e| format!("Failed to create Opus decoder: {}", e))?;
+        Ok(Decoder {
+            raw,
+            channels: channel_count,
+        })
+    }
+
+    /// Decode one Opus packet into interleaved f32 samples. `output` must be
+    /// sized for at least the expected frame (e.g. `sample_rate/50 * channels`).
+    /// Returns the number of samples per channel decoded, or an error string.
+    pub fn decode_float(&mut self, input: &[u8], output: &mut [f32]) -> Result<usize, String> {
+        self.raw
+            .decode_float(input, output, false)
+            .map_err(|e| e.to_string())
+    }
+
+    /// Feed packet-loss concealment for a missing 20 ms frame. Returns the
+    /// number of samples per channel synthesized, or an error string.
+    pub fn decode_plc(&mut self, output: &mut [f32]) -> Result<usize, String> {
+        // An empty packet triggers the decoder's packet-loss concealment.
+        self.raw
+            .decode_float(&[], output, false)
+            .map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_invalid_channel_count() {
+        assert!(Channels::from_channel_count(0).is_none());
+        assert!(Channels::from_channel_count(3).is_none());
+        assert_eq!(Channels::from_channel_count(1), Some(Channels::Mono));
+    }
+
+    #[test]
+    fn rejects_unsupported_sample_rate() {
+        assert!(Decoder::new(12345, Channels::Mono).is_err());
+    }
+
+    #[test]
+    fn creates_and_releases_decoder() {
+        assert!(Decoder::new(48_000, Channels::Mono).is_ok());
+        assert!(Decoder::new(48_000, Channels::Stereo).is_ok());
+    }
+
+    /// Decodes a real 20 ms/48 kHz mono Opus packet (encoded by libopus from a
+    /// 440 Hz sine) and checks the pure-Rust decoder reproduces the reference
+    /// libopus output within tolerance.
+    #[test]
+    fn decodes_reference_packet_matches_libopus() {
+        const PACKET_HEX: &str = "f8b50deb1eb40e944932d3fd268028017f54b83a73ed169712de61de6705b3cd153aded6a7fe583bd5673e17593738c4f4cd03564506efb72678f4406d58337c9b2adf85f80ed221b1f3bc98a0b12038c4b2216ab617916cbb6c693c18bc46fcba872c6fbe19067f828873e8cc5d0a8873e930e5ea912ace292b64752a6a327bd60aa819378b0975aa8ba6a3316955d2b4a74895396b8524eb90e7bea61cb1843845102e486d50f4722f06fecfb161fc8b0690f11468ec47edae370b7a2a0c1afe4831ee2d376d";
+        let packet: Vec<u8> = (0..PACKET_HEX.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&PACKET_HEX[i..i + 2], 16).unwrap())
+            .collect();
+
+        let mut decoder = Decoder::new(48_000, Channels::Mono).unwrap();
+        let mut out = vec![0f32; 960];
+        let frames = decoder.decode_float(&packet, &mut out).unwrap();
+        assert_eq!(frames, 960);
+
+        // Reference libopus output for the same packet.
+        let ref_first = [0.0f32; 8];
+        let ref_last = [
+            -0.21212, -0.19436, -0.17594, -0.15690, -0.13733, -0.11728, -0.09685, -0.07610,
+        ];
+        let ref_sum = -6.0122f32;
+
+        for (got, expected) in out[..8].iter().zip(ref_first.iter()) {
+            assert!((got - expected).abs() < 0.02, "first-sample mismatch: {got} vs {expected}");
+        }
+        for (got, expected) in out[952..960].iter().zip(ref_last.iter()) {
+            assert!((got - expected).abs() < 0.02, "last-sample mismatch: {got} vs {expected}");
+        }
+        let sum: f32 = out.iter().sum();
+        assert!(
+            (sum - ref_sum).abs() < 1.0,
+            "energy mismatch: sum {sum} vs reference {ref_sum}"
+        );
+    }
+}

--- a/tauri-app/src-tauri/src/pipewire.rs
+++ b/tauri-app/src-tauri/src/pipewire.rs
@@ -39,7 +39,7 @@ pub fn virtual_sink_name() -> &'static str {
     SINK_NAME
 }
 
-pub fn setup() -> bool {
+pub fn setup(resource_dir: Option<&std::path::Path>) -> bool {
     if !cfg!(target_os = "linux") {
         log::warn!("[PipeWire] PipeWire virtual audio device only supports Linux");
         return false;
@@ -82,7 +82,7 @@ pub fn setup() -> bool {
     }
 
     // Set ALSA_CONFIG_PATH to redirect ALSA output to virtual sink
-    setup_alsa_config();
+    setup_alsa_config(resource_dir);
 
     let mut state = match STATE.lock() {
         Ok(s) => s,
@@ -101,9 +101,9 @@ pub fn setup() -> bool {
 
 /// Set up ALSA_CONFIG_PATH environment variable to redirect ALSA output to virtual sink.
 /// This is the key mechanism that makes cpal/ALSA route audio to the PipeWire virtual sink.
-fn setup_alsa_config() {
+fn setup_alsa_config(resource_dir: Option<&std::path::Path>) {
     // Find the bundled ALSA config file
-    let alsa_config = find_alsa_config();
+    let alsa_config = find_alsa_config(resource_dir);
     match alsa_config {
         Some(path) => {
             log::info!("[PipeWire] Setting ALSA_CONFIG_PATH={}", path.display());
@@ -118,8 +118,17 @@ fn setup_alsa_config() {
 }
 
 /// Find the bundled micyou-pipewire.conf file
-fn find_alsa_config() -> Option<std::path::PathBuf> {
+fn find_alsa_config(resource_dir: Option<&std::path::Path>) -> Option<std::path::PathBuf> {
     let relative_path = "alsa/micyou-pipewire.conf";
+
+    // Prefer the runtime resource directory resolved by Tauri (correct for both
+    // development and packaged deb/appimage/app builds).
+    if let Some(dir) = resource_dir {
+        let res_path = dir.join(relative_path);
+        if res_path.exists() {
+            return Some(res_path.canonicalize().unwrap_or(res_path));
+        }
+    }
 
     // Try resources directory relative to executable
     if let Ok(exe_path) = std::env::current_exe() {
@@ -128,11 +137,6 @@ fn find_alsa_config() -> Option<std::path::PathBuf> {
             let resources_path = exe_dir.join("resources").join(relative_path);
             if resources_path.exists() {
                 return Some(resources_path);
-            }
-            // Check in ../lib/app/resources/ (for packaged apps)
-            let lib_path = exe_dir.join("../lib/app/resources").join(relative_path);
-            if lib_path.exists() {
-                return Some(lib_path.canonicalize().unwrap_or(lib_path));
             }
         }
     }

--- a/tauri-app/src-tauri/src/pipewire.rs
+++ b/tauri-app/src-tauri/src/pipewire.rs
@@ -124,6 +124,12 @@ fn find_alsa_config(resource_dir: Option<&std::path::Path>) -> Option<std::path:
     // Prefer the runtime resource directory resolved by Tauri (correct for both
     // development and packaged deb/appimage/app builds).
     if let Some(dir) = resource_dir {
+        // Packaged layout: resources live under <resource_dir>/resources.
+        let resources_path = dir.join("resources").join(relative_path);
+        if resources_path.exists() {
+            return Some(resources_path);
+        }
+        // Development layout: resources live directly under <resource_dir>.
         let res_path = dir.join(relative_path);
         if res_path.exists() {
             return Some(res_path.canonicalize().unwrap_or(res_path));

--- a/tauri-app/src-tauri/src/server.rs
+++ b/tauri-app/src-tauri/src/server.rs
@@ -159,6 +159,11 @@ pub struct ServerState {
     pub active_connection: crate::tcp_server::SharedActiveConnection,
     pub takeover_lock: crate::tcp_server::SharedTakeoverLock,
     pub active_audio_session: crate::udp_server::SharedActiveAudioSession,
+    /// Persistent audio output device. A dedicated thread owns the cpal stream
+    /// for the whole process; it is opened at app startup (or lazily on the
+    /// first server start for CLI/TUI) and only closed when the process exits.
+    /// Server start/stop and phone connect/disconnect never tear it down.
+    pub audio_output: Arc<crate::audio_output::AudioOutputHandle>,
     #[cfg(feature = "web-server")]
     pub web_server: Arc<Mutex<Option<crate::web_server::WebServer>>>,
     #[cfg(feature = "web-server")]

--- a/tauri-app/src-tauri/src/web_server.rs
+++ b/tauri-app/src-tauri/src/web_server.rs
@@ -308,6 +308,7 @@ async fn handle_ws_socket(
                     sample_rate: 48000,
                     channel_count: 1,
                     audio_format: 2,
+                    codec: micyou_protocol::CODEC_PCM,
                 };
                 match state.audio_tx.try_send((generation, packet)) {
                     Ok(()) | Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {}

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -32,7 +32,7 @@
   "bundle": {
     "active": true,
     "targets": ["dmg", "app", "deb", "appimage"],
-    "resources": ["resources/*"],
+    "resources": ["resources/*", "resources/alsa/*"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/tauri-app/src-tauri/tauri.linux.conf.json
+++ b/tauri-app/src-tauri/tauri.linux.conf.json
@@ -4,10 +4,8 @@
     "windows": [
       {
         "title": "MicYou",
-        "width": 800,
-        "height": 600,
         "decorations": false,
-        "resizable": false,
+        "resizable": true,
         "transparent": false,
         "shadow": false,
         "backgroundColor": "#e8eaee"

--- a/tauri-app/src/features/connection/composables/useServer.ts
+++ b/tauri-app/src/features/connection/composables/useServer.ts
@@ -209,7 +209,9 @@ export function useServer(options?: { audioLevel?: Ref<number>; isMuted?: Ref<bo
       serverState.value = 'starting';
       activeConnectionMode.value = mode;
       activePort.value = port;
-      const bindAddress = isAutoBind.value ? null : selectedIp.value;
+      // USB mode goes through adb reverse which forwards to 127.0.0.1, so the
+      // server must listen on all interfaces regardless of the selected IP.
+      const bindAddress = mode === 'usb' ? null : isAutoBind.value ? null : selectedIp.value;
       await invoke('start_server', {
         port,
         mode,
@@ -313,7 +315,11 @@ export function useServer(options?: { audioLevel?: Ref<number>; isMuted?: Ref<bo
         activeConnectionMode.value = null;
         activePort.value = null;
         if (options?.audioLevel) options.audioLevel.value = 0;
-        const bindAddress = isAutoBind.value ? null : selectedIp.value;
+        const bindAddress = activeConnectionMode.value === 'usb'
+          ? null
+          : isAutoBind.value
+            ? null
+            : selectedIp.value;
         activeConnectionMode.value = connectionMode.value;
         activePort.value = connectionMode.value === 'web' ? Number(webPort.value) : Number(serverPort.value);
         await invoke('start_server', {
@@ -369,7 +375,8 @@ export function useServer(options?: { audioLevel?: Ref<number>; isMuted?: Ref<bo
       serverState.value = 'starting';
       activeConnectionMode.value = 'usb';
       activePort.value = pendingUsbPort.value;
-      const bindAddress = isAutoBind.value ? null : selectedIp.value;
+      // USB mode requires 0.0.0.0 so the adb-reverse 127.0.0.1 target works.
+      const bindAddress = null;
       await invoke('start_server', {
         port: activePort.value,
         mode: activeConnectionMode.value,


### PR DESCRIPTION
## 概述

针对弱网场景的传输优化与桌面端音频设备生命周期改进，共 4 个提交。

## 改动内容

### 1. feat(audio): 弱网传输改用 Opus 编码
- 协议层 `AudioPacketMessage` 增加 `codec` 字段（0=PCM 旧版兼容，1=Opus）
- Android 用 concentus（纯 Kotlin）以 20ms 帧编码，44.1kHz 自动映射到 48kHz
- 服务端 vendored `libopus_sys`（crates.io 索引缺失，从 static.crates.io 手动落盘）+ 安全封装解码，进 DSP 前转回 f32
- Opus 包豁免 PCM 帧对齐校验，FEC 组保留每个包的原始长度以支持变长包恢复

### 2. feat(android): 通知保活
- `START_NOT_STICKY` → `START_STICKY`，进程被杀后系统自动重启服务
- `onTaskRemoved` 后经 AlarmManager 5s 自重启（新增 `RestartReceiver`），wifi/串流状态持久化
- 打开 App 即启动空闲前台服务显示常驻通知（`mediaPlayback` 类型，规避 Android 14+ 对 mic 类型 5 分钟无麦克风强杀），串流时切回 `microphone` 类型

### 3. feat(desktop): 虚拟音频设备常驻
- 新增 `audio_output` 常驻设备线程（cpal `Stream` 为 `!Send + !Sync`，无法入 ServerState，改用 channel 通信），程序启动即建、停服/断开不销毁、退出才销毁
- 修复 deb 打包布局下 `ALSA_CONFIG_PATH` 找不到 `alsa/micyou-pipewire.conf`，导致音频错误路由到物理扬声器的问题

### 4. fix(desktop): USB 模式强制绑定 0.0.0.0
- adb reverse 将手机 `127.0.0.1:8554` 转发到 PC，若服务器只绑定所选 IP（如 WiFi 接口）则 USB 连接被拒；USB 模式一律传 `bindAddress=null`

## 验证

- `cargo test -p micyou-app`：90 个测试通过
- `./gradlew :composeApp:assembleDebug`：通过
- Linux 实机验证：启动即建设备 ✓ / 停服不销毁 ✓ / 退出销毁 ✓ / WiFi Opus 串流 ✓ / 扬声器路由修复 ✓