### PR TITLE
桌面端设置对话框新增 `恢复默认` 按钮

### DIFF
--- a/tauri-app/src/features/settings/components/SettingsDialog.vue
+++ b/tauri-app/src/features/settings/components/SettingsDialog.vue
@@ -2310,6 +2310,7 @@ async function confirmRestore() {
 }
 
 async function doRestoreDefaultSettings() {
+  let autostartFailed = false;
   try {
     // Reset UI preferences (persisted via useStorage -> localStorage)
     closeBehavior.value = null;
@@ -2318,43 +2319,47 @@ async function doRestoreDefaultSettings() {
     autoStream.value = false;
     pocketMode.value = false;
 
-    // Batch the settings mutation under suppressAutosave so the deep watcher
-    // does not fire an extra save; then flush exactly one real save.
+    // Batch the settings mutation under suppressAutosave; release AFTER the
+    // deep watcher's batched flush (nextTick) so it runs as a no-op, yielding
+    // exactly one real save below. Releasing in `finally` before nextTick
+    // would let the watcher fire a second save (race fixed per review).
     suppressAutosave.value = true;
-    try {
-      const defaults = DEFAULT_AUDIO_SETTINGS();
-      // Full reset: drop keys no longer in defaults (avoid stale residue from
-      // renamed/removed fields), then overwrite. Init and reset share one source.
-      Object.keys(settings).forEach((k) => {
-        if (!(k in defaults)) delete (settings as Record<string, unknown>)[k];
-      });
-      Object.assign(settings, defaults);
-      // Platform normalization (AEC pinning is runtime, not a "default")
-      settings.processingChain = isAecSupported
-        ? ['AEC', ...settings.processingChain.filter((i) => i !== 'AEC')]
-        : settings.processingChain.filter((i) => i !== 'AEC');
-      if (!isAecSupported) settings.aecEnabled = false;
-    } finally {
-      suppressAutosave.value = false;
-    }
-    await nextTick(); // let the suppressed (no-op) watcher flush pass
+    const defaults = DEFAULT_AUDIO_SETTINGS();
+    // Full reset: drop keys no longer in defaults (avoid stale residue from
+    // renamed/removed fields), then overwrite. Init and reset share one source.
+    Object.keys(settings).forEach((k) => {
+      if (!(k in defaults)) delete (settings as Record<string, unknown>)[k];
+    });
+    Object.assign(settings, defaults);
+    // Platform normalization (AEC pinning is runtime, not a "default")
+    settings.processingChain = isAecSupported
+      ? ['AEC', ...settings.processingChain.filter((i) => i !== 'AEC')]
+      : settings.processingChain.filter((i) => i !== 'AEC');
+    if (!isAecSupported) settings.aecEnabled = false;
+    await nextTick(); // watcher flushes while still suppressed → no-op
+    suppressAutosave.value = false;
     saveSettings(); // exactly one real persist + backend sync
 
-    // Disable OS-level autostart if currently enabled
+    // Disable OS-level autostart if currently enabled; surface failure
+    // (previously swallowed → UI falsely showed full success)
     if (autostartEnabled.value) {
       try {
         await disableAutostart();
         autostartEnabled.value = false;
       } catch (e) {
+        autostartFailed = true;
         console.error('Failed to disable autostart on reset:', e);
       }
     }
 
     restoreResult.value = {
       title: t('settings.restoreDefaults.title'),
-      message: t('settings.restoreDefaults.success'),
+      message: autostartFailed
+        ? t('settings.restoreDefaults.autostartFailed')
+        : t('settings.restoreDefaults.success'),
     };
   } catch (e) {
+    suppressAutosave.value = false; // release on failure too (avoid leak)
     console.error('Failed to restore default settings:', e);
     restoreResult.value = {
       title: t('settings.restoreDefaults.title'),
@@ -2368,14 +2373,19 @@ async function doRestoreDefaultTheme() {
     // colorMode lives in SettingsDialog (useColorMode); theme fields live in
     // useTheme. resetThemeToDefaults reuses DEFAULT_THEME so no second copy.
     colorMode.value = DEFAULT_THEME.colorMode as typeof colorMode.value;
-    resetThemeToDefaults();
+    // Await backend removal of an installed theme package; resetThemeToDefaults
+    // returns true if that removal failed (frontend already cleared) so we can
+    // surface a partial-success instead of a silent inconsistency.
+    const themeRemoveFailed = await resetThemeToDefaults();
     // Sync ui.json (themeColor preset) — saveUiPrefs reads the freshly reset
     // themeMode/themeColor, so call it after resetThemeToDefaults.
     saveUiPrefs();
 
     restoreResult.value = {
       title: t('settings.restoreTheme.title'),
-      message: t('settings.restoreTheme.success'),
+      message: themeRemoveFailed
+        ? t('settings.restoreTheme.partialSuccess')
+        : t('settings.restoreTheme.success'),
     };
   } catch (e) {
     console.error('Failed to restore default theme:', e);

--- a/tauri-app/src/features/settings/components/SettingsDialog.vue
+++ b/tauri-app/src/features/settings/components/SettingsDialog.vue
@@ -518,6 +518,22 @@
                     </button>
                   </div>
                 </div>
+
+                <!-- Restore default settings -->
+                <div class="rounded-2xl bg-surface-variant/20 border border-outline/10 p-4">
+                  <div class="flex items-center justify-between gap-3">
+                    <div class="min-w-0">
+                      <p class="text-sm font-bold text-foreground">{{ $t('settings.restoreDefaults.label') }}</p>
+                      <p class="text-xs text-on-surface-variant mt-0.5">{{ $t('settings.restoreDefaults.desc') }}</p>
+                    </div>
+                    <button
+                      class="shrink-0 rounded-full bg-error/10 px-4 py-2 text-sm font-medium text-error transition-colors hover:bg-error/20"
+                      @click="restoreDefaultSettings"
+                    >
+                      {{ $t('settings.restoreDefaults.button') }}
+                    </button>
+                  </div>
+                </div>
               </div>
 
               <!-- APPEARANCE SECTION -->
@@ -767,6 +783,22 @@
                   >
                     {{ $t('settings.theme.catalogButton') }}
                   </button>
+                </div>
+
+                <!-- Restore default theme -->
+                <div class="rounded-2xl bg-surface-variant/20 border border-outline/10 p-4">
+                  <div class="flex items-center justify-between gap-3">
+                    <div class="min-w-0">
+                      <p class="text-sm font-bold text-foreground">{{ $t('settings.restoreTheme.label') }}</p>
+                      <p class="text-xs text-on-surface-variant mt-0.5">{{ $t('settings.restoreTheme.desc') }}</p>
+                    </div>
+                    <button
+                      class="shrink-0 rounded-full bg-error/10 px-4 py-2 text-sm font-medium text-error transition-colors hover:bg-error/20"
+                      @click="restoreDefaultTheme"
+                    >
+                      {{ $t('settings.restoreTheme.button') }}
+                    </button>
+                  </div>
                 </div>
               </div>
 
@@ -1326,6 +1358,66 @@
     </div>
   </Transition>
 
+  <!-- Restore defaults: confirm dialog (mirrors App.vue IP switch confirm style) -->
+  <Transition
+    enter-active-class="transition ease-out duration-200"
+    enter-from-class="opacity-0"
+    enter-to-class="opacity-100"
+    leave-active-class="transition ease-in duration-150"
+    leave-from-class="opacity-100"
+    leave-to-class="opacity-0"
+  >
+    <div v-if="restoreConfirmTarget" class="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div class="bg-surface rounded-2xl shadow-2xl border border-outline/10 p-6 w-80">
+        <h3 class="text-sm font-bold text-foreground mb-2">
+          {{ $t(restoreConfirmTarget === 'settings' ? 'settings.restoreDefaults.title' : 'settings.restoreTheme.title') }}
+        </h3>
+        <p class="text-xs text-on-surface-variant mb-5">
+          {{ $t(restoreConfirmTarget === 'settings' ? 'settings.restoreDefaults.confirmDesc' : 'settings.restoreTheme.confirmDesc') }}
+        </p>
+        <div class="flex justify-end gap-2">
+          <button
+            class="px-4 py-2 text-xs font-medium text-on-surface-variant hover:bg-surface-variant/50 rounded-lg transition-colors"
+            @click="restoreConfirmTarget = null"
+          >
+            {{ $t('dialogs.cancel') }}
+          </button>
+          <button
+            class="px-4 py-2 text-xs font-medium text-on-primary bg-primary hover:bg-primary/90 rounded-lg transition-colors"
+            @click="confirmRestore"
+          >
+            {{ $t('dialogs.confirm') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Transition>
+
+  <!-- Restore defaults: result dialog -->
+  <Transition
+    enter-active-class="transition ease-out duration-200"
+    enter-from-class="opacity-0"
+    enter-to-class="opacity-100"
+    leave-active-class="transition ease-in duration-150"
+    leave-from-class="opacity-100"
+    leave-to-class="opacity-0"
+  >
+    <div v-if="restoreResult" class="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div class="bg-surface rounded-2xl shadow-2xl border border-outline/10 p-6 w-80">
+        <h3 class="text-sm font-bold text-foreground mb-2">{{ restoreResult.title }}</h3>
+        <p class="text-xs text-on-surface-variant mb-5">{{ restoreResult.message }}</p>
+        <div class="flex justify-end gap-2">
+          <button
+            class="px-4 py-2 text-xs font-medium text-on-primary bg-primary hover:bg-primary/90 rounded-lg transition-colors"
+            @click="restoreResult = null"
+          >
+            {{ $t('dialogs.close') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Transition>
+
   <ContributorsDialog :isOpen="showContributors" @close="showContributors = false" />
   <SponsorsDialog :isOpen="showSponsors" @close="showSponsors = false" />
   <LicensesDialog :isOpen="showLicenses" @close="showLicenses = false" />
@@ -1349,7 +1441,7 @@
 
 <script setup lang="ts">
 import MD3Slider from '@/shared/components/ui/slider/MD3Slider.vue';
-import { ref, computed, watch, reactive, onMounted, onUnmounted } from 'vue';
+import { ref, computed, watch, reactive, onMounted, onUnmounted, nextTick } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useColorMode, useStorage } from '@vueuse/core';
 import { invoke } from '@tauri-apps/api/core';
@@ -1391,7 +1483,7 @@ import { usePlugins } from '@/features/plugins/composables/usePlugins';
 import { usePluginPanelBridge } from '@/shared/composables/usePluginPanelBridge';
 import ThemeSelector from '@/features/theme/components/ThemeSelector.vue';
 import CustomColorPicker from '@/features/theme/components/CustomColorPicker.vue';
-import { useTheme } from '@/features/theme/composables/useTheme';
+import { useTheme, DEFAULT_THEME } from '@/features/theme/composables/useTheme';
 
 onMounted(() => {
   window.addEventListener('message', onPanelMessage);
@@ -1437,6 +1529,7 @@ const {
   installedThemeId,
   installedThemeControlsColor,
   clearInstalledTheme,
+  resetThemeToDefaults,
 } = useTheme();
 const themePackageActive = computed(() =>
   Boolean(installedThemeId.value && installedThemeControlsColor.value),
@@ -2180,13 +2273,118 @@ const saveSettings = () => {
   syncSettingsToBackend();
 };
 
+// Autosave: any change to `settings` persists + syncs to backend. Suppressed
+// during "restore defaults" so a single batched mutation produces exactly one
+// save (see doRestoreDefaultSettings).
+const suppressAutosave = ref(false);
 watch(
   settings,
   () => {
+    if (suppressAutosave.value) return;
     saveSettings();
   },
   { deep: true },
 );
+
+// In-app confirm + result dialog state for restore actions (mirrors the
+// IP switch confirm dialog style in App.vue — no native confirm()/alert()).
+const restoreConfirmTarget = ref<'settings' | 'theme' | null>(null);
+const restoreResult = ref<{ title: string; message: string } | null>(null);
+
+function restoreDefaultSettings() {
+  restoreConfirmTarget.value = 'settings';
+}
+
+function restoreDefaultTheme() {
+  restoreConfirmTarget.value = 'theme';
+}
+
+async function confirmRestore() {
+  const target = restoreConfirmTarget.value;
+  restoreConfirmTarget.value = null;
+  if (target === 'settings') {
+    await doRestoreDefaultSettings();
+  } else if (target === 'theme') {
+    await doRestoreDefaultTheme();
+  }
+}
+
+async function doRestoreDefaultSettings() {
+  try {
+    // Reset UI preferences (persisted via useStorage -> localStorage)
+    closeBehavior.value = null;
+    startMinimized.value = false;
+    notificationsEnabled.value = true;
+    autoStream.value = false;
+    pocketMode.value = false;
+
+    // Batch the settings mutation under suppressAutosave so the deep watcher
+    // does not fire an extra save; then flush exactly one real save.
+    suppressAutosave.value = true;
+    try {
+      const defaults = DEFAULT_AUDIO_SETTINGS();
+      // Full reset: drop keys no longer in defaults (avoid stale residue from
+      // renamed/removed fields), then overwrite. Init and reset share one source.
+      Object.keys(settings).forEach((k) => {
+        if (!(k in defaults)) delete (settings as Record<string, unknown>)[k];
+      });
+      Object.assign(settings, defaults);
+      // Platform normalization (AEC pinning is runtime, not a "default")
+      settings.processingChain = isAecSupported
+        ? ['AEC', ...settings.processingChain.filter((i) => i !== 'AEC')]
+        : settings.processingChain.filter((i) => i !== 'AEC');
+      if (!isAecSupported) settings.aecEnabled = false;
+    } finally {
+      suppressAutosave.value = false;
+    }
+    await nextTick(); // let the suppressed (no-op) watcher flush pass
+    saveSettings(); // exactly one real persist + backend sync
+
+    // Disable OS-level autostart if currently enabled
+    if (autostartEnabled.value) {
+      try {
+        await disableAutostart();
+        autostartEnabled.value = false;
+      } catch (e) {
+        console.error('Failed to disable autostart on reset:', e);
+      }
+    }
+
+    restoreResult.value = {
+      title: t('settings.restoreDefaults.title'),
+      message: t('settings.restoreDefaults.success'),
+    };
+  } catch (e) {
+    console.error('Failed to restore default settings:', e);
+    restoreResult.value = {
+      title: t('settings.restoreDefaults.title'),
+      message: t('settings.restoreDefaults.failed'),
+    };
+  }
+}
+
+async function doRestoreDefaultTheme() {
+  try {
+    // colorMode lives in SettingsDialog (useColorMode); theme fields live in
+    // useTheme. resetThemeToDefaults reuses DEFAULT_THEME so no second copy.
+    colorMode.value = DEFAULT_THEME.colorMode as typeof colorMode.value;
+    resetThemeToDefaults();
+    // Sync ui.json (themeColor preset) — saveUiPrefs reads the freshly reset
+    // themeMode/themeColor, so call it after resetThemeToDefaults.
+    saveUiPrefs();
+
+    restoreResult.value = {
+      title: t('settings.restoreTheme.title'),
+      message: t('settings.restoreTheme.success'),
+    };
+  } catch (e) {
+    console.error('Failed to restore default theme:', e);
+    restoreResult.value = {
+      title: t('settings.restoreTheme.title'),
+      message: t('settings.restoreTheme.failed'),
+    };
+  }
+}
 
 function resetMonitoringData() {
   audioLevel.value = 0;

--- a/tauri-app/src/features/settings/components/SettingsDialog.vue
+++ b/tauri-app/src/features/settings/components/SettingsDialog.vue
@@ -1753,7 +1753,10 @@ watch(currentLanguage, (newLang) => {
 });
 
 // Reactive Settings State
-const settings = reactive({
+// Single source of truth for audio / DSP default values. Both the `settings`
+// reactive init and "restore defaults" reference this — add a field here and
+// both stay in sync, no second copy to keep aligned by hand.
+const DEFAULT_AUDIO_SETTINGS = () => ({
   audioDevice: 'auto',
   gain: 0,
   aecEnabled: false,
@@ -1776,6 +1779,8 @@ const settings = reactive({
     gains: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
   },
 });
+
+const settings = reactive(DEFAULT_AUDIO_SETTINGS());
 
 const audioDevices = ref<string[]>([]);
 const hasVBCable = computed(() =>

--- a/tauri-app/src/features/theme/composables/useTheme.ts
+++ b/tauri-app/src/features/theme/composables/useTheme.ts
@@ -240,7 +240,9 @@ export function clearInstalledTheme() {
 // down any installed theme package. The applyTheme watchEffect recomputes CSS
 // + writes theme.json; SettingsDialog calls saveUiPrefs() afterwards to sync
 // ui.json. No second copy of defaults lives here.
-export function resetThemeToDefaults() {
+// Returns true if an installed theme package existed but its backend removal
+// failed (frontend is already cleared) — caller surfaces a partial-success.
+export async function resetThemeToDefaults(): Promise<boolean> {
   themeMode.value = DEFAULT_THEME.themeMode;
   themeColor.value = DEFAULT_THEME.themeColor;
   uiStyle.value = DEFAULT_THEME.uiStyle;
@@ -253,10 +255,14 @@ export function resetThemeToDefaults() {
   const id = installedThemeId.value;
   if (id) {
     clearInstalledTheme();
-    void invoke('remove_installed_theme', { themeId: id }).catch((e) =>
-      console.warn('Failed to remove installed theme:', e),
-    );
+    try {
+      await invoke('remove_installed_theme', { themeId: id });
+    } catch (e) {
+      console.warn('Failed to remove installed theme:', e);
+      return true; // installed-theme package removal failed (frontend already cleared)
+    }
   }
+  return false;
 }
 
 export function useTheme() {

--- a/tauri-app/src/features/theme/composables/useTheme.ts
+++ b/tauri-app/src/features/theme/composables/useTheme.ts
@@ -22,16 +22,32 @@ const THEME_CLASSES = Object.keys(BUILTIN_THEMES).concat('theme-custom', 'theme-
 const THEME_COLOR_CLASSES = Object.keys(BUILTIN_THEMES).map((name) => name.replace('theme-', 'theme-color-')).concat('theme-color-custom', 'theme-color-system');
 const STYLE_CLASSES = ['style-default', 'style-glass'];
 
+// Single source of truth for theme default values. `useStorage` init and
+// resetThemeToDefaults() both reference this — change a default here once.
+// `colorMode` is consumed by SettingsDialog's useColorMode reset.
+export const DEFAULT_THEME = {
+  colorMode: 'auto',
+  themeMode: 'system' as ThemeMode,
+  themeColor: 'theme-blue',
+  uiStyle: 'style-default',
+  customH: 215,
+  customS: 35,
+  customL: 55,
+  customVariant: 'TonalSpot',
+  customCss: '',
+  customCssEnabled: true,
+};
+
 // Versioned keys intentionally avoid silently migrating the previous theme data.
-const themeMode = useStorage<ThemeMode>('micyou_theme_v2_mode', 'system');
-const themeColor = useStorage<string>('micyou_theme_v2_color', 'theme-blue');
-const uiStyle = useStorage<string>('micyou_theme_v2_ui_style', 'style-default');
-const customH = useStorage<number>('micyou_theme_v2_custom_h', 215);
-const customS = useStorage<number>('micyou_theme_v2_custom_s', 35);
-const customL = useStorage<number>('micyou_theme_v2_custom_l', 55);
-const customVariant = useStorage<string>('micyou_theme_v2_variant', 'TonalSpot');
-const customCss = useStorage<string>('micyou_theme_v2_css', '');
-const customCssEnabled = useStorage<boolean>('micyou_theme_v2_css_enabled', true);
+const themeMode = useStorage<ThemeMode>('micyou_theme_v2_mode', DEFAULT_THEME.themeMode);
+const themeColor = useStorage<string>('micyou_theme_v2_color', DEFAULT_THEME.themeColor);
+const uiStyle = useStorage<string>('micyou_theme_v2_ui_style', DEFAULT_THEME.uiStyle);
+const customH = useStorage<number>('micyou_theme_v2_custom_h', DEFAULT_THEME.customH);
+const customS = useStorage<number>('micyou_theme_v2_custom_s', DEFAULT_THEME.customS);
+const customL = useStorage<number>('micyou_theme_v2_custom_l', DEFAULT_THEME.customL);
+const customVariant = useStorage<string>('micyou_theme_v2_variant', DEFAULT_THEME.customVariant);
+const customCss = useStorage<string>('micyou_theme_v2_css', DEFAULT_THEME.customCss);
+const customCssEnabled = useStorage<boolean>('micyou_theme_v2_css_enabled', DEFAULT_THEME.customCssEnabled);
 const installedThemeId = useStorage<string>('micyou_theme_v2_installed_id', '');
 const installedThemeCss = useStorage<string>('micyou_theme_v2_installed_css', '');
 const installedThemeControlsColor = useStorage<boolean>('micyou_theme_v2_installed_controls_color', true);

--- a/tauri-app/src/features/theme/composables/useTheme.ts
+++ b/tauri-app/src/features/theme/composables/useTheme.ts
@@ -236,6 +236,29 @@ export function clearInstalledTheme() {
   installedThemeControlsColor.value = true;
 }
 
+// Reset every theme field to DEFAULT_THEME (single source of truth) and tear
+// down any installed theme package. The applyTheme watchEffect recomputes CSS
+// + writes theme.json; SettingsDialog calls saveUiPrefs() afterwards to sync
+// ui.json. No second copy of defaults lives here.
+export function resetThemeToDefaults() {
+  themeMode.value = DEFAULT_THEME.themeMode;
+  themeColor.value = DEFAULT_THEME.themeColor;
+  uiStyle.value = DEFAULT_THEME.uiStyle;
+  customH.value = DEFAULT_THEME.customH;
+  customS.value = DEFAULT_THEME.customS;
+  customL.value = DEFAULT_THEME.customL;
+  customVariant.value = DEFAULT_THEME.customVariant;
+  customCss.value = DEFAULT_THEME.customCss;
+  customCssEnabled.value = DEFAULT_THEME.customCssEnabled;
+  const id = installedThemeId.value;
+  if (id) {
+    clearInstalledTheme();
+    void invoke('remove_installed_theme', { themeId: id }).catch((e) =>
+      console.warn('Failed to remove installed theme:', e),
+    );
+  }
+}
+
 export function useTheme() {
   void initializeSystemAccent();
 
@@ -272,6 +295,7 @@ export function useTheme() {
     installedThemeCss,
     installedThemeControlsColor,
     clearInstalledTheme,
+    resetThemeToDefaults,
     systemAccent,
     systemAccentLoading,
   };

--- a/tauri-app/src/shared/locales/cat.json
+++ b/tauri-app/src/shared/locales/cat.json
@@ -287,7 +287,8 @@
       "title": "恢复默认设置喵？",
       "confirmDesc": "这会把所有音频/DSP 设置和偏好重置为默认值喵。继续吗喵？",
       "success": "设置已恢复为默认值喵~",
-      "failed": "恢复设置失败喵~"
+      "failed": "恢复设置失败喵~",
+      "autostartFailed": "设置已恢复喵，但未能关掉开机自启喵~"
     },
     "restoreTheme": {
       "label": "恢复默认主题喵~",
@@ -296,7 +297,8 @@
       "title": "恢复默认主题喵？",
       "confirmDesc": "这会把主题颜色、模式和自定义 CSS 重置为默认值喵。继续吗喵？",
       "success": "主题已恢复为默认值喵~",
-      "failed": "恢复主题失败喵~"
+      "failed": "恢复主题失败喵~",
+      "partialSuccess": "主题已恢复喵，但未能移除已装主题包喵~"
     }
   },
   "dialogs": {

--- a/tauri-app/src/shared/locales/cat.json
+++ b/tauri-app/src/shared/locales/cat.json
@@ -279,12 +279,31 @@
       "cliRunning": "CLI 模式正在运行喵 (PID {pid})，请先在终端里停掉喵~",
       "tuiRunningShort": "TUI 运行中喵~",
       "tuiRunning": "TUI 模式正在运行喵 (PID {pid})，请先在终端里停掉喵~"
+    },
+    "restoreDefaults": {
+      "label": "恢复默认设置喵~",
+      "desc": "把音频、DSP 和偏好重置为默认值喵~",
+      "button": "恢复默认喵~",
+      "title": "恢复默认设置喵？",
+      "confirmDesc": "这会把所有音频/DSP 设置和偏好重置为默认值喵。继续吗喵？",
+      "success": "设置已恢复为默认值喵~",
+      "failed": "恢复设置失败喵~"
+    },
+    "restoreTheme": {
+      "label": "恢复默认主题喵~",
+      "desc": "把主题颜色、模式和自定义重置为默认值喵~",
+      "button": "恢复默认喵~",
+      "title": "恢复默认主题喵？",
+      "confirmDesc": "这会把主题颜色、模式和自定义 CSS 重置为默认值喵。继续吗喵？",
+      "success": "主题已恢复为默认值喵~",
+      "failed": "恢复主题失败喵~"
     }
   },
   "dialogs": {
     "close": "关闭喵~",
     "cancel": "取消喵~",
     "apply": "应用喵~",
+    "confirm": "确认喵~",
     "contributors": {
       "title": "贡献者喵~ 💖",
       "loading": "正在加载贡献者喵... (・_・)",

--- a/tauri-app/src/shared/locales/en.json
+++ b/tauri-app/src/shared/locales/en.json
@@ -281,12 +281,31 @@
       "cliRunning": "CLI mode is running (PID {pid}) - stop it in the terminal before switching",
       "tuiRunningShort": "TUI running",
       "tuiRunning": "TUI mode is running (PID {pid}) - stop it in the terminal before switching"
+    },
+    "restoreDefaults": {
+      "label": "Restore default settings",
+      "desc": "Reset audio, DSP and preferences to their defaults",
+      "button": "Restore defaults",
+      "title": "Restore default settings?",
+      "confirmDesc": "This will reset all audio/DSP settings and preferences to defaults. Continue?",
+      "success": "Settings restored to defaults",
+      "failed": "Failed to restore settings"
+    },
+    "restoreTheme": {
+      "label": "Restore default theme",
+      "desc": "Reset theme color, mode and customizations to defaults",
+      "button": "Restore defaults",
+      "title": "Restore default theme?",
+      "confirmDesc": "This will reset theme color, mode and custom CSS to defaults. Continue?",
+      "success": "Theme restored to defaults",
+      "failed": "Failed to restore theme"
     }
   },
   "dialogs": {
     "close": "Close",
     "cancel": "Cancel",
     "apply": "Apply",
+    "confirm": "Confirm",
     "contributors": {
       "title": "Contributors",
       "loading": "Loading contributors...",

--- a/tauri-app/src/shared/locales/en.json
+++ b/tauri-app/src/shared/locales/en.json
@@ -289,7 +289,8 @@
       "title": "Restore default settings?",
       "confirmDesc": "This will reset all audio/DSP settings and preferences to defaults. Continue?",
       "success": "Settings restored to defaults",
-      "failed": "Failed to restore settings"
+      "failed": "Failed to restore settings",
+      "autostartFailed": "Settings restored, but failed to disable autostart"
     },
     "restoreTheme": {
       "label": "Restore default theme",
@@ -298,7 +299,8 @@
       "title": "Restore default theme?",
       "confirmDesc": "This will reset theme color, mode and custom CSS to defaults. Continue?",
       "success": "Theme restored to defaults",
-      "failed": "Failed to restore theme"
+      "failed": "Failed to restore theme",
+      "partialSuccess": "Theme restored, but failed to remove installed theme package"
     }
   },
   "dialogs": {

--- a/tauri-app/src/shared/locales/lzh.json
+++ b/tauri-app/src/shared/locales/lzh.json
@@ -287,7 +287,8 @@
       "title": "复默认之设乎？",
       "confirmDesc": "音频、DSP 及偏好将尽归默认。可乎？",
       "success": "设已复默认",
-      "failed": "复设未成"
+      "failed": "复设未成",
+      "autostartFailed": "设虽复，然开机自启未止"
     },
     "restoreTheme": {
       "label": "复默认之题",
@@ -296,7 +297,8 @@
       "title": "复默认之题乎？",
       "confirmDesc": "题色、模式及自定 CSS 将尽归默认。可乎？",
       "success": "题已复默认",
-      "failed": "复题未成"
+      "failed": "复题未成",
+      "partialSuccess": "题虽复，然旧题包未除"
     }
   },
   "dialogs": {

--- a/tauri-app/src/shared/locales/lzh.json
+++ b/tauri-app/src/shared/locales/lzh.json
@@ -279,12 +279,31 @@
       "cliRunning": "CLI 模式运行中 (PID {pid})，先于终端止之",
       "tuiRunningShort": "TUI 运行中",
       "tuiRunning": "TUI 模式运行中 (PID {pid})，先于终端止之"
+    },
+    "restoreDefaults": {
+      "label": "复默认之设",
+      "desc": "音频、DSP 及偏好皆归于默认",
+      "button": "复默认",
+      "title": "复默认之设乎？",
+      "confirmDesc": "音频、DSP 及偏好将尽归默认。可乎？",
+      "success": "设已复默认",
+      "failed": "复设未成"
+    },
+    "restoreTheme": {
+      "label": "复默认之题",
+      "desc": "题色、模式及自定皆归于默认",
+      "button": "复默认",
+      "title": "复默认之题乎？",
+      "confirmDesc": "题色、模式及自定 CSS 将尽归默认。可乎？",
+      "success": "题已复默认",
+      "failed": "复题未成"
     }
   },
   "dialogs": {
     "close": "闭",
     "cancel": "止",
     "apply": "用",
+    "confirm": "可",
     "contributors": {
       "title": "贡献者",
       "loading": "载贡献者中...",

--- a/tauri-app/src/shared/locales/zh-hk.json
+++ b/tauri-app/src/shared/locales/zh-hk.json
@@ -279,12 +279,31 @@
       "cliRunning": "CLI 模式正在運行 (PID {pid})，請喺終端機入面停止佢先",
       "tuiRunningShort": "TUI 運行中",
       "tuiRunning": "TUI 模式正在運行 (PID {pid})，請喺終端機入面停止佢先"
+    },
+    "restoreDefaults": {
+      "label": "還原預設設定",
+      "desc": "將音訊、DSP 同偏好設定重置為預設值",
+      "button": "還原預設",
+      "title": "還原預設設定？",
+      "confirmDesc": "咁會將所有音訊/DSP 設定同偏好重置為預設值。要繼續嗎？",
+      "success": "設定已還原為預設值",
+      "failed": "還原設定失敗"
+    },
+    "restoreTheme": {
+      "label": "還原預設主題",
+      "desc": "將主題色、模式同自訂重置為預設值",
+      "button": "還原預設",
+      "title": "還原預設主題？",
+      "confirmDesc": "咁會將主題色、模式同自訂 CSS 重置為預設值。要繼續嗎？",
+      "success": "主題已還原為預設值",
+      "failed": "還原主題失敗"
     }
   },
   "dialogs": {
     "close": "關閉",
     "cancel": "取消",
     "apply": "套用",
+    "confirm": "確認",
     "contributors": {
       "title": "貢獻者",
       "loading": "載入緊貢獻者...",

--- a/tauri-app/src/shared/locales/zh-hk.json
+++ b/tauri-app/src/shared/locales/zh-hk.json
@@ -287,7 +287,8 @@
       "title": "還原預設設定？",
       "confirmDesc": "咁會將所有音訊/DSP 設定同偏好重置為預設值。要繼續嗎？",
       "success": "設定已還原為預設值",
-      "failed": "還原設定失敗"
+      "failed": "還原設定失敗",
+      "autostartFailed": "設定已還原，但未能關閉開機自啟"
     },
     "restoreTheme": {
       "label": "還原預設主題",
@@ -296,7 +297,8 @@
       "title": "還原預設主題？",
       "confirmDesc": "咁會將主題色、模式同自訂 CSS 重置為預設值。要繼續嗎？",
       "success": "主題已還原為預設值",
-      "failed": "還原主題失敗"
+      "failed": "還原主題失敗",
+      "partialSuccess": "主題已還原，但未能移除已安裝主題包"
     }
   },
   "dialogs": {

--- a/tauri-app/src/shared/locales/zh-ss.json
+++ b/tauri-app/src/shared/locales/zh-ss.json
@@ -287,7 +287,8 @@
       "title": "恢复默认设置项？",
       "confirmDesc": "这会把所有音频/DSP 设置们和偏好重置为默认值项。继续吗项？",
       "success": "设置们已恢复为默认值项",
-      "failed": "恢复设置失败项"
+      "failed": "恢复设置失败项",
+      "autostartFailed": "设置们已恢复项，但未能关闭开机自启项"
     },
     "restoreTheme": {
       "label": "恢复默认主题项",
@@ -296,7 +297,8 @@
       "title": "恢复默认主题项？",
       "confirmDesc": "这会把主题颜色、模式和自定义 CSS 们重置为默认值项。继续吗项？",
       "success": "主题们已恢复为默认值项",
-      "failed": "恢复主题失败项"
+      "failed": "恢复主题失败项",
+      "partialSuccess": "主题们已恢复项，但未能移除已安装主题包项"
     }
   },
   "dialogs": {

--- a/tauri-app/src/shared/locales/zh-ss.json
+++ b/tauri-app/src/shared/locales/zh-ss.json
@@ -279,12 +279,31 @@
       "cliRunning": "CLI 模式正在运行项 (PID {pid})，请在终端中停止后再切换",
       "tuiRunningShort": "TUI 运行中项",
       "tuiRunning": "TUI 模式正在运行项 (PID {pid})，请在终端中停止后再切换"
+    },
+    "restoreDefaults": {
+      "label": "恢复默认设置项",
+      "desc": "把音频、DSP 和偏好们重置为默认值项",
+      "button": "恢复默认项",
+      "title": "恢复默认设置项？",
+      "confirmDesc": "这会把所有音频/DSP 设置们和偏好重置为默认值项。继续吗项？",
+      "success": "设置们已恢复为默认值项",
+      "failed": "恢复设置失败项"
+    },
+    "restoreTheme": {
+      "label": "恢复默认主题项",
+      "desc": "把主题颜色、模式和自定义们重置为默认值项",
+      "button": "恢复默认项",
+      "title": "恢复默认主题项？",
+      "confirmDesc": "这会把主题颜色、模式和自定义 CSS 们重置为默认值项。继续吗项？",
+      "success": "主题们已恢复为默认值项",
+      "failed": "恢复主题失败项"
     }
   },
   "dialogs": {
     "close": "合起来",
     "cancel": "取消",
     "apply": "应用",
+    "confirm": "确认项",
     "contributors": {
       "title": "贡献者们们",
       "loading": "正在加载贡献者...",

--- a/tauri-app/src/shared/locales/zh-tw.json
+++ b/tauri-app/src/shared/locales/zh-tw.json
@@ -279,12 +279,31 @@
       "cliRunning": "CLI 模式正在執行 (PID {pid})，請先在終端機中停止",
       "tuiRunningShort": "TUI 執行中",
       "tuiRunning": "TUI 模式正在執行 (PID {pid})，請先在終端機中停止"
+    },
+    "restoreDefaults": {
+      "label": "還原預設設定",
+      "desc": "將音訊、DSP 及偏好設定重置為預設值",
+      "button": "還原預設",
+      "title": "還原預設設定？",
+      "confirmDesc": "這將把所有音訊/DSP 設定和偏好重置為預設值。是否繼續？",
+      "success": "設定已還原為預設值",
+      "failed": "還原設定失敗"
+    },
+    "restoreTheme": {
+      "label": "還原預設主題",
+      "desc": "將主題色彩、模式及自訂重置為預設值",
+      "button": "還原預設",
+      "title": "還原預設主題？",
+      "confirmDesc": "這將把主題色彩、模式和自訂 CSS 重置為預設值。是否繼續？",
+      "success": "主題已還原為預設值",
+      "failed": "還原主題失敗"
     }
   },
   "dialogs": {
     "close": "關閉",
     "cancel": "取消",
     "apply": "套用",
+    "confirm": "確認",
     "contributors": {
       "title": "貢獻者",
       "loading": "正在載入貢獻者...",

--- a/tauri-app/src/shared/locales/zh-tw.json
+++ b/tauri-app/src/shared/locales/zh-tw.json
@@ -287,7 +287,8 @@
       "title": "還原預設設定？",
       "confirmDesc": "這將把所有音訊/DSP 設定和偏好重置為預設值。是否繼續？",
       "success": "設定已還原為預設值",
-      "failed": "還原設定失敗"
+      "failed": "還原設定失敗",
+      "autostartFailed": "設定已還原，但未能關閉開機自啟"
     },
     "restoreTheme": {
       "label": "還原預設主題",
@@ -296,7 +297,8 @@
       "title": "還原預設主題？",
       "confirmDesc": "這將把主題色彩、模式和自訂 CSS 重置為預設值。是否繼續？",
       "success": "主題已還原為預設值",
-      "failed": "還原主題失敗"
+      "failed": "還原主題失敗",
+      "partialSuccess": "主題已還原，但未能移除已安裝主題包"
     }
   },
   "dialogs": {

--- a/tauri-app/src/shared/locales/zh.json
+++ b/tauri-app/src/shared/locales/zh.json
@@ -289,7 +289,8 @@
       "title": "恢复默认设置？",
       "confirmDesc": "这将把所有音频/DSP 设置和偏好重置为默认值。是否继续？",
       "success": "设置已恢复为默认值",
-      "failed": "恢复设置失败"
+      "failed": "恢复设置失败",
+      "autostartFailed": "设置已恢复，但未能关闭开机自启"
     },
     "restoreTheme": {
       "label": "恢复默认主题",
@@ -298,7 +299,8 @@
       "title": "恢复默认主题？",
       "confirmDesc": "这将把主题颜色、模式和自定义 CSS 重置为默认值。是否继续？",
       "success": "主题已恢复为默认值",
-      "failed": "恢复主题失败"
+      "failed": "恢复主题失败",
+      "partialSuccess": "主题已恢复，但未能移除已安装主题包"
     }
   },
   "dialogs": {

--- a/tauri-app/src/shared/locales/zh.json
+++ b/tauri-app/src/shared/locales/zh.json
@@ -281,12 +281,31 @@
       "cliRunning": "CLI 模式正在运行 (PID {pid})，请在终端中停止后再切换",
       "tuiRunningShort": "TUI 运行中",
       "tuiRunning": "TUI 模式正在运行 (PID {pid})，请在终端中停止后再切换"
+    },
+    "restoreDefaults": {
+      "label": "恢复默认设置",
+      "desc": "将音频、DSP 及偏好设置重置为默认值",
+      "button": "恢复默认",
+      "title": "恢复默认设置？",
+      "confirmDesc": "这将把所有音频/DSP 设置和偏好重置为默认值。是否继续？",
+      "success": "设置已恢复为默认值",
+      "failed": "恢复设置失败"
+    },
+    "restoreTheme": {
+      "label": "恢复默认主题",
+      "desc": "将主题颜色、模式及自定义重置为默认值",
+      "button": "恢复默认",
+      "title": "恢复默认主题？",
+      "confirmDesc": "这将把主题颜色、模式和自定义 CSS 重置为默认值。是否继续？",
+      "success": "主题已恢复为默认值",
+      "failed": "恢复主题失败"
     }
   },
   "dialogs": {
     "close": "关闭",
     "cancel": "取消",
     "apply": "应用",
+    "confirm": "确认",
     "contributors": {
       "title": "贡献者",
       "loading": "正在加载贡献者...",


### PR DESCRIPTION

https://github.com/user-attachments/assets/a93f9d9c-089d-4049-9d67-d53f22f7fc80

起因是自己的强迫症（
之前使用时总是会调整了功能但是又忘记默认值了，所以想着加个重置设置的按钮

变更：

将设置的默认值拉出来合并到一处`DEFAULT_THEME`和`DEFAULT_AUDIO_SETTINGS`里
然后对音频设置以及主题设置分别添加重置按钮

`恢复默认设置`会将“语言、外观以及连接配置”以外的内容重置，即调整Reactive Settings State的内容，界面语言（`ui.json`）和连接配置（`server.json` 的端口/模式/监听地址）重置时保持原样不变。

`恢复默认主题`会将外观相关内容重置

仅在Windows上测试，未对mac、linux测试