### PR TITLE
fix: resolve notify interception caused by Windows notification mechanism

### DIFF
--- a/tauri-app/src-tauri/installer.iss
+++ b/tauri-app/src-tauri/installer.iss
@@ -41,8 +41,8 @@ Source: "binaries\micyou-cli-x86_64-pc-windows-msvc.exe"; DestDir: "{app}"; Dest
 Source: "binaries\micyou-tui-x86_64-pc-windows-msvc.exe"; DestDir: "{app}"; DestName: "micyou-tui.exe"; Flags: ignoreversion
 
 [Icons]
-Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; AppUserModelID: "com.lanrhyme.micyou"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon; AppUserModelID: "com.lanrhyme.micyou"
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
#### 📌 Context / Problem
On Windows 10/11, non-packaged desktop applications (standard `.exe` files) require an explicit `AppUserModelID` (AUMID) to be associated with their shortcuts. Without this property, the Windows OS silently discards any Toast notifications sent by the application. 

Previously, the Inno Setup installer (`installer.iss`) did not set this property, causing the installed version of MicYou to fail to trigger system notifications when launched via the created shortcuts.

#### 🛠️ Changes Made
Added the `AppUserModelID: "com.lanrhyme.micyou"` property to the shortcut definitions in the `[Icons]` section of `src-tauri/installer.iss`. This value matches the `identifier` defined in `tauri.conf.json`.

**Modified lines in `installer.iss`:**
```ini
[Icons]
; Added AppUserModelID to enable Windows Toast notifications for non-packaged apps
Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; AppUserModelID: "com.lanrhyme.micyou"
Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon; AppUserModelID: "com.lanrhyme.micyou"
```