### PR TITLE
修复plugin相关前端错误以及CLI的构建错误

### DIFF
--- a/tauri-app/crates/micyou-cli/src/commands.rs
+++ b/tauri-app/crates/micyou-cli/src/commands.rs
@@ -1,5 +1,6 @@
 use crate::config;
 use micyou_audio::dsp::AudioDspSettings;
+use std::process::exit;
 use tauri_app_lib::mode_lock as lock;
 
 pub fn cmd_devices() {

--- a/tauri-app/src-tauri/capabilities/default.json
+++ b/tauri-app/src-tauri/capabilities/default.json
@@ -25,8 +25,6 @@
     "core:window:allow-show",
     "core:window:allow-hide",
     "core:event:default",
-    "opener:default",
-    "opener:allow-open-path",
     "dialog:default",
     "autostart:default",
     "notification:default"

--- a/tauri-app/src-tauri/src/commands/plugins.rs
+++ b/tauri-app/src-tauri/src/commands/plugins.rs
@@ -273,10 +273,10 @@ pub(crate) fn open_plugin_window_impl(
 #[tauri::command]
 pub fn open_plugin_window(
     app: tauri::AppHandle,
-    pluginId: String,
-    panelId: String,
+    plugin_id: String,
+    panel_id: String,
 ) -> Result<(), String> {
-    open_plugin_window_impl(&app, &pluginId, &panelId)
+    open_plugin_window_impl(&app, &plugin_id, &panel_id)
 }
 
 /// Read a plugin-authored settings page (self-contained HTML file inside
@@ -284,8 +284,8 @@ pub fn open_plugin_window(
 #[tauri::command]
 pub fn get_plugin_panel(
     state: State<'_, ServerState>,
-    pluginId: String,
-    panelId: String,
+    plugin_id: String,
+    panel_id: String,
 ) -> Result<String, String> {
     let manager = state
         .plugins
@@ -293,15 +293,15 @@ pub fn get_plugin_panel(
         .lock()
         .map_err(|_| "plugin manager lock poisoned".to_string())?;
     let entry = manager
-        .entry(&pluginId)
+        .entry(&plugin_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("unknown plugin {pluginId}"))?;
+        .ok_or_else(|| format!("unknown plugin {plugin_id}"))?;
     let panel = entry
         .manifest
         .ui
         .as_ref()
-        .and_then(|u| u.panels.iter().find(|p| p.id == panelId))
-        .ok_or_else(|| format!("unknown panel {panelId}"))?;
+        .and_then(|u| u.panels.iter().find(|p| p.id == panel_id))
+        .ok_or_else(|| format!("unknown panel {panel_id}"))?;
     let path = entry.dir.join(&panel.entry);
     std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))
 }

--- a/tauri-app/src-tauri/src/commands/plugins.rs
+++ b/tauri-app/src-tauri/src/commands/plugins.rs
@@ -199,7 +199,11 @@ pub fn get_plugin_sync_status(state: State<'_, ServerState>) -> Result<PluginSyn
 /// Open the plugin directory in the system file manager (helper for manual
 /// installs: drop a plugin folder / .zip there).
 #[tauri::command]
-pub fn open_plugins_dir(state: State<'_, ServerState>) -> Result<String, String> {
+pub fn open_plugins_dir(
+    app: tauri::AppHandle,
+    state: State<'_, ServerState>,
+) -> Result<String, String> {
+    use tauri_plugin_opener::OpenerExt;
     let dir = state
         .plugins
         .manager
@@ -208,6 +212,13 @@ pub fn open_plugins_dir(state: State<'_, ServerState>) -> Result<String, String>
         .plugins_dir()
         .to_path_buf();
     std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    // 直接在 Rust 侧打开目录，不经过 IPC 的 ACL scope 检查。
+    // 插件目录是自定义的 %APPDATA%\micyou（config_dir() 用 "micyou" 而非应用标识符），
+    // 而 Tauri scope 的 $APPDATA 会拼上 com.lanrhyme.micyou，无法匹配该路径，
+    // 前端 openPath 会因此抛 "Not allowed to open path"。
+    app.opener()
+        .open_path(dir.display().to_string(), None::<&str>)
+        .map_err(|e| format!("open plugins dir: {e}"))?;
     Ok(dir.display().to_string())
 }
 

--- a/tauri-app/src/features/plugins/composables/usePlugins.ts
+++ b/tauri-app/src/features/plugins/composables/usePlugins.ts
@@ -122,7 +122,7 @@ export function usePlugins() {
   async function saveConfig(plugin: PluginView | string, key: string, value: unknown) {
     try {
       const pluginId = typeof plugin === 'string' ? plugin : plugin.id;
-  await invoke('set_plugin_config', { id: pluginId, key, value });
+      await invoke('set_plugin_config', { id: pluginId, key, value });
       return true;
     } catch (e) {
       error.value = String(e);

--- a/tauri-app/src/features/plugins/composables/usePlugins.ts
+++ b/tauri-app/src/features/plugins/composables/usePlugins.ts
@@ -1,7 +1,6 @@
 import { ref } from 'vue';
 import { invoke } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
-import { openPath } from '@tauri-apps/plugin-opener';
 
 export interface PluginDependency {
   id: string;
@@ -161,11 +160,10 @@ export function usePlugins() {
     }
   }
 
-  /** 打开系统文件管理器显示插件目录 */
+  /** 打开系统文件管理器显示插件目录（目录由后端 open_plugins_dir 命令直接打开） */
   async function openDir(): Promise<boolean> {
     try {
-      const dir = await invoke<string>('open_plugins_dir');
-      if (dir) await openPath(dir);
+      await invoke('open_plugins_dir');
       return true;
     } catch (e) {
       error.value = String(e);

--- a/tauri-app/src/features/settings/components/SettingsDialog.vue
+++ b/tauri-app/src/features/settings/components/SettingsDialog.vue
@@ -9,7 +9,7 @@
         <!-- Close Button -->
         <button
           @click="$emit('close')"
-          class="absolute top-4 right-4 z-[100] w-10 h-10 rounded-full bg-surface-variant/40 hover:bg-surface-variant/80 flex items-center justify-center transition-colors"
+          class="absolute top-4 right-4 z-40 w-10 h-10 rounded-full bg-surface-variant/40 hover:bg-surface-variant/80 flex items-center justify-center transition-colors"
         >
           <X class="w-5 h-5 text-on-surface" />
         </button>


### PR DESCRIPTION
1. 修复点开插件商店页面后设置的关闭按钮仍置顶显示的问题
2. 修复插件目录无法打开的问题，将前端打开改为rust后端打开，并移除无用代码
3. 修复cargo check后，因未引用而导致的构建错误