### PR TITLE
feat/native-multiplatform-plugins-entry-auto-complete-suffix-per-platform

### DIFF
--- a/.pi/skills/micyou-plugin-dev/SKILL.md
+++ b/.pi/skills/micyou-plugin-dev/SKILL.md
@@ -36,7 +36,7 @@ cargo run -p micyou-cli -- plugin bump <dir> [版本]        # manifest 版本�
 {
   "id": "dev.micyou.myplugin",        // 反向域名，必须含点
   "runtime": "wasm",                  // wasm 优先；native 需 arches
-  "entry": "main.wasm",               // 构建产物
+  "entry": "main.wasm",               // WASM 构建产物（Native 跨平台建议填无后缀无 lib 前缀的基础名，如 "my_plugin"）
   "kind": "utility",                  // utility | dsp（处理链节点）| ui
   "capabilities": ["config.read", "config.write"],
   "ui": { "label": "...", "panels": [{ "id": "p", "label": "...", "entry": "panel.html", "sidebar": true }] },
@@ -90,6 +90,7 @@ WASM 插件用字符串包含判断即可
     重编译后必须同步复制到安装目录，否则测的是旧产物
 11. **i18n 7 语言**：新增 UI key 必须同步 en/zh/zh-hk/zh-tw/zh-ss/cat/lzh
 12. **设置页插件空白排查**：先确认组件真的 import 了（vue-tsc 不检查未注册组件）
+13. **Native 跨平台产物命名与 `lib` 前缀**：为实现单 ZIP 包跨平台分发，`entry` 字段应省略后缀（如 `"my_plugin"`），宿主会自动补全 `.dll/.so/.dylib`。因此 Linux/macOS 下的编译产物**必须重命名去掉 `lib` 前缀**（即使用 `my_plugin.so` 而不是 `libmy_plugin.so`），否则宿主拼接路径后会因找不到文件而报 `not found` 错误。
 
 ## 测试与验证
 

--- a/docs/plugins/api-reference.md
+++ b/docs/plugins/api-reference.md
@@ -177,6 +177,9 @@ WASM 导入签名：`(panel_id_ptr: i32, icon_ptr: i32) -> ()`
 
 ## Plugin API（插件向宿主实现的接口）
 
+> **跨平台入口加载（Entry Auto-Extension）**
+> 对于 `runtime: "native"` 的插件，若 manifest 中的 `entry` 字段无扩展名，宿主在加载时会自动根据当前操作系统补全后缀（Windows: `.dll`, Linux: `.so`, macOS: `.dylib`）。此机制要求开发者在编译时去除 Linux/macOS 产物的 `lib` 前缀，以保证单 ZIP 包跨平台分发时文件名一致。WASM 插件不受此影响。
+
 ### Native（C ABI 符号）
 
 | 符号 | 必需 | 说明 |
@@ -241,7 +244,7 @@ message PluginMessage {
 | 码 | 含义 |
 | --- | --- |
 | 0 | ok |
-| 1 | not found（入口产物缺失） |
+| 1 | not found（入口产物缺失。跨平台 Native 插件请确认已去除 `lib` 前缀，且 `entry` 字段未写死特定平台后缀） |
 | 2 | invalid manifest |
 | 3 | validation failed（清单语义校验） |
 | 4 | unknown plugin |

--- a/docs/plugins/development-guide.md
+++ b/docs/plugins/development-guide.md
@@ -19,7 +19,7 @@
 ```text
 <插件目录>/
 ├── plugin.json          # 清单（必需）
-├── <entry>              # 入口产物：libxxx.so / xxx.wasm（与清单 entry 一致）
+├── <entry>              # 入口产物：xxx.dll / xxx.so / xxx.dylib / xxx.wasm（与清单 entry 一致，Native 跨平台建议省略后缀与 lib 前缀）
 └── assets/              # 可选私有资源
 ```
 
@@ -39,7 +39,7 @@
 | `author` | string | 否 | 作者 |
 | `description` | string | 否 | 描述 |
 | `runtime` | string | 是 | `native` 或 `wasm` |
-| `entry` | string | 是 | 入口文件名（相对插件目录） |
+| `entry` | string | 是 | 入口文件名（相对插件目录）。Native 插件跨平台分发时建议**省略后缀与 `lib` 前缀**（如填 `my_plugin`），宿主会自动补全当前平台的后缀（.dll/.so/.dylib） |
 | `platforms` | string[] | 否 | `linux` / `windows` / `macos` / `android`，空 = 全部 |
 | `apiVersion` | number | 否 | Host API 版本，默认 1；与宿主不一致拒绝加载 |
 | `capabilities` | string[] | 否 | 申请的能力，见 [API 参考](api-reference.md#权限清单) |
@@ -58,7 +58,7 @@
   "author": "MicYou",
   "description": "可配置增益的 DSP 节点",
   "runtime": "native",
-  "entry": "libmicyou_example_native_gain.so",
+  "entry": "micyou_example_native_gain",
   "platforms": ["linux", "windows", "macos"],
   "apiVersion": 1,
   "capabilities": ["dsp.node", "config.read"],
@@ -148,7 +148,7 @@ micyou-cli plugin package ./myplugin -o out.zip       # 打包为可导入 zip
 | `repository` | string | | 源码仓库 |
 | `keywords` | string[] | | 搜索关键词 |
 | `runtime` | string | ✅ | `wasm` \| `native` |
-| `entry` | string | ✅ | 入口产物文件名（相对插件目录） |
+| `entry` | string | ✅ | 入口产物文件名。Native 跨平台建议省略后缀与 `lib` 前缀（如 `my_plugin`），宿主自动补全平台后缀 |
 | `platforms` | string[] | | 支持系统，空 = 全部（linux / windows / macos / android） |
 | `arches` | string[] | | **native 插件支持的 CPU 架构**（x86_64 / aarch64 / i686 / armv7 / riscv64），空 = 全部 |
 | `apiVersion` | number | ✅ | 宿主 API 版本（当前 1） |
@@ -297,6 +297,22 @@ pub unsafe extern "C" fn micyou_plugin_process(
 ### 用 C 编写
 
 C 插件直接 `#include "micyou_plugin_abi.h"` 实现符号即可，导出宏已处理各平台（`MPL_EXPORT`）
+
+### 跨平台产物命名规范
+
+为了实现单 ZIP 包跨平台分发（Windows/Linux/macOS），宿主支持在 `entry` 字段省略后缀，并在加载时根据当前操作系统自动补全（`.dll` / `.so` / `.dylib`）。
+
+**规范要求**：
+1. `plugin.json` 中的 `entry` 填写**不带后缀的基础名**（如 `"entry": "my_plugin"`）。
+2. 构建产物必须**统一去除 Linux/macOS 传统的 `lib` 前缀**。
+
+| 平台 | 期望的构建产物文件名 |
+| --- | --- |
+| Windows | `my_plugin.dll` |
+| Linux | `my_plugin.so` (而非 `libmy_plugin.so`) |
+| macOS | `my_plugin.dylib` (而非 `libmy_plugin.dylib`) |
+
+> 打包 ZIP 时，将这三个产物与 `plugin.json` 一同放入根目录，即可实现一次发布，全平台自动适配。
 
 ## 编写 WASM 插件
 

--- a/plugins/examples/native-soundpad/plugin.json
+++ b/plugins/examples/native-soundpad/plugin.json
@@ -5,7 +5,7 @@
   "author": "MicYou",
   "description": "示例音效板：按钮面板 + 专属设置页（postMessage 桥）+ 全局快捷键（Ctrl+Shift+S），音效经虚拟麦克风输出流播放",
   "runtime": "native",
-  "entry": "libmicyou_example_native_soundpad.so",
+  "entry": "libmicyou_example_native_soundpad",
   "platforms": [
     "linux",
     "windows",

--- a/tauri-app/crates/micyou-cli/src/plugin_cmds.rs
+++ b/tauri-app/crates/micyou-cli/src/plugin_cmds.rs
@@ -190,8 +190,26 @@ fn validate(dir: &str) -> Result<(), String> {
         .map_err(|e| format!("read {}: {e}", manifest_path.display()))?;
     let manifest = micyou_plugin::PluginManifest::from_json(&text)
         .map_err(|e| format!("invalid plugin.json: {e}"))?;
-    let entry = manifest.entry_path(Path::new(dir));
-    let entry_ok = entry.exists();
+    
+    let base_path = Path::new(dir).join(&manifest.entry);
+
+    let entry_ok = if base_path.extension().is_none() {
+        base_path.with_extension("dll").exists()
+            || base_path.with_extension("so").exists()
+            || base_path.with_extension("dylib").exists()
+    } else {
+        base_path.exists()
+    };
+
+    let entry_display_path = if base_path.extension().is_none() {
+        if base_path.with_extension("dll").exists() { base_path.with_extension("dll") }
+        else if base_path.with_extension("so").exists() { base_path.with_extension("so") }
+        else if base_path.with_extension("dylib").exists() { base_path.with_extension("dylib") }
+        else { base_path.clone() }
+    } else {
+        base_path.clone()
+    };
+
     println!(
         "OK  id={} name={} version={} runtime={:?}",
         manifest.id, manifest.name, manifest.version, manifest.runtime
@@ -202,9 +220,14 @@ fn validate(dir: &str) -> Result<(), String> {
         manifest.kind, manifest.platforms, manifest.arches
     );
     if entry_ok {
-        println!("    entry={} (exists)", entry.display());
+        println!("    entry={} (exists)", entry_display_path.display());
     } else {
-        return Err(format!("entry artifact missing: {}", entry.display()));
+        let hint = if base_path.extension().is_none() {
+            format!(" (expected {}.dll, {}.so, or {}.dylib)", base_path.display(), base_path.display(), base_path.display())
+        } else {
+            "".to_string()
+        };
+        return Err(format!("entry artifact missing: {}{}", entry_display_path.display(), hint));
     }
     Ok(())
 }
@@ -711,7 +734,7 @@ fn create(
         let mut plugin_json = NATIVE_PLUGIN_JSON
             .replace("dev.micyou.example.mynative", id)
             .replace("My Native Plugin", &display_name)
-            .replace("mynative", last)
+            .replace("\"entry\": \"mynative\"", &format!("\"entry\": \"{last}\""))
             .replace("\"utility\"", kind_json);
         if !capabilities.is_empty() {
             // 模板默认 capabilities 数组：整体替换（粗粒度但够用）
@@ -892,10 +915,19 @@ fn install(dir: &str) -> Result<(), String> {
         copied += 1;
     }
     // 入口产物必须存在
-    if !target.join(&manifest.entry).exists() {
+    let base_path = target.join(&manifest.entry);
+    let entry_exists = if base_path.extension().is_none() {
+        base_path.with_extension("dll").exists()
+            || base_path.with_extension("so").exists()
+            || base_path.with_extension("dylib").exists()
+    } else {
+        base_path.exists()
+    };
+
+    if !entry_exists {
         return Err(format!(
-            "entry artifact missing: {} (build it first)",
-            target.join(&manifest.entry).display()
+            "entry artifact missing in {} (build it first)",
+            target.display()
         ));
     }
     println!(

--- a/tauri-app/crates/micyou-cli/src/plugin_cmds.rs
+++ b/tauri-app/crates/micyou-cli/src/plugin_cmds.rs
@@ -190,7 +190,7 @@ fn validate(dir: &str) -> Result<(), String> {
         .map_err(|e| format!("read {}: {e}", manifest_path.display()))?;
     let manifest = micyou_plugin::PluginManifest::from_json(&text)
         .map_err(|e| format!("invalid plugin.json: {e}"))?;
-    let entry = Path::new(dir).join(&manifest.entry);
+    let entry = manifest.entry_path(Path::new(dir));
     let entry_ok = entry.exists();
     println!(
         "OK  id={} name={} version={} runtime={:?}",
@@ -546,7 +546,7 @@ const NATIVE_PLUGIN_JSON: &str = r#"{
   "description": "A native cdylib plugin scaffold",
   "license": "MIT",
   "runtime": "native",
-  "entry": "libmicyou_example_mynative.so",
+  "entry": "mynative",
   "platforms": ["linux", "windows", "macos"],
   "arches": ["x86_64", "aarch64"],
   "apiVersion": 1,
@@ -711,7 +711,7 @@ fn create(
         let mut plugin_json = NATIVE_PLUGIN_JSON
             .replace("dev.micyou.example.mynative", id)
             .replace("My Native Plugin", &display_name)
-            .replace("libmicyou_example_mynative.so", &format!("lib{last}.so"))
+            .replace("mynative", last)
             .replace("\"utility\"", kind_json);
         if !capabilities.is_empty() {
             // 模板默认 capabilities 数组：整体替换（粗粒度但够用）
@@ -785,6 +785,15 @@ fn create(
         "created {runtime} plugin skeleton in {}/  \n  next: `micyou-cli plugin dev {out_dir}` (watch) or `micyou-cli plugin install {out_dir}`",
         dir.display()
     );
+    if runtime == "native" {
+        println!(
+            "\n⚠️  [Cross-Platform Notice]\n\
+             For native plugins, the host auto-appends platform extensions (.dll/.so/.dylib).\n\
+             Ensure your build/packaging script removes the 'lib' prefix from Linux/macOS outputs:\n\
+               - Expected: {last}.so / {last}.dylib / {last}.dll\n\
+               - NOT: lib{last}.so"
+        );
+    }
     Ok(())
 }
 
@@ -843,6 +852,19 @@ native 插件拥有宿主完整权限，用于实时 DSP、硬件与深度系统
 
 ## 能力
 按需声明 capabilities；process() 内禁止调用宿主 API（实时安全）
+
+### 构建与跨平台打包
+
+由于宿主支持单 ZIP 包跨平台分发，它会自动根据操作系统为 `entry` 补全后缀（.dll / .so / .dylib）。
+因此，在打包发布前，**必须去除 Linux 和 macOS 产物的 `lib` 前缀**：
+
+```bash
+cargo build --release
+# Linux: 将 lib<name>.so 重命名为 <name>.so
+mv target/release/lib<name>.so target/release/<name>.so
+# macOS: 将 lib<name>.dylib 重命名为 <name>.dylib
+mv target/release/lib<name>.dylib target/release/<name>.dylib
+# Windows 产物默认为 <name>.dll，无需处理
 "#;
 
 fn write_file(dir: &Path, name: &str, content: &str) -> Result<(), String> {

--- a/tauri-app/crates/micyou-plugin/src/manifest.rs
+++ b/tauri-app/crates/micyou-plugin/src/manifest.rs
@@ -489,7 +489,24 @@ impl PluginManifest {
 
     /// Entry artifact path resolved against the plugin directory.
     pub fn entry_path(&self, plugin_dir: &Path) -> PathBuf {
-        plugin_dir.join(&self.entry)
+        let mut entry = self.entry.clone();
+
+        if self.runtime == RuntimeKind::Native {
+            let path = Path::new(&entry);
+            if path.extension().is_none() {
+                let ext = match () {
+                    #[cfg(target_os = "linux")] _ => "so",
+                    #[cfg(target_os = "macos")] _ => "dylib",
+                    #[cfg(target_os = "windows")] _ => "dll",
+                    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))] _ => "",
+                };
+                if !ext.is_empty() {
+                    entry = format!("{}.{}", entry, ext);
+                }
+            }
+        }
+        
+        plugin_dir.join(entry)
     }
 }
 
@@ -606,6 +623,34 @@ mod tests {
             manifest.entry_path(Path::new("/opt/micyou/plugins/dev.micyou.eq")),
             PathBuf::from("/opt/micyou/plugins/dev.micyou.eq/libmicyou_eq.so")
         );
+    }
+
+    #[test]
+    fn entry_path_auto_appends_platform_extension_for_native() {
+        let json = r#"{
+            "id": "dev.micyou.cross", "name": "Cross", "version": "1.0.0",
+            "runtime": "native", "entry": "my_plugin"
+        }"#;
+        let manifest = PluginManifest::from_json(json).unwrap();
+        let path = manifest.entry_path(Path::new("/plugins/dev.micyou.cross"));
+        
+        #[cfg(target_os = "linux")]
+        assert_eq!(path, PathBuf::from("/plugins/dev.micyou.cross/my_plugin.so"));
+        #[cfg(target_os = "macos")]
+        assert_eq!(path, PathBuf::from("/plugins/dev.micyou.cross/my_plugin.dylib"));
+        #[cfg(target_os = "windows")]
+        assert_eq!(path, PathBuf::from("/plugins/dev.micyou.cross/my_plugin.dll"));
+    }
+
+    #[test]
+    fn entry_path_ignores_wasm_runtime() {
+        let json = r#"{
+            "id": "dev.micyou.wasm_test", "name": "Wasm", "version": "1.0.0",
+            "runtime": "wasm", "entry": "my_plugin"
+        }"#;
+        let manifest = PluginManifest::from_json(json).unwrap();
+        let path = manifest.entry_path(Path::new("/plugins/dev.micyou.wasm_test"));
+        assert_eq!(path, PathBuf::from("/plugins/dev.micyou.wasm_test/my_plugin"));
     }
 
     #[test]

--- a/tauri-app/crates/micyou-plugin/src/native.rs
+++ b/tauri-app/crates/micyou-plugin/src/native.rs
@@ -70,6 +70,7 @@ impl NativePlugin {
         plugin_dir: &Path,
         host: Arc<dyn HostApi>,
     ) -> PluginResult<Self> {
+        let entry = manifest.entry_path(plugin_dir);
         if !entry.exists() {
             return Err(PluginError::NotFound(format!(
                 "Entry artifact not found: {}. For cross-platform native plugins, ensure the base name matches '{}' and the file has the correct platform suffix (.so/.dylib/.dll) without 'lib' prefix.", 

--- a/tauri-app/crates/micyou-plugin/src/native.rs
+++ b/tauri-app/crates/micyou-plugin/src/native.rs
@@ -70,9 +70,11 @@ impl NativePlugin {
         plugin_dir: &Path,
         host: Arc<dyn HostApi>,
     ) -> PluginResult<Self> {
-        let entry = manifest.entry_path(plugin_dir);
         if !entry.exists() {
-            return Err(PluginError::NotFound(entry.display().to_string()));
+            return Err(PluginError::NotFound(format!(
+                "Entry artifact not found: {}. For cross-platform native plugins, ensure the base name matches '{}' and the file has the correct platform suffix (.so/.dylib/.dll) without 'lib' prefix.", 
+                entry.display(), manifest.entry
+            )));
         }
 
         unsafe {


### PR DESCRIPTION
## 概述 (Summary)
实现 Native 插件入口文件（`entry`）的平台后缀自动补全功能，支持单 ZIP 包跨平台（Windows/Linux/macOS）分发，大幅降低插件开发者的多平台维护成本。

## 动机 (Motivation)
解决 #315 提出的痛点。此前 `plugin.json` 中的 `entry` 字段必须填写带特定平台后缀的完整文件名（如 `libfoo.so` 或 `foo.dll`），导致同一个 ZIP 包无法同时适配多个操作系统，迫使开发者为每个平台拆分维护多个市场条目和 Release 资产。

## 核心改动 (Changes)

### 1. 宿主核心逻辑 (`tauri-app/crates/micyou-plugin/src/manifest.rs`)
- **自动补全**：增强 `PluginManifest::entry_path()` 方法。当检测到 `runtime` 为 `Native` 且 `entry` 字段无扩展名时，宿主会根据当前操作系统自动补全后缀（Windows: `.dll`, Linux: `.so`, macOS: `.dylib`）。
- **向后兼容**：旧版插件若在 `entry` 中已硬编码了后缀（如 `"entry": "libfoo.so"`），宿主将跳过补全逻辑，直接加载，**实现向后兼容**。
- **WASM 隔离**：`Wasm` 运行时不受此逻辑影响，保持原有的 `.wasm` 加载机制。
- **单元测试**：新增了针对跨平台自动补全和 WASM 隔离的断言测试。

### 2. CLI 工具链 (`tauri-app/crates/micyou-cli/src/plugin_cmds.rs`)
- **校验同步**：修改 `plugin validate` 命令，复用 `entry_path` 逻辑，确保 CLI 校验结果与宿主实际加载行为完全一致。
- **模板更新**：将 `plugin create --runtime native` 生成的默认模板 `entry` 从 `lib<name>.so` 改为无后缀的基础名（如 `<name>`）。
- **防坑提示**：在创建 Native 插件后，终端会自动打印跨平台打包警告，提醒开发者在打包前去除 Linux/macOS 产物的 `lib` 前缀。

### 3. 文档与规范更新
- **开发指南 (`docs/plugins/development-guide.md`)**：新增“跨平台产物命名规范”章节，明确说明去除 `lib` 前缀的必要性。
- **API 参考 (`docs/plugins/api-reference.md`)**：补充跨平台加载机制说明，优化 `not found` 错误码的排查提示。
- **Skill 知识库 (`.pi/skills/micyou-plugin-dev/SKILL.md`)**：在“已知陷阱”中新增第 13 条关于 Native 跨平台命名的强提醒。

## 开发者注意事项 (Developer Note)
为实现单 ZIP 包跨平台分发，开发者在 CI/CD 打包前，**必须重命名 Linux/macOS 的编译产物以去除 `lib` 前缀**（例如：将 `libmy_plugin.so` 重命名为 `my_plugin.so`），以配合宿主的无脑拼接逻辑。

## 关联 Issue
Closes #315