### PR TITLE
fix(desktop): repair packaging and CLI/TUI mode switching

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -90,19 +90,13 @@ jobs:
       run: npm ci --include=dev
       working-directory: tauri-app
     - name: Build Tauri App (Windows)
-      run: npx @tauri-apps/cli build --no-bundle
+      run: npm run tauri -- build --no-bundle
       working-directory: tauri-app
     - name: Build Inno Setup Installer
       shell: pwsh
       working-directory: tauri-app
       run: |
         $version = '${{ steps.version.outputs.version }}'
-        New-Item -ItemType Directory -Force -Path "src-tauri/target/release" | Out-Null
-        $bin = Get-ChildItem -Path . -Recurse -Filter "*.exe" | Where-Object { $_.Name -match "(micyou|MicYou)" -and $_.FullName -notmatch "bundle" } | Select-Object -First 1
-        if ($bin) {
-          Copy-Item $bin.FullName "src-tauri/target/release/micyou-app.exe" -Force
-          Copy-Item $bin.FullName "src-tauri/target/release/MicYou.exe" -Force
-        }
         iscc /DMyAppVersion="$version" src-tauri/installer.iss
     - name: Prepare Artifact
       shell: pwsh
@@ -163,7 +157,7 @@ jobs:
       working-directory: tauri-app
 
     - name: Build Tauri App (macOS)
-      run: npx @tauri-apps/cli build --bundles dmg --target ${{ matrix.target }}
+      run: npm run tauri -- build --bundles dmg --target ${{ matrix.target }}
       working-directory: tauri-app
     - name: Prepare Artifact
       run: |
@@ -224,7 +218,7 @@ jobs:
       run: npm ci --include=dev
       working-directory: tauri-app
     - name: Build Tauri App (Linux)
-      run: npx @tauri-apps/cli build --bundles deb,rpm,appimage
+      run: npm run tauri -- build --bundles deb,rpm,appimage
       working-directory: tauri-app
     - name: Prepare Artifacts
       run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -112,19 +112,13 @@ jobs:
       run: npm ci --include=dev
       working-directory: tauri-app
     - name: Build Tauri App (Windows)
-      run: npx @tauri-apps/cli build --no-bundle
+      run: npm run tauri -- build --no-bundle
       working-directory: tauri-app
     - name: Build Inno Setup Installer
       shell: pwsh
       working-directory: tauri-app
       run: |
         $version = '${{ steps.version.outputs.version }}'
-        New-Item -ItemType Directory -Force -Path "src-tauri/target/release" | Out-Null
-        $bin = Get-ChildItem -Path . -Recurse -Filter "*.exe" | Where-Object { $_.Name -match "(micyou|MicYou)" -and $_.FullName -notmatch "bundle" } | Select-Object -First 1
-        if ($bin) {
-          Copy-Item $bin.FullName "src-tauri/target/release/micyou-app.exe" -Force
-          Copy-Item $bin.FullName "src-tauri/target/release/MicYou.exe" -Force
-        }
         iscc /DMyAppVersion="$version" src-tauri/installer.iss
     - name: Prepare Artifact
       shell: pwsh
@@ -184,7 +178,7 @@ jobs:
       run: npm ci --include=dev
       working-directory: tauri-app
     - name: Build Tauri App (macOS)
-      run: npx @tauri-apps/cli build --bundles dmg --target ${{ matrix.target }}
+      run: npm run tauri -- build --bundles dmg --target ${{ matrix.target }}
       working-directory: tauri-app
     - name: Prepare Artifact
       run: |
@@ -245,7 +239,7 @@ jobs:
       run: npm ci --include=dev
       working-directory: tauri-app
     - name: Build Tauri App (Linux)
-      run: npx @tauri-apps/cli build --bundles deb,rpm,appimage
+      run: npm run tauri -- build --bundles deb,rpm,appimage
       working-directory: tauri-app
     - name: Prepare Artifacts
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,19 +113,13 @@ jobs:
         run: npm ci --include=dev
         working-directory: tauri-app
       - name: Build Tauri App (Windows)
-        run: npx @tauri-apps/cli build --no-bundle
+        run: npm run tauri -- build --no-bundle
         working-directory: tauri-app
       - name: Build Inno Setup Installer
         shell: pwsh
         working-directory: tauri-app
         run: |
           $version = '${{ steps.version.outputs.version }}'
-          New-Item -ItemType Directory -Force -Path "src-tauri/target/release" | Out-Null
-          $bin = Get-ChildItem -Path . -Recurse -Filter "*.exe" | Where-Object { $_.Name -match "(micyou|MicYou)" -and $_.FullName -notmatch "bundle" } | Select-Object -First 1
-          if ($bin) {
-            Copy-Item $bin.FullName "src-tauri/target/release/micyou-app.exe" -Force
-            Copy-Item $bin.FullName "src-tauri/target/release/MicYou.exe" -Force
-          }
           iscc /DMyAppVersion="$version" src-tauri/installer.iss
       - name: Prepare Artifact
         shell: pwsh
@@ -188,7 +182,7 @@ jobs:
         working-directory: tauri-app
 
       - name: Build Tauri App (macOS)
-        run: npx @tauri-apps/cli build --bundles dmg --target ${{ matrix.target }}
+        run: npm run tauri -- build --bundles dmg --target ${{ matrix.target }}
         working-directory: tauri-app
       - name: Prepare Artifact
         run: |
@@ -249,7 +243,7 @@ jobs:
         run: npm ci --include=dev
         working-directory: tauri-app
       - name: Build Tauri App (Linux)
-        run: npx @tauri-apps/cli build --bundles deb,rpm,appimage
+        run: npm run tauri -- build --bundles deb,rpm,appimage
         working-directory: tauri-app
       - name: Prepare Artifacts
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-MicYou turns Android devices into PC microphones. The Android client captures microphone audio and streams it over the network; the desktop app receives it and plays it back through a virtual mic device (VB-CABLE on Windows, BlackHole on macOS, PipeWire on Linux) or a browser via HTTPS. Two app surfaces share one wire protocol: a single-module Android app (`:composeApp`, Kotlin + Jetpack Compose + Material 3) and a desktop app (`tauri-app/`, Tauri 2 + Rust backend + Vue 3/Vite/Tailwind frontend). The desktop Rust core is reused by three frontends — GUI (Tauri), CLI (`micyou`), and TUI (`micyou-tui`) — which share the same server lifecycle, config files, and DSP settings.
+MicYou turns Android devices into PC microphones. The Android client captures microphone audio and streams it over the network; the desktop app receives it and plays it back through a virtual mic device (VB-CABLE on Windows, BlackHole on macOS, PipeWire on Linux) or a browser via HTTPS. Two app surfaces share one wire protocol: a single-module Android app (`:composeApp`, Kotlin + Jetpack Compose + Material 3) and a desktop app (`tauri-app/`, Tauri 2 + Rust backend + Vue 3/Vite/Tailwind frontend). The desktop Rust core is reused by three frontends — GUI (`micyou`), CLI (`micyou-cli`), and TUI (`micyou-tui`) — which share the same server lifecycle, config files, and DSP settings.
 
 ## Architecture & Data Flow
 
@@ -57,8 +57,8 @@ npm run tauri dev
 npm run tauri build    # runs sync-version + npm run build first (beforeBuildCommand)
 
 # Alternate frontends (Rust workspace, from tauri-app/)
-cargo run -p micyou-cli -- serve        # CLI server (binary: micyou)
-micyou settings get/set, chain list/set # CLI subcommands (clap)
+cargo run -p micyou-cli -- serve            # CLI server (binary: micyou-cli)
+micyou-cli settings get/set, chain list/set # CLI subcommands (clap)
 cargo run -p micyou-tui                 # TUI frontend
 
 # Version bump flow

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -56,15 +56,15 @@ MicYou 插件系统允许第三方为桌面端与（未来）安卓端扩展能�
 ## 开发工具
 
 ```bash
-micyou plugin create dev.micyou.myplugin --kind utility --capabilities config.read   # wasm 骨架默认 Rust（自动编译）
-micyou plugin create dev.micyou.myplugin --lang wat                                 # 高级场景才手写 WAT
-micyou plugin create dev.micyou.mynative --runtime native --kind dsp
-micyou plugin validate ./myplugin
-micyou plugin install ./myplugin            # 一键部署到应用插件目录
-micyou plugin dev ./myplugin                # 监听变更自动重装（开发循环）
-micyou plugin package ./myplugin -o out.zip
-micyou plugin bump ./myplugin               # 版本 patch +1
-micyou plugin list                          # 列出已安装插件（id/版本/运行时/状态）
+micyou-cli plugin create dev.micyou.myplugin --kind utility --capabilities config.read   # wasm 骨架默认 Rust（自动编译）
+micyou-cli plugin create dev.micyou.myplugin --lang wat                                 # 高级场景才手写 WAT
+micyou-cli plugin create dev.micyou.mynative --runtime native --kind dsp
+micyou-cli plugin validate ./myplugin
+micyou-cli plugin install ./myplugin            # 一键部署到应用插件目录
+micyou-cli plugin dev ./myplugin                # 监听变更自动重装（开发循环）
+micyou-cli plugin package ./myplugin -o out.zip
+micyou-cli plugin bump ./myplugin               # 版本 patch +1
+micyou-cli plugin list                          # 列出已安装插件（id/版本/运行时/状态）
 
 应用内：设置-插件 → 插件市场（浏览 MicYou-Plugins 仓库：封面图/运行时/能力/平台/架构，
 安装前展示能力确认，一键安装；插件 zip 由各插件仓库 CI 打包发布 GitHub Release，

--- a/docs/plugins/development-guide.md
+++ b/docs/plugins/development-guide.md
@@ -120,13 +120,13 @@
   - 要求：按平台分别编译（.so / .dylib / .dll），须声明 `arches`
   - 注意：process() 内禁止调用宿主 API（实时安全）
 
-### 开发工具（micyou plugin）
+### 开发工具（micyou-cli plugin）
 
 ```bash
-micyou plugin create dev.micyou.myplugin          # 生成 wasm 骨架（默认）
-micyou plugin create dev.micyou.mynative --runtime native
-micyou plugin validate ./myplugin                 # 校验 plugin.json 与入口产物
-micyou plugin package ./myplugin -o out.zip       # 打包为可导入 zip
+micyou-cli plugin create dev.micyou.myplugin          # 生成 wasm 骨架（默认）
+micyou-cli plugin create dev.micyou.mynative --runtime native
+micyou-cli plugin validate ./myplugin                 # 校验 plugin.json 与入口产物
+micyou-cli plugin package ./myplugin -o out.zip       # 打包为可导入 zip
 ```
 
 - `create` 生成 plugin.json + 入口模板 + panel.html + README
@@ -303,7 +303,7 @@ C 插件直接 `#include "micyou_plugin_abi.h"` 实现符号即可，导出宏�
 WASM 插件是 core wasm 模块（无需 WASI），在 `wasmi` 纯 Rust 解释器中沙箱执行
 
 > **用高级语言写，别手写 WAT**
-> 推荐用 Rust 编译到 `wasm32-unknown-unknown`（`micyou plugin create --runtime wasm`
+> 推荐用 Rust 编译到 `wasm32-unknown-unknown`（`micyou-cli plugin create --runtime wasm`
 > 默认就生成 Rust 骨架并自动编译），类型安全、可维护、标准库可用
 > WAT 手写仅保留给体积极致或零工具链的高级场景（`--lang wat`）
 
@@ -338,7 +338,7 @@ WASM 插件是 core wasm 模块（无需 WASI），在 `wasmi` 纯 Rust 解释�
 
 ### 完整最小示例（Rust）
 
-`micyou plugin create dev.micyou.hello --runtime wasm` 生成完整 Rust 骨架（推荐路径）
+`micyou-cli plugin create dev.micyou.hello --runtime wasm` 生成完整 Rust 骨架（推荐路径）
 
 #### 构建
 
@@ -348,7 +348,7 @@ cargo build --release                      # 骨架内执行（.cargo/config.tom
 cp target/wasm32-unknown-unknown/release/myplugin.wasm main.wasm
 ```
 
-`micyou plugin create` 已内置编译：检测到 wasm32 目标时自动产出 `main.wasm`
+`micyou-cli plugin create` 已内置编译：检测到 wasm32 目标时自动产出 `main.wasm`
 
 #### 核心骨架（src/lib.rs）
 
@@ -398,11 +398,11 @@ pub extern "C" fn handle_message(ptr: *const u8, len: i32) -> i32 {
 ```
 
 > 完整模板含全部工具函数（字符串写入/读取、payload 读取）与 `process` DSP 示例，
-> 见 `micyou plugin create --runtime wasm` 生成的骨架
+> 见 `micyou-cli plugin create --runtime wasm` 生成的骨架
 
 ### 高级场景：手写 WAT（不推荐）
 
-仅当需要极致体积或无法引入工具链时，用 `micyou plugin create <id> --runtime wasm --lang wat`
+仅当需要极致体积或无法引入工具链时，用 `micyou-cli plugin create <id> --runtime wasm --lang wat`
 生成 WAT 骨架（内置 wat crate 直接编译 main.wasm）
 
 ```
@@ -531,7 +531,7 @@ host->send_message(host->ctx,
 2. **用构建工具内联**：vite/esbuild 开发时引用模块，发布前内联为单文件
    - `vite build` + `vite-plugin-singlefile`
    - esbuild：`esbuild src/main.ts --bundle --outfile=panel.html --loader:.html=copy`（CSS 用 `--bundle` 内联）
-3. **调试**：面板内 `call('log', {level:'debug', message: ...})` 写宿主日志，`micyou plugin dev <dir>` 监听变更自动重装，重启应用即可看到新面板
+3. **调试**：面板内 `call('log', {level:'debug', message: ...})` 写宿主日志，`micyou-cli plugin dev <dir>` 监听变更自动重装，重启应用即可看到新面板
 
 主题变量：宿主注入全部 `--*` CSS 变量（Material 3 HSL 三元组，用 `hsl(var(--primary))` 等引用），切主题时面板自动重载
 3. 面板内联脚本通过 postMessage 桥与宿主通信（见 `usePluginPanelBridge`）：
@@ -586,7 +586,7 @@ await call('play', { id: 'beep' });
 
 ## 端到端开发流程
 
-从零到市场发布的完整流程（配合 `micyou plugin` 工具链）
+从零到市场发布的完整流程（配合 `micyou-cli plugin` 工具链）
 
 ### 第 0 步：规划
 
@@ -602,11 +602,11 @@ await call('play', { id: 'beep' });
 
 ```bash
 # WASM 插件（默认 Rust 骨架，自动编译 main.wasm）
-micyou plugin create dev.yourname.myplugin \
+micyou-cli plugin create dev.yourname.myplugin \
   --kind utility --capabilities config.read,config.write
 
 # Native 插件
-micyou plugin create dev.yourname.mydsp \
+micyou-cli plugin create dev.yourname.mydsp \
   --runtime native --kind dsp
 ```
 
@@ -615,7 +615,7 @@ micyou plugin create dev.yourname.mydsp \
 ### 第 2 步：开发循环（热重装）
 
 ```bash
-micyou plugin dev <插件目录>
+micyou-cli plugin dev <插件目录>
 ```
 
 - 首次自动 validate + install（部署到 `~/.config/micyou/plugins/<id>/`）
@@ -626,7 +626,7 @@ micyou plugin dev <插件目录>
 ### 第 3 步：验证
 
 ```bash
-micyou plugin validate <插件目录>
+micyou-cli plugin validate <插件目录>
 # 校验 manifest 结构 + 入口产物存在性
 ```
 
@@ -635,7 +635,7 @@ micyou plugin validate <插件目录>
 ### 第 4 步：打包
 
 ```bash
-micyou plugin package <插件目录> -o myplugin.zip
+micyou-cli plugin package <插件目录> -o myplugin.zip
 # zip 根目录含 plugin.json，应用内可导入
 ```
 
@@ -661,9 +661,9 @@ micyou plugin package <插件目录> -o myplugin.zip
 ### 第 6 步：迭代与维护
 
 ```bash
-micyou plugin bump <插件目录>        # patch +1
-micyou plugin bump <插件目录> 2.0.0  # 指定版本
-micyou plugin package <插件目录> -o plugin.zip
+micyou-cli plugin bump <插件目录>        # patch +1
+micyou-cli plugin bump <插件目录> 2.0.0  # 指定版本
+micyou-cli plugin package <插件目录> -o plugin.zip
 ```
 发布新版本 = 插件仓库打新 release（新 zip 资产）+ 更新市场 `plugin/<id>/plugin.json`
 的 version 与 downloadUrl 并推送，用户应用内「检查更新」拉取

--- a/tauri-app/.gitignore
+++ b/tauri-app/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 *.local
 src/generated/third-party-licenses.html
+src-tauri/binaries/*
 
 # Editor directories and files
 .vscode/*

--- a/tauri-app/Cargo.lock
+++ b/tauri-app/Cargo.lock
@@ -3543,6 +3543,7 @@ dependencies = [
  "micyou-plugin",
  "semver",
  "serde_json",
+ "tauri-winres",
  "tokio",
  "wat",
  "zip",
@@ -3590,6 +3591,7 @@ dependencies = [
  "ratatui",
  "serde_json",
  "sysinfo",
+ "tauri-winres",
  "tokio",
 ]
 

--- a/tauri-app/clean-bundles.js
+++ b/tauri-app/clean-bundles.js
@@ -1,0 +1,25 @@
+import { execFileSync } from 'node:child_process';
+import { rmSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appDir = path.dirname(fileURLToPath(import.meta.url));
+const metadata = JSON.parse(
+  execFileSync('cargo', ['metadata', '--no-deps', '--format-version', '1'], {
+    cwd: appDir,
+    encoding: 'utf8',
+  }),
+);
+const targetDir = path.resolve(metadata.target_directory);
+const target = process.env.TAURI_ENV_TARGET_TRIPLE;
+const bundleDirs = [path.join(targetDir, 'release', 'bundle')];
+if (target) bundleDirs.push(path.join(targetDir, target, 'release', 'bundle'));
+
+for (const bundleDir of new Set(bundleDirs)) {
+  const resolved = path.resolve(bundleDir);
+  if (!resolved.startsWith(targetDir + path.sep)) {
+    throw new Error('Refusing to clean a bundle directory outside Cargo target');
+  }
+  rmSync(resolved, { recursive: true, force: true });
+  console.log('[bundle] Cleaned ' + path.relative(appDir, resolved));
+}

--- a/tauri-app/crates/micyou-cli/Cargo.toml
+++ b/tauri-app/crates/micyou-cli/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 description = "MicYou command-line interface"
 
 [[bin]]
-name = "micyou"
+name = "micyou-cli"
 path = "src/main.rs"
 
 [dependencies]

--- a/tauri-app/crates/micyou-cli/Cargo.toml
+++ b/tauri-app/crates/micyou-cli/Cargo.toml
@@ -27,3 +27,6 @@ semver = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.169"
+
+[build-dependencies]
+tauri-winres = "0.3.6"

--- a/tauri-app/crates/micyou-cli/build.rs
+++ b/tauri-app/crates/micyou-cli/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    println!("cargo:rerun-if-changed=../windows-app-manifest.xml");
+
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
+    }
+
+    tauri_winres::WindowsResource::new()
+        .set_manifest(include_str!("../windows-app-manifest.xml"))
+        .compile_for(&["micyou-cli"])
+        .expect("failed to embed the Windows Common Controls v6 manifest into micyou-cli");
+}

--- a/tauri-app/crates/micyou-cli/src/commands.rs
+++ b/tauri-app/crates/micyou-cli/src/commands.rs
@@ -175,7 +175,7 @@ pub fn cmd_mics() {
         println!("  available: {available}");
         println!("  virtual sink: {device_exists}");
         if available && !device_exists {
-            println!("  run `micyou serve` to auto-setup the virtual sink, or use the GUI");
+            println!("  run `micyou-cli serve` to auto-setup the virtual sink, or use the GUI");
         }
         if !available {
             println!("  PipeWire not detected (is pipewire-pulse running?)");
@@ -197,7 +197,7 @@ pub fn cmd_mics() {
         println!("VB-CABLE status:");
         println!("  installed: {installed}");
         if !installed {
-            println!("  run `micyou mics install` to install VB-CABLE");
+            println!("  run `micyou-cli mics install` to install VB-CABLE");
         }
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]

--- a/tauri-app/crates/micyou-cli/src/commands.rs
+++ b/tauri-app/crates/micyou-cli/src/commands.rs
@@ -1,5 +1,6 @@
 use crate::config;
 use micyou_audio::dsp::AudioDspSettings;
+#[cfg(target_os = "windows")]
 use std::process::exit;
 use tauri_app_lib::mode_lock as lock;
 

--- a/tauri-app/crates/micyou-cli/src/main.rs
+++ b/tauri-app/crates/micyou-cli/src/main.rs
@@ -52,11 +52,11 @@ fn install_alsa_stderr_filter() {
 
 #[derive(Parser)]
 #[command(
-    name = "micyou",
+    name = "micyou-cli",
     version,
     about = "MicYou CLI - turn your Android device into a PC microphone",
     long_about = "MicYou CLI runs the audio server with minimal memory footprint.\n\
-                  Use `micyou serve` to start the server, or `micyou --help` for all commands."
+                  Use `micyou-cli serve` to start the server, or `micyou-cli --help` for all commands."
 )]
 struct Cli {
     #[command(subcommand)]
@@ -125,7 +125,7 @@ enum SettingsAction {
         /// 设置键名，如 gain / nsEnabled / outputBufferMs
         key: Option<String>,
     },
-    /// 修改设置，如 `micyou settings set gain 10`
+    /// 修改设置，如 `micyou-cli settings set gain 10`
     Set {
         /// 设置键名
         key: String,
@@ -140,7 +140,7 @@ enum SettingsAction {
 enum ChainAction {
     /// 显示当前处理链路
     List,
-    /// 设置处理链路顺序，如 `micyou chain set AEC,NoiseReduction,Dereverb`
+    /// 设置处理链路顺序，如 `micyou-cli chain set AEC,NoiseReduction,Dereverb`
     Set {
         /// 逗号分隔的链路项
         chain: String,
@@ -151,7 +151,7 @@ enum ChainAction {
 enum ServerAction {
     /// 显示当前服务器连接设置
     Get,
-    /// 修改服务器设置，如 `micyou server set port 8554` / `micyou server set mode usb`
+    /// 修改服务器设置，如 `micyou-cli server set port 8554` / `micyou-cli server set mode usb`
     Set {
         /// 键名：port / webPort / mode / bindAddress / autoBind / outputDevice
         key: String,

--- a/tauri-app/crates/micyou-cli/src/plugin_cmds.rs
+++ b/tauri-app/crates/micyou-cli/src/plugin_cmds.rs
@@ -1,4 +1,4 @@
-//! `micyou plugin` — plugin development toolkit.
+//! `micyou-cli plugin` — plugin development toolkit.
 //!
 //! Subcommands:
 //! - `validate <dir>`  validate a plugin directory's plugin.json
@@ -228,7 +228,7 @@ fn bump(dir: &str, version: Option<&str>) -> Result<(), String> {
     std::fs::write(&manifest_path, out + "
 ").map_err(|e| format!("write: {e}"))?;
     println!("bumped {cur} -> {next} in {}", manifest_path.display());
-    println!("  tip: `micyou plugin package {dir}` to repackage");
+    println!("  tip: `micyou-cli plugin package {dir}` to repackage");
     Ok(())
 }
 
@@ -459,7 +459,7 @@ rustflags = ["-C", "link-arg=--export-memory"]
 "#;
 
 const WASM_TEMPLATE_WAT: &str = r#";; MicYou WASM plugin template
-;; Build: micyou plugin package <dir> (or compile with wat2wasm)
+;; Build: micyou-cli plugin package <dir> (or compile with wat2wasm)
 ;; Host API 一览见 docs/plugins/api-reference.md（WASM import 表）
 (module
   (import "micyou" "log" (func $log (param i32 i32)))
@@ -767,7 +767,7 @@ fn create(
         }
     }
     println!(
-        "created {runtime} plugin skeleton in {}/  \n  next: `micyou plugin dev {out_dir}` (watch) or `micyou plugin install {out_dir}`",
+        "created {runtime} plugin skeleton in {}/  \n  next: `micyou-cli plugin dev {out_dir}` (watch) or `micyou-cli plugin install {out_dir}`",
         dir.display()
     );
     Ok(())
@@ -780,7 +780,7 @@ const WASM_README: &str = r#"# 插件骨架
 
 ## 安装
 - 开发：把本目录放入 ~/.config/micyou/plugins/<id>/
-- 分发：`micyou plugin package .` 打包 zip 后在应用内导入
+- 分发：`micyou-cli plugin package .` 打包 zip 后在应用内导入
 
 ## 面板
 panel.html 通过 postMessage 桥调用宿主 API（get_config/set_config/trigger 等）
@@ -797,11 +797,11 @@ const WASM_RUST_README: &str = r#"# WASM 插件骨架（Rust）
 3. 复制产物为入口：`cp target/wasm32-unknown-unknown/release/myplugin.wasm main.wasm`
 
 ## 开发循环
-`micyou plugin dev .` 监听变更自动重装（可先执行一次构建）
+`micyou-cli plugin dev .` 监听变更自动重装（可先执行一次构建）
 
 ## 安装
-- 开发：`micyou plugin install .`
-- 分发：`micyou plugin package . -o out.zip` 后在应用内导入
+- 开发：`micyou-cli plugin install .`
+- 分发：`micyou-cli plugin package . -o out.zip` 后在应用内导入
 
 ## 模板说明
 - `src/lib.rs`：宿主导入（module "micyou"）与宿主契约导出（alloc/dealloc/
@@ -812,7 +812,7 @@ const WASM_RUST_README: &str = r#"# WASM 插件骨架（Rust）
 - 面板：panel.html 通过 postMessage 桥调用宿主 API
 
 ## 手动 WAT 路径（不推荐）
-`micyou plugin create <id> --runtime wasm --lang wat` 生成 WAT 骨架，
+`micyou-cli plugin create <id> --runtime wasm --lang wat` 生成 WAT 骨架，
 仅适合体积极致/无工具链的高级场景
 "#;
 

--- a/tauri-app/crates/micyou-tui/Cargo.toml
+++ b/tauri-app/crates/micyou-tui/Cargo.toml
@@ -26,3 +26,6 @@ sysinfo = "0.39.6"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.169"
+
+[build-dependencies]
+tauri-winres = "0.3.6"

--- a/tauri-app/crates/micyou-tui/build.rs
+++ b/tauri-app/crates/micyou-tui/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    println!("cargo:rerun-if-changed=../windows-app-manifest.xml");
+
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
+    }
+
+    tauri_winres::WindowsResource::new()
+        .set_manifest(include_str!("../windows-app-manifest.xml"))
+        .compile_for(&["micyou-tui"])
+        .expect("failed to embed the Windows Common Controls v6 manifest into micyou-tui");
+}

--- a/tauri-app/crates/windows-app-manifest.xml
+++ b/tauri-app/crates/windows-app-manifest.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -5,10 +5,13 @@
   "type": "module",
   "scripts": {
     "licenses": "node generate-licenses.js",
+    "clean-bundles": "node clean-bundles.js",
     "dev": "npm run licenses && vite",
     "build": "npm run licenses && vue-tsc --noEmit && vite build",
     "preview": "vite preview",
-    "tauri": "tauri",
+    "prepare-sidecars": "node prepare-sidecars.js",
+    "prepare-sidecars:dev": "node prepare-sidecars.js --debug",
+    "tauri": "node run-tauri.js",
     "sync-version": "node sync-version.js"
   },
   "dependencies": {

--- a/tauri-app/prepare-sidecars.js
+++ b/tauri-app/prepare-sidecars.js
@@ -1,0 +1,63 @@
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appDir = path.dirname(fileURLToPath(import.meta.url));
+const debug = process.argv.includes('--debug');
+
+function hostTargetTriple() {
+  const details = execFileSync('rustc', ['-vV'], { encoding: 'utf8' });
+  const target = details.match(/^host:\s*(\S+)$/m)?.[1];
+  if (!target) throw new Error('Unable to determine the Rust host target triple');
+  return target;
+}
+
+function cargoTargetDirectory() {
+  const metadata = execFileSync('cargo', ['metadata', '--no-deps', '--format-version', '1'], {
+    cwd: appDir,
+    encoding: 'utf8',
+  });
+  return JSON.parse(metadata).target_directory;
+}
+
+const target = process.env.TAURI_ENV_TARGET_TRIPLE || hostTargetTriple();
+const profile = debug ? 'debug' : 'release';
+const extension = target.includes('windows') ? '.exe' : '';
+const outputDir = path.join(appDir, 'src-tauri', 'binaries');
+const sidecars = ['micyou', 'micyou-tui'];
+mkdirSync(outputDir, { recursive: true });
+
+const cargoArgs = [
+  'build',
+  '--locked',
+  '--target',
+  target,
+  '-p',
+  'micyou-cli',
+  '-p',
+  'micyou-tui',
+];
+if (!debug) cargoArgs.push('--release');
+
+console.log('[sidecars] Building CLI and TUI for ' + target + ' (' + profile + ')');
+execFileSync('cargo', cargoArgs, {
+  cwd: appDir,
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    // Both terminal crates depend on the desktop core library. Disable sidecar
+    // validation only for this bootstrap build; the following Tauri build sees
+    // the prepared binaries and validates/bundles them normally.
+    TAURI_CONFIG: JSON.stringify({ bundle: { externalBin: [] } }),
+  },
+});
+
+const targetDir = cargoTargetDirectory();
+
+for (const binary of sidecars) {
+  const source = path.join(targetDir, target, profile, binary + extension);
+  const destination = path.join(outputDir, binary + '-' + target + extension);
+  copyFileSync(source, destination);
+  console.log('[sidecars] Prepared ' + path.relative(appDir, destination));
+}

--- a/tauri-app/prepare-sidecars.js
+++ b/tauri-app/prepare-sidecars.js
@@ -25,7 +25,7 @@ const target = process.env.TAURI_ENV_TARGET_TRIPLE || hostTargetTriple();
 const profile = debug ? 'debug' : 'release';
 const extension = target.includes('windows') ? '.exe' : '';
 const outputDir = path.join(appDir, 'src-tauri', 'binaries');
-const sidecars = ['micyou', 'micyou-tui'];
+const sidecars = ['micyou-cli', 'micyou-tui'];
 mkdirSync(outputDir, { recursive: true });
 
 const cargoArgs = [

--- a/tauri-app/run-tauri.js
+++ b/tauri-app/run-tauri.js
@@ -1,0 +1,24 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appDir = path.dirname(fileURLToPath(import.meta.url));
+const cli = path.join(appDir, 'node_modules', '@tauri-apps', 'cli', 'tauri.js');
+const env = { ...process.env };
+
+// linuxdeploy ships an older strip binary that cannot read newer RELR ELF
+// sections. Cargo already optimizes release binaries, so skipping this second
+// strip pass is both safe and portable across rolling and CI distributions.
+if (process.platform === 'linux' && env.NO_STRIP === undefined) env.NO_STRIP = '1';
+
+const result = spawnSync(process.execPath, [cli, ...process.argv.slice(2)], {
+  cwd: appDir,
+  env,
+  stdio: 'inherit',
+});
+if (result.error) throw result.error;
+if (result.signal) {
+  console.error('Tauri terminated by signal ' + result.signal);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ name = "tauri_app_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [[bin]]
-name = "micyou-gui"
+name = "micyou"
 path = "src/main.rs"
 
 [features]

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -10,6 +10,10 @@ license.workspace = true
 name = "tauri_app_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[[bin]]
+name = "micyou-gui"
+path = "src/main.rs"
+
 [features]
 default = ["vbcable", "adb", "web-server"]
 vbcable = []

--- a/tauri-app/src-tauri/installer.iss
+++ b/tauri-app/src-tauri/installer.iss
@@ -4,7 +4,7 @@
 #endif
 #define MyAppPublisher "LanRhyme"
 #define MyAppURL "https://github.com/LanRhyme/MicYou"
-#define MyAppExeName "MicYou.exe"
+#define MyAppExeName "micyou-gui.exe"
 
 [Setup]
 AppId={{C8E6D8A6-3A1B-4E38-B76B-C9DB2A0058C0}
@@ -36,7 +36,9 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "target\release\MicYou.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\target\release\micyou-gui.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "binaries\micyou-x86_64-pc-windows-msvc.exe"; DestDir: "{app}"; DestName: "micyou.exe"; Flags: ignoreversion
+Source: "binaries\micyou-tui-x86_64-pc-windows-msvc.exe"; DestDir: "{app}"; DestName: "micyou-tui.exe"; Flags: ignoreversion
 
 [Icons]
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"

--- a/tauri-app/src-tauri/installer.iss
+++ b/tauri-app/src-tauri/installer.iss
@@ -4,7 +4,7 @@
 #endif
 #define MyAppPublisher "LanRhyme"
 #define MyAppURL "https://github.com/LanRhyme/MicYou"
-#define MyAppExeName "micyou-gui.exe"
+#define MyAppExeName "micyou.exe"
 
 [Setup]
 AppId={{C8E6D8A6-3A1B-4E38-B76B-C9DB2A0058C0}
@@ -36,8 +36,8 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "..\target\release\micyou-gui.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "binaries\micyou-x86_64-pc-windows-msvc.exe"; DestDir: "{app}"; DestName: "micyou.exe"; Flags: ignoreversion
+Source: "..\target\release\micyou.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "binaries\micyou-cli-x86_64-pc-windows-msvc.exe"; DestDir: "{app}"; DestName: "micyou-cli.exe"; Flags: ignoreversion
 Source: "binaries\micyou-tui-x86_64-pc-windows-msvc.exe"; DestDir: "{app}"; DestName: "micyou-tui.exe"; Flags: ignoreversion
 
 [Icons]

--- a/tauri-app/src-tauri/packaging/micyou.desktop.hbs
+++ b/tauri-app/src-tauri/packaging/micyou.desktop.hbs
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Categories={{categories}}
+{{#if comment}}Comment={{comment}}{{/if}}
+Exec={{exec}}
+StartupWMClass=micyou-gui
+Icon={{icon}}
+Name=MicYou
+Terminal=false
+Type=Application

--- a/tauri-app/src-tauri/packaging/micyou.desktop.hbs
+++ b/tauri-app/src-tauri/packaging/micyou.desktop.hbs
@@ -2,7 +2,7 @@
 Categories={{categories}}
 {{#if comment}}Comment={{comment}}{{/if}}
 Exec={{exec}}
-StartupWMClass=micyou-gui
+StartupWMClass=micyou
 Icon={{icon}}
 Name=MicYou
 Terminal=false

--- a/tauri-app/src-tauri/src/commands/mode.rs
+++ b/tauri-app/src-tauri/src/commands/mode.rs
@@ -64,15 +64,15 @@ pub struct ModeStatus {
     pub running: bool,
 }
 
-/// Resolve the `micyou` CLI binary path:
+/// Resolve the `micyou-cli` binary path:
 /// 1. sibling of the current exe (dev builds share target/debug)
 /// 2. parent of the current exe dir (release layouts)
 /// 3. PATH
 pub fn find_cli_binary() -> Option<PathBuf> {
     let exe_name = if cfg!(target_os = "windows") {
-        "micyou.exe"
+        "micyou-cli.exe"
     } else {
-        "micyou"
+        "micyou-cli"
     };
 
     find_named_binary(exe_name)
@@ -105,8 +105,8 @@ fn find_named_binary(exe_name: &str) -> Option<PathBuf> {
         }
     }
 
-    // Resolve PATH entries ourselves so Windows cannot match `MicYou.exe`
-    // when the requested CLI filename is the case-distinct `micyou.exe`.
+    // Resolve PATH entries ourselves so Windows cannot substitute a
+    // differently-cased executable for the requested CLI filename.
     find_binary_on_path(exe_name)
 }
 
@@ -171,23 +171,23 @@ pub fn open_cli_terminal() -> Result<(), String> {
         let candidates: &[(&str, &[&str])] = &[
             (
                 "kitty",
-                &["--", binary.to_str().unwrap_or("micyou"), "serve"],
+                &["--", binary.to_str().unwrap_or("micyou-cli"), "serve"],
             ),
             (
                 "alacritty",
-                &["-e", binary.to_str().unwrap_or("micyou"), "serve"],
+                &["-e", binary.to_str().unwrap_or("micyou-cli"), "serve"],
             ),
             (
                 "gnome-terminal",
-                &["--", binary.to_str().unwrap_or("micyou"), "serve"],
+                &["--", binary.to_str().unwrap_or("micyou-cli"), "serve"],
             ),
             (
                 "konsole",
-                &["-e", binary.to_str().unwrap_or("micyou"), "serve"],
+                &["-e", binary.to_str().unwrap_or("micyou-cli"), "serve"],
             ),
             (
                 "xterm",
-                &["-e", binary.to_str().unwrap_or("micyou"), "serve"],
+                &["-e", binary.to_str().unwrap_or("micyou-cli"), "serve"],
             ),
         ];
         for (term, args) in candidates {
@@ -354,7 +354,7 @@ async fn switch_to_terminal(
 }
 
 /// Switch from the GUI to CLI mode: release the GUI lock and launch a terminal
-/// running `micyou serve`. The frontend should exit the app after this succeeds.
+/// running `micyou-cli serve`. The frontend should exit the app after this succeeds.
 #[tauri::command]
 pub async fn switch_to_cli(app: AppHandle, state: State<'_, ServerState>) -> Result<(), String> {
     switch_to_terminal(app, state, TerminalMode::Cli).await
@@ -439,13 +439,14 @@ mod tests {
             std::process::id()
         ));
         fs::create_dir_all(&dir).expect("temporary test directory should be created");
-        fs::write(dir.join("MicYou.exe"), b"gui").expect("GUI fixture should be written");
+        fs::write(dir.join("MicYou-CLI.exe"), b"wrong case")
+            .expect("case-variant CLI fixture should be written");
 
-        assert_eq!(find_exact_file(&dir, "micyou.exe"), None);
+        assert_eq!(find_exact_file(&dir, "micyou-cli.exe"), None);
 
-        let cli = dir.join("micyou.exe");
+        let cli = dir.join("micyou-cli.exe");
         fs::write(&cli, b"cli").expect("CLI fixture should be written");
-        assert_eq!(find_exact_file(&dir, "micyou.exe"), Some(cli));
+        assert_eq!(find_exact_file(&dir, "micyou-cli.exe"), Some(cli));
 
         fs::remove_dir_all(dir).expect("temporary test directory should be removed");
     }

--- a/tauri-app/src-tauri/src/commands/mode.rs
+++ b/tauri-app/src-tauri/src/commands/mode.rs
@@ -1,6 +1,8 @@
 use crate::mode_lock::{self, RunMode};
 use crate::server::ServerState;
 use serde::Serialize;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::{AppHandle, State};
@@ -66,67 +68,58 @@ pub struct ModeStatus {
 /// 1. sibling of the current exe (dev builds share target/debug)
 /// 2. parent of the current exe dir (release layouts)
 /// 3. PATH
-pub fn find_cli_binary() -> Option<std::path::PathBuf> {
+pub fn find_cli_binary() -> Option<PathBuf> {
     let exe_name = if cfg!(target_os = "windows") {
         "micyou.exe"
     } else {
         "micyou"
     };
 
+    find_named_binary(exe_name)
+}
+
+fn find_exact_file(dir: &Path, file_name: &str) -> Option<PathBuf> {
+    std::fs::read_dir(dir)
+        .ok()?
+        .filter_map(Result::ok)
+        .find(|entry| entry.file_name() == OsStr::new(file_name) && entry.path().is_file())
+        .map(|entry| entry.path())
+}
+
+fn find_binary_on_path(exe_name: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path).find_map(|dir| find_exact_file(&dir, exe_name))
+}
+
+fn find_named_binary(exe_name: &str) -> Option<PathBuf> {
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
-            let candidate = dir.join(exe_name);
-            if candidate.exists() {
+            if let Some(candidate) = find_exact_file(dir, exe_name) {
                 return Some(candidate);
             }
             if let Some(grandparent) = dir.parent() {
-                let candidate = grandparent.join(exe_name);
-                if candidate.exists() {
+                if let Some(candidate) = find_exact_file(grandparent, exe_name) {
                     return Some(candidate);
                 }
             }
         }
     }
 
-    // Fall back to PATH lookup
-    if let Ok(output) = Command::new(exe_name).arg("--version").output() {
-        if output.status.success() {
-            return Some(std::path::PathBuf::from(exe_name));
-        }
-    }
-    None
+    // Resolve PATH entries ourselves so Windows cannot match `MicYou.exe`
+    // when the requested CLI filename is the case-distinct `micyou.exe`.
+    find_binary_on_path(exe_name)
 }
 
 /// Resolve the standalone `micyou-tui` binary using the same lookup order as
 /// the CLI binary.
-pub fn find_tui_binary() -> Option<std::path::PathBuf> {
+pub fn find_tui_binary() -> Option<PathBuf> {
     let exe_name = if cfg!(target_os = "windows") {
         "micyou-tui.exe"
     } else {
         "micyou-tui"
     };
 
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            let candidate = dir.join(exe_name);
-            if candidate.exists() {
-                return Some(candidate);
-            }
-            if let Some(grandparent) = dir.parent() {
-                let candidate = grandparent.join(exe_name);
-                if candidate.exists() {
-                    return Some(candidate);
-                }
-            }
-        }
-    }
-
-    if let Ok(output) = Command::new(exe_name).arg("--version").output() {
-        if output.status.success() {
-            return Some(std::path::PathBuf::from(exe_name));
-        }
-    }
-    None
+    find_named_binary(exe_name)
 }
 
 /// Current lock status for the frontend.
@@ -223,17 +216,21 @@ pub fn open_cli_terminal() -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
         let bin = binary.to_string_lossy().to_string();
-        // Prefer Windows Terminal if available, otherwise plain cmd start
+        // Launch wt.exe directly so a missing App Execution Alias produces a
+        // real spawn error. `cmd /c start wt ...` itself succeeds even when
+        // `wt` does not exist, which made the old fallback unreachable.
+        if let Some(wt) = find_binary_on_path("wt.exe") {
+            if Command::new(wt)
+                .args(["-d", ".", "cmd", "/k", &bin, "serve"])
+                .spawn()
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
         Command::new("cmd")
-            .args([
-                "/c", "start", "", "wt", "-d", ".", "cmd", "/k", &bin, "serve",
-            ])
+            .args(["/c", "start", "", "cmd", "/k", &bin, "serve"])
             .spawn()
-            .or_else(|_| {
-                Command::new("cmd")
-                    .args(["/c", "start", "", &bin, "serve"])
-                    .spawn()
-            })
             .map_err(|e| e.to_string())?;
         Ok(())
     }
@@ -288,10 +285,18 @@ pub fn open_tui_terminal() -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
         let bin = binary.to_string_lossy().to_string();
+        if let Some(wt) = find_binary_on_path("wt.exe") {
+            if Command::new(wt)
+                .args(["-d", ".", "cmd", "/k", &bin])
+                .spawn()
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
         Command::new("cmd")
-            .args(["/c", "start", "", "wt", "-d", ".", "cmd", "/k", &bin])
+            .args(["/c", "start", "", "cmd", "/k", &bin])
             .spawn()
-            .or_else(|_| Command::new("cmd").args(["/c", "start", "", &bin]).spawn())
             .map_err(|e| e.to_string())?;
         Ok(())
     }
@@ -395,8 +400,10 @@ pub fn save_theme_colors(
 
 #[cfg(test)]
 mod tests {
-    use super::ModeSwitchGuard;
+    use super::{find_exact_file, ModeSwitchGuard};
+    use std::fs;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn mode_switch_gate_rejects_a_second_target() {
@@ -419,5 +426,27 @@ mod tests {
 
         assert!(flag.load(Ordering::Acquire));
         assert!(ModeSwitchGuard::acquire(&flag).is_err());
+    }
+
+    #[test]
+    fn binary_lookup_requires_an_exact_case_match() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after the Unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "micyou-mode-exact-name-{}-{suffix}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).expect("temporary test directory should be created");
+        fs::write(dir.join("MicYou.exe"), b"gui").expect("GUI fixture should be written");
+
+        assert_eq!(find_exact_file(&dir, "micyou.exe"), None);
+
+        let cli = dir.join("micyou.exe");
+        fs::write(&cli, b"cli").expect("CLI fixture should be written");
+        assert_eq!(find_exact_file(&dir, "micyou.exe"), Some(cli));
+
+        fs::remove_dir_all(dir).expect("temporary test directory should be removed");
     }
 }

--- a/tauri-app/src-tauri/src/commands/system.rs
+++ b/tauri-app/src-tauri/src/commands/system.rs
@@ -213,12 +213,9 @@ fn should_capture_loopback(
 }
 
 /// Locate the directory containing MicYou's bundled runtime resources (ONNX
-/// models and the `alsa/` config). The path cannot be derived from
-/// `resource_dir()` alone on a packaged deb: the binary is installed as
-/// `/usr/bin/micyou-app` (Cargo package name) while the deb bundler places
-/// resources under `/usr/lib/<productName>/resources`, so the Tauri-resolved
-/// resource dir (`/usr/lib/<crate name>`) does not exist. We therefore probe a
-/// candidate list ending in a scan of `/usr/lib/*`.
+/// models and the ALSA config). Linux packages use the standard
+/// /usr/bin + /usr/lib/micyou/resources layout, while AppImage exposes the
+/// same tree below its temporary mount point.
 fn find_resource_dir(resource_dir: Option<&std::path::Path>) -> Option<std::path::PathBuf> {
     const MARKERS: [&str; 2] = ["purevox6.onnx", "aec7_ep0185.onnx"];
 
@@ -239,22 +236,13 @@ fn find_resource_dir(resource_dir: Option<&std::path::Path>) -> Option<std::path
     {
         candidates.push(executable_dir.clone());
         candidates.push(executable_dir.join("resources"));
+        if let Some(prefix) = executable_dir.parent() {
+            candidates.push(prefix.join("lib").join("micyou").join("resources"));
+        }
     }
 
     // Compile-time fallback for `cargo run` from the workspace.
     candidates.push(std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources"));
-
-    // Packaged deb/appimage: resources live under /usr/lib/<productName>/resources,
-    // which does not always match the binary-derived resource_dir().
-    if let Ok(entries) = std::fs::read_dir("/usr/lib") {
-        for entry in entries.flatten() {
-            if let Ok(ft) = entry.file_type() {
-                if ft.is_dir() {
-                    candidates.push(entry.path().join("resources"));
-                }
-            }
-        }
-    }
 
     candidates
         .into_iter()
@@ -323,12 +311,17 @@ pub fn ensure_audio_output_started(
     output_buffer_ms: usize,
     resource_dir: Option<&std::path::Path>,
 ) -> bool {
+    #[cfg(target_os = "linux")]
+    let resolved_resource_dir = find_resource_dir(resource_dir);
+
     // On Linux, create the PipeWire virtual sink/source before opening output.
     #[cfg(target_os = "linux")]
     {
-        if output_device.is_none() && crate::pipewire::is_available() && !crate::pipewire::is_setup()
+        if output_device.is_none()
+            && crate::pipewire::is_available()
+            && !crate::pipewire::is_setup()
         {
-            if crate::pipewire::setup(resource_dir) {
+            if crate::pipewire::setup(resolved_resource_dir.as_deref()) {
                 log::info!("[PipeWire] Virtual device ready, ALSA will route to virtual sink");
             } else {
                 log::warn!("[PipeWire] Setup failed, falling back to default device");

--- a/tauri-app/src-tauri/src/commands/system.rs
+++ b/tauri-app/src-tauri/src/commands/system.rs
@@ -376,7 +376,7 @@ pub async fn start_server(
 }
 
 /// Core server startup, independent of the Tauri runtime.
-/// Shared by the GUI, CLI (`micyou serve`) and TUI (`micyou-tui`).
+/// Shared by the GUI, CLI (`micyou-cli serve`) and TUI (`micyou-tui`).
 pub async fn start_server_inner(
     state: &ServerState,
     port: u16,

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MicYou",
-  "mainBinaryName": "micyou-gui",
+  "mainBinaryName": "micyou",
   "version": "2.0.0",
   "identifier": "com.lanrhyme.micyou",
   "build": {
@@ -35,7 +35,7 @@
     "active": true,
     "targets": ["dmg", "app", "deb", "rpm", "appimage"],
     "category": "Music",
-    "externalBin": ["binaries/micyou", "binaries/micyou-tui"],
+    "externalBin": ["binaries/micyou-cli", "binaries/micyou-tui"],
     "resources": ["resources/*", "resources/alsa/*"],
     "icon": [
       "icons/32x32.png",

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,12 +1,14 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MicYou",
+  "mainBinaryName": "micyou-gui",
   "version": "2.0.0",
   "identifier": "com.lanrhyme.micyou",
   "build": {
-    "beforeDevCommand": "npm run dev",
+    "beforeDevCommand": "npm run prepare-sidecars:dev && npm run dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "npm run sync-version && npm run build",
+    "beforeBuildCommand": "npm run sync-version && npm run prepare-sidecars && npm run build",
+    "beforeBundleCommand": "npm run clean-bundles",
     "frontendDist": "../dist"
   },
   "app": {
@@ -31,7 +33,9 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "app", "deb", "appimage"],
+    "targets": ["dmg", "app", "deb", "rpm", "appimage"],
+    "category": "Music",
+    "externalBin": ["binaries/micyou", "binaries/micyou-tui"],
     "resources": ["resources/*", "resources/alsa/*"],
     "icon": [
       "icons/32x32.png",

--- a/tauri-app/src-tauri/tauri.linux.conf.json
+++ b/tauri-app/src-tauri/tauri.linux.conf.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
+  "productName": "micyou",
   "app": {
     "windows": [
       {
@@ -11,5 +12,15 @@
         "backgroundColor": "#00000000"
       }
     ]
+  },
+  "bundle": {
+    "linux": {
+      "deb": {
+        "desktopTemplate": "packaging/micyou.desktop.hbs"
+      },
+      "rpm": {
+        "desktopTemplate": "packaging/micyou.desktop.hbs"
+      }
+    }
   }
 }

--- a/tauri-app/src/shared/locales/cat.json
+++ b/tauri-app/src/shared/locales/cat.json
@@ -271,7 +271,7 @@
       "desc": "CLI 和 TUI 模式内存占用更少喵，在终端里跑喵~",
       "switchButton": "切换到 CLI 模式喵~",
       "switchTuiButton": "切换到 TUI 模式喵~",
-      "confirmSwitch": "要切换到 CLI 模式喵？图形界面会关闭，终端会打开跑 micyou serve 喵~",
+      "confirmSwitch": "要切换到 CLI 模式喵？图形界面会关闭，终端会打开跑 micyou-cli serve 喵~",
       "confirmSwitchTui": "要切换到 TUI 模式喵？图形界面会关闭，终端会打开跑 micyou-tui 喵~",
       "switchFailed": "切换失败喵~ (´;ω;`)",
       "guiCurrent": "图形界面 (GUI) 喵~",

--- a/tauri-app/src/shared/locales/en.json
+++ b/tauri-app/src/shared/locales/en.json
@@ -273,7 +273,7 @@
       "desc": "CLI and TUI modes use less memory and run in a terminal",
       "switchButton": "Switch to CLI Mode",
       "switchTuiButton": "Switch to TUI Mode",
-      "confirmSwitch": "Switch to CLI mode? The GUI will close and a terminal will run micyou serve",
+      "confirmSwitch": "Switch to CLI mode? The GUI will close and a terminal will run micyou-cli serve",
       "confirmSwitchTui": "Switch to TUI mode? The GUI will close and a terminal will run micyou-tui",
       "switchFailed": "Switch failed",
       "guiCurrent": "GUI",

--- a/tauri-app/src/shared/locales/lzh.json
+++ b/tauri-app/src/shared/locales/lzh.json
@@ -271,7 +271,7 @@
       "desc": "CLI 与 TUI 模式耗内存寡，运行于终端",
       "switchButton": "切至 CLI 模式",
       "switchTuiButton": "切至 TUI 模式",
-      "confirmSwitch": "欲切至 CLI 模式乎？图形界面将闭，终端将启 micyou serve",
+      "confirmSwitch": "欲切至 CLI 模式乎？图形界面将闭，终端将启 micyou-cli serve",
       "confirmSwitchTui": "欲切至 TUI 模式乎？图形界面将闭，终端将启 micyou-tui",
       "switchFailed": "切换败",
       "guiCurrent": "图形界面 (GUI)",

--- a/tauri-app/src/shared/locales/zh-hk.json
+++ b/tauri-app/src/shared/locales/zh-hk.json
@@ -271,7 +271,7 @@
       "desc": "CLI 同 TUI 模式用少啲記憶體，喺終端機入面運行",
       "switchButton": "切換到 CLI 模式",
       "switchTuiButton": "切換到 TUI 模式",
-      "confirmSwitch": "要切換到 CLI 模式？圖形介面會關閉，終端機會打開運行 micyou serve",
+      "confirmSwitch": "要切換到 CLI 模式？圖形介面會關閉，終端機會打開運行 micyou-cli serve",
       "confirmSwitchTui": "要切換到 TUI 模式？圖形介面會關閉，終端機會打開運行 micyou-tui",
       "switchFailed": "切換失敗",
       "guiCurrent": "圖形介面 (GUI)",

--- a/tauri-app/src/shared/locales/zh-ss.json
+++ b/tauri-app/src/shared/locales/zh-ss.json
@@ -271,7 +271,7 @@
       "desc": "CLI 和 TUI 模式使用更少内存项，通过终端运行",
       "switchButton": "切换到 CLI 模式项",
       "switchTuiButton": "切换到 TUI 模式项",
-      "confirmSwitch": "切换到 CLI 模式？图形界面将关闭项，终端将打开运行 micyou serve",
+      "confirmSwitch": "切换到 CLI 模式？图形界面将关闭项，终端将打开运行 micyou-cli serve",
       "confirmSwitchTui": "切换到 TUI 模式？图形界面将关闭项，终端将打开运行 micyou-tui",
       "switchFailed": "切换失败项",
       "guiCurrent": "图形界面 (GUI) 项",

--- a/tauri-app/src/shared/locales/zh-tw.json
+++ b/tauri-app/src/shared/locales/zh-tw.json
@@ -271,7 +271,7 @@
       "desc": "CLI 和 TUI 模式使用較少記憶體，在終端機中執行",
       "switchButton": "切換到 CLI 模式",
       "switchTuiButton": "切換到 TUI 模式",
-      "confirmSwitch": "切換到 CLI 模式？圖形介面將關閉，終端機會開啟並執行 micyou serve",
+      "confirmSwitch": "切換到 CLI 模式？圖形介面將關閉，終端機會開啟並執行 micyou-cli serve",
       "confirmSwitchTui": "切換到 TUI 模式？圖形介面將關閉，終端機會開啟並執行 micyou-tui",
       "switchFailed": "切換失敗",
       "guiCurrent": "圖形介面 (GUI)",

--- a/tauri-app/src/shared/locales/zh.json
+++ b/tauri-app/src/shared/locales/zh.json
@@ -273,7 +273,7 @@
       "desc": "CLI 和 TUI 模式使用更少内存，通过终端运行",
       "switchButton": "切换到 CLI 模式",
       "switchTuiButton": "切换到 TUI 模式",
-      "confirmSwitch": "切换到 CLI 模式？图形界面将关闭，终端将打开并运行 micyou serve",
+      "confirmSwitch": "切换到 CLI 模式？图形界面将关闭，终端将打开并运行 micyou-cli serve",
       "confirmSwitchTui": "切换到 TUI 模式？图形界面将关闭，终端将打开并运行 micyou-tui",
       "switchFailed": "切换失败",
       "guiCurrent": "图形界面 (GUI)",


### PR DESCRIPTION
## 概述

修复桌面端跨平台打包与 GUI、CLI、TUI 模式切换问题，统一产物命名和安装布局，并确保终端前端随安装包一起发布。

## 主要改动

### 统一包名与二进制名称

- Linux 软件包与桌面文件统一使用 `micyou`
- GUI 二进制统一为 `micyou`
- CLI 二进制统一为 `micyou-cli`
- TUI 二进制保持 `micyou-tui`
- Linux 安装布局由 `/opt` 调整为标准 `/usr/bin`、`/usr/lib/micyou` 和 `/usr/share`
- Windows Inno 安装器同时安装 GUI、CLI 和 TUI

### 完善构建与打包流程

- 在 Tauri 构建前自动编译并准备 CLI/TUI sidecar
- 清理旧 bundle 目录，避免不同 target 的陈旧产物混入发布包
- GitHub Actions 统一通过 `npm run tauri -- build` 执行桌面构建
- Linux 同时生成 DEB、RPM 和 AppImage
- AppImage 构建设置 `NO_STRIP=1`，规避 linuxdeploy 对 RELR ELF 的兼容问题
- 修正安装包资源目录解析，覆盖 DEB、RPM 与 AppImage 布局

### 修复 CLI/TUI 模式切换

- 精确查找独立的 CLI/TUI 二进制，避免 Windows 大小写不敏感导致误匹配 GUI
- 启动前检测 `wt.exe`，Windows Terminal 不可用时正确降级到 `cmd`
- CLI/TUI 分别启动 `micyou-cli serve` 与 `micyou-tui`
- 为 Windows CLI/TUI 嵌入 Common Controls v6 manifest，修复 `TaskDialogIndirect` 入口点错误
- 保留模式切换互斥与失败后的 GUI 锁恢复行为

### 同步文档与界面文案

- 更新全部桌面端语言文件中的 CLI 命令
- 更新 CLI 帮助、插件开发文档和仓库开发说明

## 验证

- `npm run tauri build` 通过
- 已生成并检查：
  - `micyou_2.0.0_amd64.deb`
  - `micyou-2.0.0-1.x86_64.rpm`
  - `micyou_2.0.0_amd64.AppImage`
- DEB、RPM、AppImage 均包含：
  - `micyou`
  - `micyou-cli`
  - `micyou-tui`
- `cargo check --workspace` 通过
- `cargo test -p micyou-app --lib`：95 个测试通过
- GitHub Actions workflow 配置检查通过
- Windows Common Controls 资源已成功生成并定向链接到 CLI/TUI；最终安装包由 Windows Actions 构建验证

Closes #304