### PR TITLE
feat(android): add Android 5.0+ compatibility (non-breaking, v1.1.5 KMP)

### DIFF
--- a/Android_Compatibility_Compile_Guide.md
+++ b/Android_Compatibility_Compile_Guide.md
@@ -1,0 +1,255 @@
+# Android 低版本兼容性编译说明
+
+> 适用版本：v1.1.5 / v2.0.1  
+> 目标设备：Android 5.0+ (API 21+) / 32 位设备  
+> 设计原则：**非破坏性** — 不修改原版编译逻辑，通过 Gradle 属性条件启用兼容模式
+
+---
+
+## 快速开始
+
+### 前置条件：JDK 17 安装
+
+AGP 8.x 以上需要 JDK 11+（v2.0.1 原版 AGP 9.x 需要 JDK 17+）。推荐安装 Eclipse Temurin JDK 17 LTS：
+
+下载地址：https://adoptium.net/temurin/releases/?version=17&arch=x64
+
+安装时勾选 "Set JAVA_HOME variable" 和 "Add to PATH"。安装后 Gradle 会自动使用，不影响系统已有的 Java 8。
+
+验证安装：
+```bash
+java -version
+# 应显示 openjdk version "17.x.x"
+```
+
+如需在项目级指定 JDK 路径（不影响系统环境），在 `gradle.properties` 中取消注释：
+```properties
+org.gradle.java.home=C\:\\Program Files\\Eclipse Adoptium\\jdk-17.0.20.101-hotspot
+```
+
+### 前置条件：Android SDK
+
+`local.properties` 中需指定 SDK 路径：
+```properties
+sdk.dir=D\:\\Android\\android-sdk-windows
+```
+
+需安装的 SDK 组件：
+- Platform: android-36（compileSdk 36）
+- Build Tools: 36.0.0 或更高
+
+---
+
+### 原版构建（与上游完全一致）
+
+```bash
+./gradlew :composeApp:assembleDebug
+```
+
+不加任何额外参数，编译结果、依赖版本、SDK 配置与原版完全相同。
+
+### 兼容版构建（支持 Android 5.0+）
+
+**重要：在 PowerShell 中必须给参数加引号，否则点号会被截断：**
+
+```powershell
+# PowerShell — 必须用引号
+./gradlew :composeApp:assembleDebug "-Pmicyou.androidCompat=true"
+```
+
+```bash
+# CMD / Bash — 不需要引号
+./gradlew :composeApp:assembleDebug -Pmicyou.androidCompat=true
+```
+
+输出路径：
+```
+composeApp/build/outputs/apk/debug/composeApp-debug.apk
+```
+
+---
+
+## 兼容模式做了什么
+
+启用 `-Pmicyou.androidCompat=true` 后，以下配置会自动切换到兼容版本：
+
+### v2.0.1 版本对照
+
+| 配置项 | 原版 | 兼容版 |
+|--------|------|--------|
+| AGP | 9.3.1 | 8.9.1 |
+| Kotlin | 2.4.10 | 2.1.20 |
+| minSdk | 24 (Android 7.0) | 21 (Android 5.0) |
+| targetSdk | 36 | 29 |
+| Compose BOM | 2026.05.00 | 2024.09.00 |
+| materialKolor | 5.0.0-alpha07 | 1.7.1 |
+| haze | 1.7.2 | 1.0.0 |
+| Ktor | 3.5.0 | 3.0.3 |
+| kotlinx-coroutines | 1.11.0 | 1.9.0 |
+| kotlinx-serialization | 1.11.0 | 1.7.3 |
+| kotlinx-datetime | 0.8.0 | 0.7.1 |
+| androidx.activity | 1.12.2 | 1.8.2 |
+| androidx.lifecycle | 2.9.4 | 2.8.0 |
+| androidx.core | 1.17.0 | 1.12.0 |
+| MultiDex | 关闭 | 开启 |
+| coreLibraryDesugaring | 关闭 | 开启 |
+| JVM target | 11 | 1.8 |
+| 32位 ABI | 无 | armeabi-v7a, x86 |
+| 代码混淆 (release) | 开启 | 关闭 |
+
+### v1.1.5 版本对照
+
+| 配置项 | 原版 | 兼容版 |
+|--------|------|--------|
+| minSdk | 24 (Android 7.0) | 21 (Android 5.0) |
+| targetSdk | 36 | 29 |
+| Compose Multiplatform | 1.10.1 | 1.7.3 |
+| Compose Material3 | 1.10.0-alpha05 | 1.7.3 |
+| Kotlin | 2.2.20 | 2.1.20 |
+| Ktor | 3.4.0 | 3.0.3 |
+| kotlinx-coroutines | 1.10.2 | 1.9.0 |
+| kotlinx-serialization | 1.8.1 | 1.7.3 |
+| androidx.activity | 1.12.2 | 1.8.2 |
+| androidx.lifecycle | 2.9.6 | 2.8.0 |
+| androidx.core | 1.17.0 | 1.12.0 |
+| MultiDex | 关闭 | 开启 |
+| coreLibraryDesugaring | 关闭 | 开启 |
+
+### 运行时兼容（不依赖编译开关，始终生效）
+
+- **设置 UI 格式过滤**：API < 23 时设置界面不显示 "32-bit Float" 选项，避免用户选择不支持的格式导致两端格式不匹配
+- **默认格式自动选择**：API < 23 时默认 PCM_16BIT，API >= 23 时默认 PCM_FLOAT（v2.0.1），Desktop 始终 PCM_FLOAT
+- **已保存格式校验**：从旧设备迁移的设置（如 PCM_FLOAT）在低 API 设备上自动回退到 PCM_16BIT
+- **PCM_FLOAT 降级**：API < 23 时即使通过其他方式传入 PCM_FLOAT，运行时也会降级为 PCM_16BIT
+- **TileService 守卫**：`startActivityAndCollapse` 按 API 级别分支调用
+- **全局异常处理**：`MicYouApplication` 注册 UncaughtExceptionHandler，崩溃时写入日志文件
+- **MultiDex 反射加载**：通过反射调用 `MultiDex.install()`，无依赖时优雅跳过
+
+---
+
+## 技术实现原理
+
+### 版本切换机制（v2.0.1）
+
+v2.0.1 通过 `settings.gradle.kts` 中的 `dependencyResolutionManagement.versionCatalogs` 覆盖版本号：
+
+1. 检测 `-Pmicyou.androidCompat` 命令行参数（通过 `gradle.startParameter.projectProperties`）
+2. 在 `versionCatalogs` 块中覆盖 `agp`、`kotlin` 等版本号
+3. 所有 `alias(libs.plugins.*)` 引用自动使用降级后的版本
+4. `composeApp/build.gradle.kts` 中的条件判断控制 minSdk、MultiDex、desugaring 等
+
+### 版本切换机制（v1.1.5）
+
+v1.1.5 通过 `build.gradle.kts` 中的 `resolutionStrategy` 和条件判断实现。
+
+---
+
+## 修改的文件
+
+### v2.0.1 改动文件
+
+| 文件 | 改动说明 |
+|------|----------|
+| `settings.gradle.kts` | 新增：兼容模式检测 + versionCatalogs 版本覆盖 |
+| `gradle/libs.versions.toml` | 恢复原版版本，新增 `compat-*` 系列兼容版本条目 |
+| `composeApp/build.gradle.kts` | 添加 `androidCompat` 条件判断，控制 SDK / 依赖 / MultiDex / desugaring / JVM target |
+| `composeApp/src/main/kotlin/.../MicYouApplication.kt` | MultiDex 改为反射调用，保留崩溃日志记录 |
+| `composeApp/src/main/AndroidManifest.xml` | 添加 `android:name`、`tools:ignore`、`tools:overrideLibrary` |
+| `gradle.properties` | 添加 `org.gradle.java.home` 配置说明（默认注释） |
+| `local.properties` | SDK 路径指向本地 Android SDK |
+
+### v1.1.5 改动文件
+
+| 文件 | 改动说明 |
+|------|----------|
+| `gradle/libs.versions.toml` | 恢复原版版本，新增 `compat-*` 系列兼容版本条目 |
+| `composeApp/build.gradle.kts` | 添加 `androidCompat` 条件判断 |
+| `composeApp/src/androidMain/kotlin/.../MicYouApplication.kt` | 新建，MultiDex 反射调用 + 全局异常处理 |
+| `composeApp/src/androidMain/kotlin/.../AudioEngine.android.kt` | PCM_FLOAT 降级 + AudioRecord.read API 检查 |
+| `composeApp/src/androidMain/kotlin/.../MicYouTileService.kt` | startActivityAndCollapse API 级别守卫 |
+| `composeApp/src/androidMain/AndroidManifest.xml` | 添加 `android:name`、高版本权限 `tools:ignore` |
+
+---
+
+## 非破坏性设计说明
+
+1. **默认行为不变**：不传 `-Pmicyou.androidCompat=true` 时，所有版本号、依赖、配置与原版完全一致
+2. **新增而非修改**：`libs.versions.toml` 中新增 `compat-*` 条目，原版本值不动
+3. **版本覆盖而非替换**：`settings.gradle.kts` 通过 `versionCatalogs.version()` 覆盖版本号，不修改原 TOML 文件
+4. **运行时安全**：`MicYouApplication` 通过反射调用 MultiDex，无该依赖时静默跳过
+5. **代码层兼容**：PCM_FLOAT 降级、TileService 守卫等是纯运行时检查，不影响编译
+6. **编译环境隔离**：JDK 路径通过 `org.gradle.java.home` 项目级配置，不影响系统 Java 环境
+
+---
+
+## PowerShell 注意事项
+
+在 PowerShell 中使用 `-P` 参数时，如果参数名包含点号（如 `micyou.androidCompat`），**必须用引号包裹整个参数**：
+
+```powershell
+# 正确 — 引号包裹
+./gradlew :composeApp:assembleDebug "-Pmicyou.androidCompat=true"
+
+# 错误 — 不加引号，PowerShell 会把 micyou.androidCompat 截断为 micyou
+./gradlew :composeApp:assembleDebug -Pmicyou.androidCompat=true
+```
+
+在 CMD 或 Bash 中不需要引号。
+
+---
+
+## 扩展：兼容更低版本
+
+如需进一步向下兼容（例如 API 19 / Android 4.4），可按以下步骤扩展：
+
+1. 在 `libs.versions.toml` 中新增 `compat-low-*` 系列版本条目
+2. 在 `settings.gradle.kts` 中添加新的属性判断，例如 `-Pmicyou.androidCompat=api19`
+3. 在 `composeApp/build.gradle.kts` 中添加对应分支的条件逻辑
+4. 在代码中添加更多运行时 API 级别检查
+
+建议的参数设计：
+
+```
+-Pmicyou.androidCompat=api21   # 默认，兼容 Android 5.0+
+-Pmicyou.androidCompat=api19   # 扩展，兼容 Android 4.4+
+```
+
+当前实现使用 `hasProperty` 检测属性是否存在（布尔模式），如需多档兼容，可改为读取属性值：
+
+```kotlin
+val compatLevel = project.properties["micyou.androidCompat"]?.toString()
+val androidCompat = compatLevel != null
+val isApi19 = compatLevel == "api19"
+```
+
+---
+
+## 已知限制
+
+- 兼容版 targetSdk = 29，不满足 Google Play 最新 target API 要求（仅用于侧载/内部测试）
+- Android 5.0 设备内存通常较小（1-2GB），Compose 应用可能存在性能差异
+- 兼容版未经过完整的功能回归测试，建议在目标设备上验证核心功能
+- v2.0.1 原版 AGP 9.3.1 需要 Gradle 9.5.0+，兼容模式 AGP 8.9.1 只需 Gradle 8.x
+- filekit 库在兼容模式下未降级，如遇 minSdk 冲突可在 resolutionStrategy 中补充 force
+
+---
+
+## 验证方法
+
+在低版本设备上安装 APK 后，依次验证：
+
+1. 应用能否正常启动，不出现白屏或闪退
+2. 点击连接按钮，音频服务能否正常启动
+3. 音频流能否正常传输到 PC 端
+4. 快捷设置磁贴（Tile）能否正常显示和点击
+5. 切换各种音频格式（PCM_16BIT / PCM_FLOAT）是否正常
+
+如遇崩溃，可通过以下方式查看日志：
+
+```bash
+# 查看全局崩溃日志
+adb logcat -s MicYouApplication
+
+# 或查看设备上的日志文件
+adb shell run-as com.lanrhyme.micyou cat files/crash/*.txt
+```

--- a/Android_兼容性编译说明.md
+++ b/Android_兼容性编译说明.md
@@ -1,0 +1,255 @@
+# Android 低版本兼容性编译说明
+
+> 适用版本：v1.1.5 / v2.0.1  
+> 目标设备：Android 5.0+ (API 21+) / 32 位设备  
+> 设计原则：**非破坏性** — 不修改原版编译逻辑，通过 Gradle 属性条件启用兼容模式
+
+---
+
+## 快速开始
+
+### 前置条件：JDK 17 安装
+
+AGP 8.x 以上需要 JDK 11+（v2.0.1 原版 AGP 9.x 需要 JDK 17+）。推荐安装 Eclipse Temurin JDK 17 LTS：
+
+下载地址：https://adoptium.net/temurin/releases/?version=17&arch=x64
+
+安装时勾选 "Set JAVA_HOME variable" 和 "Add to PATH"。安装后 Gradle 会自动使用，不影响系统已有的 Java 8。
+
+验证安装：
+```bash
+java -version
+# 应显示 openjdk version "17.x.x"
+```
+
+如需在项目级指定 JDK 路径（不影响系统环境），在 `gradle.properties` 中取消注释：
+```properties
+org.gradle.java.home=C\:\\Program Files\\Eclipse Adoptium\\jdk-17.0.20.101-hotspot
+```
+
+### 前置条件：Android SDK
+
+`local.properties` 中需指定 SDK 路径：
+```properties
+sdk.dir=D\:\\Android\\android-sdk-windows
+```
+
+需安装的 SDK 组件：
+- Platform: android-36（compileSdk 36）
+- Build Tools: 36.0.0 或更高
+
+---
+
+### 原版构建（与上游完全一致）
+
+```bash
+./gradlew :composeApp:assembleDebug
+```
+
+不加任何额外参数，编译结果、依赖版本、SDK 配置与原版完全相同。
+
+### 兼容版构建（支持 Android 5.0+）
+
+**重要：在 PowerShell 中必须给参数加引号，否则点号会被截断：**
+
+```powershell
+# PowerShell — 必须用引号
+./gradlew :composeApp:assembleDebug "-Pmicyou.androidCompat=true"
+```
+
+```bash
+# CMD / Bash — 不需要引号
+./gradlew :composeApp:assembleDebug -Pmicyou.androidCompat=true
+```
+
+输出路径：
+```
+composeApp/build/outputs/apk/debug/composeApp-debug.apk
+```
+
+---
+
+## 兼容模式做了什么
+
+启用 `-Pmicyou.androidCompat=true` 后，以下配置会自动切换到兼容版本：
+
+### v2.0.1 版本对照
+
+| 配置项 | 原版 | 兼容版 |
+|--------|------|--------|
+| AGP | 9.3.1 | 8.9.1 |
+| Kotlin | 2.4.10 | 2.1.20 |
+| minSdk | 24 (Android 7.0) | 21 (Android 5.0) |
+| targetSdk | 36 | 29 |
+| Compose BOM | 2026.05.00 | 2024.09.00 |
+| materialKolor | 5.0.0-alpha07 | 1.7.1 |
+| haze | 1.7.2 | 1.0.0 |
+| Ktor | 3.5.0 | 3.0.3 |
+| kotlinx-coroutines | 1.11.0 | 1.9.0 |
+| kotlinx-serialization | 1.11.0 | 1.7.3 |
+| kotlinx-datetime | 0.8.0 | 0.7.1 |
+| androidx.activity | 1.12.2 | 1.8.2 |
+| androidx.lifecycle | 2.9.4 | 2.8.0 |
+| androidx.core | 1.17.0 | 1.12.0 |
+| MultiDex | 关闭 | 开启 |
+| coreLibraryDesugaring | 关闭 | 开启 |
+| JVM target | 11 | 1.8 |
+| 32位 ABI | 无 | armeabi-v7a, x86 |
+| 代码混淆 (release) | 开启 | 关闭 |
+
+### v1.1.5 版本对照
+
+| 配置项 | 原版 | 兼容版 |
+|--------|------|--------|
+| minSdk | 24 (Android 7.0) | 21 (Android 5.0) |
+| targetSdk | 36 | 29 |
+| Compose Multiplatform | 1.10.1 | 1.7.3 |
+| Compose Material3 | 1.10.0-alpha05 | 1.7.3 |
+| Kotlin | 2.2.20 | 2.1.20 |
+| Ktor | 3.4.0 | 3.0.3 |
+| kotlinx-coroutines | 1.10.2 | 1.9.0 |
+| kotlinx-serialization | 1.8.1 | 1.7.3 |
+| androidx.activity | 1.12.2 | 1.8.2 |
+| androidx.lifecycle | 2.9.6 | 2.8.0 |
+| androidx.core | 1.17.0 | 1.12.0 |
+| MultiDex | 关闭 | 开启 |
+| coreLibraryDesugaring | 关闭 | 开启 |
+
+### 运行时兼容（不依赖编译开关，始终生效）
+
+- **设置 UI 格式过滤**：API < 23 时设置界面不显示 "32-bit Float" 选项，避免用户选择不支持的格式导致两端格式不匹配
+- **默认格式自动选择**：API < 23 时默认 PCM_16BIT，API >= 23 时默认 PCM_FLOAT（v2.0.1），Desktop 始终 PCM_FLOAT
+- **已保存格式校验**：从旧设备迁移的设置（如 PCM_FLOAT）在低 API 设备上自动回退到 PCM_16BIT
+- **PCM_FLOAT 降级**：API < 23 时即使通过其他方式传入 PCM_FLOAT，运行时也会降级为 PCM_16BIT
+- **TileService 守卫**：`startActivityAndCollapse` 按 API 级别分支调用
+- **全局异常处理**：`MicYouApplication` 注册 UncaughtExceptionHandler，崩溃时写入日志文件
+- **MultiDex 反射加载**：通过反射调用 `MultiDex.install()`，无依赖时优雅跳过
+
+---
+
+## 技术实现原理
+
+### 版本切换机制（v2.0.1）
+
+v2.0.1 通过 `settings.gradle.kts` 中的 `dependencyResolutionManagement.versionCatalogs` 覆盖版本号：
+
+1. 检测 `-Pmicyou.androidCompat` 命令行参数（通过 `gradle.startParameter.projectProperties`）
+2. 在 `versionCatalogs` 块中覆盖 `agp`、`kotlin` 等版本号
+3. 所有 `alias(libs.plugins.*)` 引用自动使用降级后的版本
+4. `composeApp/build.gradle.kts` 中的条件判断控制 minSdk、MultiDex、desugaring 等
+
+### 版本切换机制（v1.1.5）
+
+v1.1.5 通过 `build.gradle.kts` 中的 `resolutionStrategy` 和条件判断实现。
+
+---
+
+## 修改的文件
+
+### v2.0.1 改动文件
+
+| 文件 | 改动说明 |
+|------|----------|
+| `settings.gradle.kts` | 新增：兼容模式检测 + versionCatalogs 版本覆盖 |
+| `gradle/libs.versions.toml` | 恢复原版版本，新增 `compat-*` 系列兼容版本条目 |
+| `composeApp/build.gradle.kts` | 添加 `androidCompat` 条件判断，控制 SDK / 依赖 / MultiDex / desugaring / JVM target |
+| `composeApp/src/main/kotlin/.../MicYouApplication.kt` | MultiDex 改为反射调用，保留崩溃日志记录 |
+| `composeApp/src/main/AndroidManifest.xml` | 添加 `android:name`、`tools:ignore`、`tools:overrideLibrary` |
+| `gradle.properties` | 添加 `org.gradle.java.home` 配置说明（默认注释） |
+| `local.properties` | SDK 路径指向本地 Android SDK |
+
+### v1.1.5 改动文件
+
+| 文件 | 改动说明 |
+|------|----------|
+| `gradle/libs.versions.toml` | 恢复原版版本，新增 `compat-*` 系列兼容版本条目 |
+| `composeApp/build.gradle.kts` | 添加 `androidCompat` 条件判断 |
+| `composeApp/src/androidMain/kotlin/.../MicYouApplication.kt` | 新建，MultiDex 反射调用 + 全局异常处理 |
+| `composeApp/src/androidMain/kotlin/.../AudioEngine.android.kt` | PCM_FLOAT 降级 + AudioRecord.read API 检查 |
+| `composeApp/src/androidMain/kotlin/.../MicYouTileService.kt` | startActivityAndCollapse API 级别守卫 |
+| `composeApp/src/androidMain/AndroidManifest.xml` | 添加 `android:name`、高版本权限 `tools:ignore` |
+
+---
+
+## 非破坏性设计说明
+
+1. **默认行为不变**：不传 `-Pmicyou.androidCompat=true` 时，所有版本号、依赖、配置与原版完全一致
+2. **新增而非修改**：`libs.versions.toml` 中新增 `compat-*` 条目，原版本值不动
+3. **版本覆盖而非替换**：`settings.gradle.kts` 通过 `versionCatalogs.version()` 覆盖版本号，不修改原 TOML 文件
+4. **运行时安全**：`MicYouApplication` 通过反射调用 MultiDex，无该依赖时静默跳过
+5. **代码层兼容**：PCM_FLOAT 降级、TileService 守卫等是纯运行时检查，不影响编译
+6. **编译环境隔离**：JDK 路径通过 `org.gradle.java.home` 项目级配置，不影响系统 Java 环境
+
+---
+
+## PowerShell 注意事项
+
+在 PowerShell 中使用 `-P` 参数时，如果参数名包含点号（如 `micyou.androidCompat`），**必须用引号包裹整个参数**：
+
+```powershell
+# 正确 — 引号包裹
+./gradlew :composeApp:assembleDebug "-Pmicyou.androidCompat=true"
+
+# 错误 — 不加引号，PowerShell 会把 micyou.androidCompat 截断为 micyou
+./gradlew :composeApp:assembleDebug -Pmicyou.androidCompat=true
+```
+
+在 CMD 或 Bash 中不需要引号。
+
+---
+
+## 扩展：兼容更低版本
+
+如需进一步向下兼容（例如 API 19 / Android 4.4），可按以下步骤扩展：
+
+1. 在 `libs.versions.toml` 中新增 `compat-low-*` 系列版本条目
+2. 在 `settings.gradle.kts` 中添加新的属性判断，例如 `-Pmicyou.androidCompat=api19`
+3. 在 `composeApp/build.gradle.kts` 中添加对应分支的条件逻辑
+4. 在代码中添加更多运行时 API 级别检查
+
+建议的参数设计：
+
+```
+-Pmicyou.androidCompat=api21   # 默认，兼容 Android 5.0+
+-Pmicyou.androidCompat=api19   # 扩展，兼容 Android 4.4+
+```
+
+当前实现使用 `hasProperty` 检测属性是否存在（布尔模式），如需多档兼容，可改为读取属性值：
+
+```kotlin
+val compatLevel = project.properties["micyou.androidCompat"]?.toString()
+val androidCompat = compatLevel != null
+val isApi19 = compatLevel == "api19"
+```
+
+---
+
+## 已知限制
+
+- 兼容版 targetSdk = 29，不满足 Google Play 最新 target API 要求（仅用于侧载/内部测试）
+- Android 5.0 设备内存通常较小（1-2GB），Compose 应用可能存在性能差异
+- 兼容版未经过完整的功能回归测试，建议在目标设备上验证核心功能
+- v2.0.1 原版 AGP 9.3.1 需要 Gradle 9.5.0+，兼容模式 AGP 8.9.1 只需 Gradle 8.x
+- filekit 库在兼容模式下未降级，如遇 minSdk 冲突可在 resolutionStrategy 中补充 force
+
+---
+
+## 验证方法
+
+在低版本设备上安装 APK 后，依次验证：
+
+1. 应用能否正常启动，不出现白屏或闪退
+2. 点击连接按钮，音频服务能否正常启动
+3. 音频流能否正常传输到 PC 端
+4. 快捷设置磁贴（Tile）能否正常显示和点击
+5. 切换各种音频格式（PCM_16BIT / PCM_FLOAT）是否正常
+
+如遇崩溃，可通过以下方式查看日志：
+
+```bash
+# 查看全局崩溃日志
+adb logcat -s MicYouApplication
+
+# 或查看设备上的日志文件
+adb shell run-as com.lanrhyme.micyou cat files/crash/*.txt
+```

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -29,14 +29,15 @@ plugins {
     alias(libs.plugins.kotlinSerialization)
 }
 
-val composeVersion = libs.versions.composeMultiplatform.get()
-val composeMaterial3Version = libs.versions.composeMaterial3.get()
+val androidCompat = project.hasProperty("micyou.androidCompat")
+val composeVersion = if (androidCompat) libs.versions.compat.composeMultiplatform.get() else libs.versions.composeMultiplatform.get()
+val composeMaterial3Version = if (androidCompat) libs.versions.compat.composeMaterial3.get() else libs.versions.composeMaterial3.get()
 
 configurations.configureEach {
     resolutionStrategy.eachDependency {
         if (requested.group == "org.jetbrains.compose" || requested.group.startsWith("org.jetbrains.compose.")) {
             val name = requested.name
-            if (name == "material-icons-extended" || name == "material-icons-extended-desktop" || 
+            if (name == "material-icons-extended" || name == "material-icons-extended-desktop" ||
                 name == "material-icons-core" || name == "material-icons-core-desktop" ||
                 name == "material") {
                 useVersion("1.7.3")
@@ -46,6 +47,18 @@ configurations.configureEach {
                 useVersion(composeVersion)
             } else {
                 useVersion(composeVersion)
+            }
+        }
+        if (androidCompat) {
+            when {
+                requested.group == "androidx.activity" -> useVersion(libs.versions.compat.androidx.activity.get())
+                requested.group == "androidx.lifecycle" -> useVersion(libs.versions.compat.androidx.lifecycle.get())
+                requested.group == "androidx.core" -> useVersion(libs.versions.compat.androidx.core.get())
+                requested.group == "io.ktor" -> useVersion(libs.versions.compat.ktor.get())
+                requested.group == "org.jetbrains.kotlinx" && requested.name.startsWith("kotlinx-coroutines") ->
+                    useVersion(libs.versions.compat.kotlinx.coroutines.get())
+                requested.group == "org.jetbrains.kotlinx" && requested.name.startsWith("kotlinx-serialization") ->
+                    useVersion(libs.versions.compat.kotlinx.serialization.get())
             }
         }
     }
@@ -111,10 +124,13 @@ android {
 
     defaultConfig {
         applicationId = "com.lanrhyme.micyou"
-        minSdk = libs.versions.android.minSdk.get().toInt()
-        targetSdk = libs.versions.android.targetSdk.get().toInt()
+        minSdk = (if (androidCompat) libs.versions.compat.android.minSdk.get() else libs.versions.android.minSdk.get()).toInt()
+        targetSdk = (if (androidCompat) libs.versions.compat.android.targetSdk.get() else libs.versions.android.targetSdk.get()).toInt()
         versionCode = project.property("project.version.code").toString().toInt()
         versionName = project.property("project.version").toString()
+        if (androidCompat) {
+            multiDexEnabled = true
+        }
     }
 
     buildFeatures {
@@ -151,12 +167,19 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        if (androidCompat) {
+            isCoreLibraryDesugaringEnabled = true
+        }
     }
 }
 
 dependencies {
     implementation(libs.androidx.core.ktx)
     debugImplementation(libs.compose.uiTooling)
+    if (androidCompat) {
+        coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${libs.versions.compat.desugarJdkLibs.get()}")
+        implementation("androidx.multidex:multidex:${libs.versions.compat.multidex.get()}")
+    }
 }
 
 compose.desktop {

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,28 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <!-- FOREGROUND_SERVICE_MICROPHONE 需要 API 34+，使用 tools:ignore 忽略低版本警告 -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" tools:ignore="HighApiLevel" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     
     <!-- Bluetooth Permissions -->
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <!-- BLUETOOTH_CONNECT/SCAN 需要 API 31+，使用 tools:ignore 忽略低版本警告 -->
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" tools:ignore="HighApiLevel" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" tools:ignore="HighApiLevel" />
 
     <!-- Update install permission -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
+        android:name=".MicYouApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@android:style/Theme.Material.NoActionBar">
+        android:theme="@android:style/Theme.Material.NoActionBar"
+        tools:overrideLibrary="dev.chrisbanes.haze">
         <activity
             android:exported="true"
             android:name=".MainActivity"
@@ -36,15 +41,16 @@
 
         <service
             android:name=".AudioService"
-            android:foregroundServiceType="microphone"
             android:exported="false" />
 
+        <!-- TileService 需要 API 24+，在低版本设备上不会被使用 -->
         <service
             android:name=".MicYouTileService"
             android:label="@string/qs_tile_label"
             android:icon="@drawable/ic_qs_mic"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
-            android:exported="true">
+            android:exported="true"
+            tools:ignore="HighApiLevel">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/AudioEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/AudioEngine.android.kt
@@ -6,6 +6,7 @@ import android.media.AudioRecord
 import android.media.MediaRecorder
 import android.media.audiofx.AutomaticGainControl
 import android.media.audiofx.NoiseSuppressor
+import android.os.Build
 import io.ktor.network.selector.SelectorManager
 import io.ktor.network.sockets.Socket
 import io.ktor.network.sockets.aSocket
@@ -25,6 +26,7 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -95,10 +97,21 @@ actual class AudioEngine actual constructor() {
     private var enableNS: Boolean = false
     @Volatile
     private var enableAGC: Boolean = false
+    @Volatile
+    private var audioSource: AndroidAudioSource = AndroidAudioSource.Mic
 
     private var noiseSuppressor: NoiseSuppressor? = null
     private var automaticGainControl: AutomaticGainControl? = null
-    
+
+    // Saved connection params for restart
+    private var savedIp: String = ""
+    private var savedPort: Int = 0
+    private var savedMode: ConnectionMode = ConnectionMode.Wifi
+    private var savedSampleRate: SampleRate = SampleRate.Rate44100
+    private var savedChannelCount: ChannelCount = ChannelCount.Mono
+    private var savedAudioFormat: com.lanrhyme.micyou.AudioFormat = com.lanrhyme.micyou.AudioFormat.PCM_16BIT
+    private var isRunning: Boolean = false
+
     private val CHECK_1 = "MicYouCheck1"
     private val CHECK_2 = "MicYouCheck2"
 
@@ -114,6 +127,15 @@ actual class AudioEngine actual constructor() {
         if (!isClient) return
         Logger.i("AudioEngine", "Starting Android AudioEngine: mode=$mode, ip=$ip, port=$port, sampleRate=${sampleRate.value}, channels=${channelCount.label}, format=${audioFormat.label}")
         _lastError.value = null
+
+        // Save connection params for potential restart
+        savedIp = ip
+        savedPort = port
+        savedMode = mode
+        savedSampleRate = sampleRate
+        savedChannelCount = channelCount
+        savedAudioFormat = audioFormat
+        isRunning = true
 
         val jobToJoin = startStopMutex.withLock {
             val currentJob = job
@@ -143,39 +165,37 @@ actual class AudioEngine actual constructor() {
                         val androidAudioFormat = when(audioFormat) {
                             com.lanrhyme.micyou.AudioFormat.PCM_8BIT -> AudioFormat.ENCODING_PCM_8BIT
                             com.lanrhyme.micyou.AudioFormat.PCM_16BIT -> AudioFormat.ENCODING_PCM_16BIT
-                            com.lanrhyme.micyou.AudioFormat.PCM_FLOAT -> AudioFormat.ENCODING_PCM_FLOAT
+                            // AudioRecord.read(float[], ...) 重载均为 API 23+，API < 23 降级为 PCM_16BIT 避免 NoSuchMethodError
+                            com.lanrhyme.micyou.AudioFormat.PCM_FLOAT ->
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) AudioFormat.ENCODING_PCM_FLOAT
+                                else AudioFormat.ENCODING_PCM_16BIT
                             else -> AudioFormat.ENCODING_PCM_16BIT // Default fallback
                         }
                         
                         val minBufSize = AudioRecord.getMinBufferSize(androidSampleRate, androidChannelConfig, androidAudioFormat)
 
                         try {
-                            val useProcessing = enableNS || enableAGC
-                            // 如果启用了处理，优先使用 MIC，因为 UNPROCESSED 可能会绕过系统效果
-                            val preferredSource = if (useProcessing) MediaRecorder.AudioSource.MIC else MediaRecorder.AudioSource.UNPROCESSED
+                            // 使用用户选择的音频源
+                            val sourceId = audioSource.sourceId
 
-                            Logger.d("AudioEngine", "Initializing AudioRecord with source $preferredSource")
+                            Logger.d("AudioEngine", "Initializing AudioRecord with source ${audioSource.name} (id=$sourceId)")
                             recorder = try {
                                 AudioRecord(
-                                    preferredSource,
+                                    sourceId,
                                     androidSampleRate,
                                     androidChannelConfig,
                                     androidAudioFormat,
                                     minBufSize * 2
                                 )
                             } catch (e: Exception) {
-                                Logger.w("AudioEngine", "Preferred source $preferredSource failed, falling back to MIC: ${e.message}")
-                                if (preferredSource != MediaRecorder.AudioSource.MIC) {
-                                    AudioRecord(
-                                        MediaRecorder.AudioSource.MIC,
-                                        androidSampleRate,
-                                        androidChannelConfig,
-                                        androidAudioFormat,
-                                        minBufSize * 2
-                                    )
-                                } else {
-                                    throw e
-                                }
+                                Logger.w("AudioEngine", "${audioSource.name} failed, falling back to MIC: ${e.message}")
+                                AudioRecord(
+                                    MediaRecorder.AudioSource.MIC,
+                                    androidSampleRate,
+                                    androidChannelConfig,
+                                    androidAudioFormat,
+                                    minBufSize * 2
+                                )
                             }
                         } catch (e: SecurityException) {
                             Logger.e("AudioEngine", "Record permission denied", e)
@@ -370,7 +390,8 @@ actual class AudioEngine actual constructor() {
                             var readBytes = 0
                             val audioData: ByteArray
 
-                            if (androidAudioFormat == AudioFormat.ENCODING_PCM_FLOAT && floatBuffer != null) {
+                            if (androidAudioFormat == AudioFormat.ENCODING_PCM_FLOAT && floatBuffer != null
+                                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                                 val readFloats = recorder.read(floatBuffer, 0, floatBuffer.size, AudioRecord.READ_BLOCKING)
                                 if (readFloats > 0) {
                                     readBytes = readFloats * 4
@@ -410,7 +431,9 @@ actual class AudioEngine actual constructor() {
                         throw e
                     } catch (e: Exception) {
                         if (isActive && !isNormalDisconnect(e)) {
-                            Logger.e("AudioEngine", "Connection lost", e)
+                            Logger.e("AudioEngine", "Connection error: ${e.javaClass.simpleName}: ${e.message}", e)
+                            ErrorLogger.logError("AudioEngine", "Connection error: ${e.javaClass.simpleName}: ${e.message}", e)
+                            
                             _state.value = StreamState.Error
                             
                             val errorMsg = when {
@@ -461,6 +484,7 @@ actual class AudioEngine actual constructor() {
         job?.cancel()
         job = null
         _state.value = StreamState.Idle
+        isRunning = false
 
         val context = ContextHelper.getContext()
         if (context != null) {
@@ -505,14 +529,51 @@ actual class AudioEngine actual constructor() {
         dereverbLevel: Float,
         amplification: Float
     ) {
+        val nsChanged = this.enableNS != enableNS
+        val agcChanged = this.enableAGC != enableAGC
+
         this.enableNS = enableNS
         this.enableAGC = enableAGC
-        
+
         try {
             noiseSuppressor?.enabled = enableNS
             automaticGainControl?.enabled = enableAGC
         } catch (e: Exception) {
             println("Error updating audio effects: ${e.message}")
+        }
+
+        // Restart audio stream if hardware processing state changed and stream is running
+        if ((nsChanged || agcChanged) && isRunning && _state.value == StreamState.Streaming) {
+            Logger.i("AudioEngine", "Hardware processing changed, restarting audio stream...")
+            CoroutineScope(Dispatchers.IO).launch {
+                stop()
+                delay(500)
+                start(savedIp, savedPort, savedMode, true, savedSampleRate, savedChannelCount, savedAudioFormat)
+            }
+        }
+    }
+
+    actual fun setAudioSource(sourceName: String) {
+        val source = try {
+            AndroidAudioSource.valueOf(sourceName)
+        } catch (e: Exception) {
+            AndroidAudioSource.Mic
+        }
+
+        // Only restart if source actually changed and engine is running
+        if (this.audioSource != source) {
+            this.audioSource = source
+            Logger.d("AudioEngine", "Audio source changed to: ${source.name}")
+
+            // Restart audio stream if currently running
+            if (isRunning && _state.value == StreamState.Streaming) {
+                Logger.i("AudioEngine", "Restarting audio stream with new source...")
+                CoroutineScope(Dispatchers.IO).launch {
+                    stop()
+                    delay(500) // Wait for cleanup
+                    start(savedIp, savedPort, savedMode, true, savedSampleRate, savedChannelCount, savedAudioFormat)
+                }
+            }
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/MicYouApplication.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/MicYouApplication.kt
@@ -1,0 +1,34 @@
+package com.lanrhyme.micyou
+
+import android.app.Application
+import android.util.Log
+
+class MicYouApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        installMultiDexViaReflection()
+        setupCrashHandler()
+    }
+
+    private fun installMultiDexViaReflection() {
+        try {
+            val clazz = Class.forName("androidx.multidex.MultiDex")
+            val method = clazz.getMethod("install", Application::class.java)
+            method.invoke(null, this)
+            Log.i("MicYouApplication", "MultiDex installed")
+        } catch (e: ClassNotFoundException) {
+            Log.i("MicYouApplication", "MultiDex not available (compat mode disabled)")
+        } catch (e: Exception) {
+            Log.w("MicYouApplication", "MultiDex install failed: ${e.message}")
+        }
+    }
+
+    private fun setupCrashHandler() {
+        val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            Log.e("MicYouApplication", "Uncaught exception on ${thread.name}", throwable)
+            defaultHandler?.uncaughtException(thread, throwable)
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/MicYouTileService.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/MicYouTileService.kt
@@ -27,9 +27,14 @@ class MicYouTileService : TileService() {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                } else {
+                    PendingIntent.FLAG_UPDATE_CURRENT
+                }
                 val pendingIntent = PendingIntent.getActivity(
                     this, 0, intent,
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                    flags
                 )
                 startActivityAndCollapse(pendingIntent)
             } else {

--- a/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/lanrhyme/micyou/Platform.android.kt
@@ -45,3 +45,30 @@ actual fun getDynamicColorScheme(isDark: Boolean): ColorScheme? {
     return null
 }
 
+actual fun isDynamicColorSupported(): Boolean {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+}
+
+actual fun getDynamicSeedColor(): Long? {
+    return null
+}
+
+actual fun getAudioSourceOptions(): List<AudioSourceOption> {
+    return AndroidAudioSource.getSupportedSources().map { AudioSourceOption(it.name, it.label) }
+}
+
+actual fun availableAudioFormats(): List<AudioFormat> {
+    val supportsFloat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+    return AudioFormat.entries.filter { format ->
+        when (format) {
+            AudioFormat.PCM_FLOAT -> supportsFloat
+            else -> true
+        }
+    }
+}
+
+actual fun defaultAudioFormat(): AudioFormat {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) AudioFormat.PCM_FLOAT
+    else AudioFormat.PCM_16BIT
+}
+

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioSettings.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/AudioSettings.kt
@@ -17,3 +17,17 @@ enum class AudioFormat(val value: Int, val label: String) {
     PCM_FLOAT(4, "32-bit Float") // AudioFormat.ENCODING_PCM_FLOAT = 4
 }
 
+/**
+ * 返回当前平台可用的音频格式列表（用于设置 UI）。
+ * Android: PCM_FLOAT 在 API < 23 时不显示
+ * Desktop: 所有格式可用
+ */
+expect fun availableAudioFormats(): List<AudioFormat>
+
+/**
+ * 返回当前平台的安全默认格式。
+ * Android: API < 23 → PCM_16BIT，API >= 23 → PCM_FLOAT
+ * Desktop: PCM_FLOAT
+ */
+expect fun defaultAudioFormat(): AudioFormat
+

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopSettings.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/DesktopSettings.kt
@@ -1,13 +1,30 @@
 package com.lanrhyme.micyou
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -17,14 +34,23 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.TextSnippet
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.rounded.Description
+import androidx.compose.material.icons.rounded.Extension
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.Language
+import androidx.compose.material.icons.rounded.Mic
+import androidx.compose.material.icons.rounded.Palette
+import androidx.compose.material.icons.rounded.People
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -42,13 +68,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.VerticalDivider
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -58,33 +84,106 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import com.lanrhyme.micyou.animation.EasingFunctions
 import kotlinx.coroutines.delay
-import micyou.composeapp.generated.resources.Res
-import micyou.composeapp.generated.resources.icon_compass
-import micyou.composeapp.generated.resources.icon_creative
-import micyou.composeapp.generated.resources.icon_file
-import micyou.composeapp.generated.resources.icon_microphone
-import micyou.composeapp.generated.resources.icon_palette
-import micyou.composeapp.generated.resources.icon_planet
-import micyou.composeapp.generated.resources.icon_settings
-import micyou.composeapp.generated.resources.icon_star_fall
-import micyou.composeapp.generated.resources.icon_star_fall_mini
-import org.jetbrains.compose.resources.painterResource
+
+/**
+ * 可复用的设置项容器组件
+ */
+@Composable
+private fun SettingsItemContainer(
+    modifier: Modifier = Modifier,
+    cardOpacity: Float = 1f,
+    onClick: (() -> Unit)? = null,
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.medium)
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
+            .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
+    ) {
+        content()
+    }
+}
+
+/**
+ * 可复用的设置项开关组件
+ */
+@Composable
+private fun SettingsSwitchItem(
+    headline: String,
+    supporting: String? = null,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    cardOpacity: Float = 1f
+) {
+    SettingsItemContainer(
+        cardOpacity = cardOpacity,
+        onClick = { onCheckedChange(!checked) }
+    ) {
+        ListItem(
+            headlineContent = { Text(headline) },
+            supportingContent = supporting?.let { { Text(it) } },
+            trailingContent = { Switch(checked = checked, onCheckedChange = onCheckedChange) },
+            modifier = Modifier.clickable { onCheckedChange(!checked) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+        )
+    }
+}
+
+/**
+ * 可复用的设置项下拉选择组件
+ */
+@Composable
+private fun <T> SettingsDropdownItem(
+    headline: String,
+    selected: T,
+    options: List<T>,
+    labelProvider: (T) -> String,
+    onSelect: (T) -> Unit,
+    cardOpacity: Float = 1f
+) {
+    var expanded by remember { mutableStateOf(false) }
+    SettingsItemContainer(cardOpacity = cardOpacity) {
+        ListItem(
+            headlineContent = { Text(headline) },
+            trailingContent = {
+                Box {
+                    TextButton(onClick = { expanded = true }) { Text(labelProvider(selected)) }
+                    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }, shape = MaterialTheme.shapes.medium) {
+                        options.forEach { option ->
+                            DropdownMenuItem(
+                                text = { Text(labelProvider(option)) },
+                                onClick = { onSelect(option); expanded = false },
+                                trailingIcon = { if (selected == option) Icon(Icons.Default.Check, contentDescription = null) }
+                            )
+                        }
+                    }
+                }
+            },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+        )
+    }
+}
 
 enum class SettingsSection {
     General,
     Appearance,
     Audio,
+    Plugins,
     About
 }
 
@@ -101,6 +200,36 @@ fun DesktopSettings(
     val strings = LocalAppStrings.current
     val isDarkTheme = isDarkThemeActive(state.themeMode)
     val forcePureBlackBackground = state.oledPureBlack && isDarkTheme
+    
+    // Haze state for background effect
+    val hazeState = if (state.backgroundSettings.enableHazeEffect && state.backgroundSettings.hasCustomBackground) {
+        rememberHazeState()
+    } else null
+    
+    // 页面进入动画状态
+    var visible by remember { mutableStateOf(false) }
+    var contentVisible by remember { mutableStateOf(false) }
+    
+    val scale by animateFloatAsState(
+        targetValue = if (visible) 1f else 0.9f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "pageScale"
+    )
+    
+    val alpha by animateFloatAsState(
+        targetValue = if (visible) 1f else 0f,
+        animationSpec = tween(400, easing = EasingFunctions.EaseOutExpo),
+        label = "pageAlpha"
+    )
+    
+    LaunchedEffect(Unit) {
+        visible = true
+        delay(100)
+        contentVisible = true
+    }
 
     LaunchedEffect(state.snackbarMessage) {
         state.snackbarMessage?.let {
@@ -109,112 +238,198 @@ fun DesktopSettings(
         }
     }
 
-    Scaffold(
-        snackbarHost = { SnackbarHost(snackbarHostState) },
-        containerColor = MaterialTheme.colorScheme.surface,
-        contentColor = MaterialTheme.colorScheme.onSurface
-    ) { padding ->
-        Box(modifier = Modifier.padding(padding)) {
+    // 当使用自定义背景时，Surface 使用透明色
+    val surfaceColor = if (state.backgroundSettings.hasCustomBackground) {
+        Color.Transparent
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+    
+    Surface(
+        color = surfaceColor,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier
+            .fillMaxSize()
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+                this.alpha = alpha
+            }
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
             CustomBackground(
                 settings = state.backgroundSettings,
                 modifier = Modifier.fillMaxSize(),
+                hazeState = hazeState,
                 forcePureBlackBackground = forcePureBlackBackground
             )
+            
             if (platform.type == PlatformType.Desktop) {
-                DesktopLayout(viewModel, onClose)
+                DesktopLayout(viewModel, onClose, contentVisible, hazeState)
             } else {
-                MobileLayout(viewModel, onClose)
+                MobileLayout(viewModel, onClose, hazeState)
             }
         }
     }
 }
 
 @Composable
-fun DesktopLayout(viewModel: MainViewModel, onClose: () -> Unit) {
+fun DesktopLayout(viewModel: MainViewModel, onClose: () -> Unit, contentVisible: Boolean, hazeState: HazeState?) {
     var currentSection by remember { mutableStateOf(SettingsSection.General) }
     val strings = LocalAppStrings.current
     val state by viewModel.uiState.collectAsState()
     val cardOpacity = state.backgroundSettings.cardOpacity
     
-    Row(modifier = Modifier.fillMaxSize()) {
-        Surface(
-            modifier = Modifier.width(220.dp).fillMaxSize(),
-            color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = cardOpacity * 0.9f)
+    Row(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // 左侧导航栏 - 使用 AnimatedCard 样式
+        AnimatedSettingsCard(
+            visible = contentVisible,
+            delayMillis = 100,
+            modifier = Modifier.width(240.dp).fillMaxHeight(),
+            cardOpacity = cardOpacity,
+            hazeState = hazeState,
+            enableHaze = state.backgroundSettings.enableHazeEffect,
+            containerColor = MaterialTheme.colorScheme.surfaceContainer
         ) {
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(vertical = 24.dp),
-                verticalArrangement = Arrangement.spacedBy(2.dp)
+                    .padding(top = 16.dp, bottom = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 item {
-                    Text(
-                        strings.settingsTitle,
-                        style = MaterialTheme.typography.titleLarge,
-                        color = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp)
-                    )
+                    Row(
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        IconButton(
+                            onClick = onClose,
+                            modifier = Modifier.size(40.dp)
+                        ) {
+                            Icon(
+                                Icons.AutoMirrored.Rounded.ArrowBack,
+                                contentDescription = strings.close,
+                                modifier = Modifier.size(22.dp)
+                            )
+                        }
+                        Text(
+                            strings.settingsTitle,
+                            style = MaterialTheme.typography.titleLarge,
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
                 }
                 
-                item { HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp)) }
+                item { 
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
+                    ) 
+                }
                 
-                items(SettingsSection.entries.toList()) { section ->
+                itemsIndexed(SettingsSection.entries.toList()) { index, section ->
                     val icon = when (section) {
-                        SettingsSection.General -> painterResource(Res.drawable.icon_settings)
-                        SettingsSection.Appearance -> painterResource(Res.drawable.icon_palette)
-                        SettingsSection.Audio -> painterResource(Res.drawable.icon_microphone)
-                        SettingsSection.About -> painterResource(Res.drawable.icon_compass)
+                        SettingsSection.General -> Icons.Rounded.Settings
+                        SettingsSection.Appearance -> Icons.Rounded.Palette
+                        SettingsSection.Audio -> Icons.Rounded.Mic
+                        SettingsSection.Plugins -> Icons.Rounded.Extension
+                        SettingsSection.About -> Icons.Rounded.Info
                     }
                     val isSelected = currentSection == section
                     
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 12.dp, vertical = 3.dp)
-                            .clip(RoundedCornerShape(10.dp))
-                            .clickable { currentSection = section }
-                            .background(
-                                if (isSelected) MaterialTheme.colorScheme.secondaryContainer
-                                else Color.Transparent
-                            )
-                            .animateContentSize()
-                            .padding(horizontal = 16.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                    // 导航项进入动画
+                    var navItemVisible by remember { mutableStateOf(false) }
+                    LaunchedEffect(contentVisible) {
+                        if (contentVisible) {
+                            delay(150L + index * 50L)
+                            navItemVisible = true
+                        }
+                    }
+                    
+                    AnimatedVisibility(
+                        visible = navItemVisible,
+                        enter = slideInHorizontally(
+                            initialOffsetX = { -30 },
+                            animationSpec = tween(300, easing = EasingFunctions.EaseOutExpo)
+                        ) + fadeIn(tween(300)),
+                        exit = fadeOut(tween(200))
                     ) {
-                        Icon(
-                            painter = icon,
-                            contentDescription = section.getLabel(strings),
-                            modifier = Modifier.size(22.dp),
-                            tint = if (isSelected) MaterialTheme.colorScheme.primary
-                            else MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Text(
-                            section.getLabel(strings),
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal,
-                            color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer
-                            else MaterialTheme.colorScheme.onSurfaceVariant
+                        NavigationItem(
+                            icon = icon,
+                            label = section.getLabel(strings),
+                            isSelected = isSelected,
+                            onClick = { currentSection = section }
                         )
                     }
                 }
             }
         }
         
-        VerticalDivider()
-        
-        Surface(
-            modifier = Modifier.fillMaxSize().padding(24.dp),
-            color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = cardOpacity * 0.7f),
-            shape = RoundedCornerShape(16.dp)
+        // 右侧内容区 - 使用 AnimatedCard 样式
+        AnimatedSettingsCard(
+            visible = contentVisible,
+            delayMillis = 200,
+            modifier = Modifier.weight(1f).fillMaxHeight(),
+            cardOpacity = cardOpacity,
+            hazeState = hazeState,
+            enableHaze = state.backgroundSettings.enableHazeEffect,
+            containerColor = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.7f)
         ) {
-            Column(modifier = Modifier.padding(20.dp)) {
-                Text(currentSection.getLabel(strings), style = MaterialTheme.typography.headlineMedium)
-                Spacer(Modifier.height(24.dp))
+            Column(
+                modifier = Modifier.padding(top = 20.dp, start = 24.dp, end = 24.dp, bottom = 24.dp)
+            ) {
+                // 标题区域
+                AnimatedContent(
+                    targetState = currentSection,
+                    transitionSpec = {
+                        (slideInHorizontally(
+                            initialOffsetX = { if (targetState.ordinal > initialState.ordinal) 50 else -50 },
+                            animationSpec = tween(300, easing = EasingFunctions.EaseOutExpo)
+                        ) + fadeIn(tween(250))) togetherWith
+                        (slideOutHorizontally(
+                            targetOffsetX = { if (targetState.ordinal > initialState.ordinal) -50 else 50 },
+                            animationSpec = tween(250, easing = EasingFunctions.EaseInExpo)
+                        ) + fadeOut(tween(200)))
+                    },
+                    label = "sectionTitle"
+                ) { section ->
+                    Text(
+                        section.getLabel(strings),
+                        style = MaterialTheme.typography.headlineMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
                 
-                LazyColumn(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                    item {
-                         SettingsContent(currentSection, viewModel)
+                Spacer(Modifier.height(16.dp))
+                
+                // 内容区域 - 使用 AnimatedContent 实现页面切换动画
+                AnimatedContent(
+                    targetState = currentSection,
+                    transitionSpec = {
+                        val direction = if (targetState.ordinal > initialState.ordinal) 1 else -1
+                        (slideInHorizontally(
+                            initialOffsetX = { direction * 100 },
+                            animationSpec = tween(350, easing = EasingFunctions.EaseOutExpo)
+                        ) + fadeIn(tween(300))) togetherWith
+                        (slideOutHorizontally(
+                            targetOffsetX = { -direction * 100 },
+                            animationSpec = tween(300, easing = EasingFunctions.EaseInExpo)
+                        ) + fadeOut(tween(250)))
+                    },
+                    label = "sectionContent"
+                ) { section ->
+                    LazyColumn(
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        item {
+                            SettingsContent(section, viewModel)
+                        }
                     }
                 }
             }
@@ -222,41 +437,314 @@ fun DesktopLayout(viewModel: MainViewModel, onClose: () -> Unit) {
     }
 }
 
+/**
+ * 导航项组件 - 带选中动画效果
+ */
 @Composable
-fun MobileLayout(viewModel: MainViewModel, onClose: () -> Unit) {
+private fun NavigationItem(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    
+    val backgroundColor by animateColorAsState(
+        targetValue = when {
+            isSelected -> MaterialTheme.colorScheme.secondaryContainer
+            isHovered -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+            else -> Color.Transparent
+        },
+        animationSpec = tween(200),
+        label = "navBackground"
+    )
+    
+    val scale by animateFloatAsState(
+        targetValue = if (isSelected) 1.02f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "navScale"
+    )
+    
+    val iconTint by animateColorAsState(
+        targetValue = when {
+            isSelected -> MaterialTheme.colorScheme.primary
+            isHovered -> MaterialTheme.colorScheme.onSurface
+            else -> MaterialTheme.colorScheme.onSurfaceVariant
+        },
+        animationSpec = tween(200),
+        label = "navIconTint"
+    )
+    
+    val textColor by animateColorAsState(
+        targetValue = when {
+            isSelected -> MaterialTheme.colorScheme.onSecondaryContainer
+            isHovered -> MaterialTheme.colorScheme.onSurface
+            else -> MaterialTheme.colorScheme.onSurfaceVariant
+        },
+        animationSpec = tween(200),
+        label = "navTextColor"
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 2.dp)
+            .scale(scale)
+            .clip(MaterialTheme.shapes.extraLarge)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick
+            )
+            .background(backgroundColor)
+            .animateContentSize()
+            .padding(horizontal = 20.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = label,
+            modifier = Modifier.size(24.dp),
+            tint = iconTint
+        )
+        Spacer(modifier = Modifier.width(14.dp))
+        Text(
+            label,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal,
+            color = textColor
+        )
+        
+        Spacer(modifier = Modifier.weight(1f))
+
+        // 选中指示器
+        androidx.compose.animation.AnimatedVisibility(
+            visible = isSelected,
+            enter = scaleIn(
+                initialScale = 0f,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                    stiffness = Spring.StiffnessLow
+                )
+            ) + fadeIn(tween(200)),
+            exit = scaleOut(
+                targetScale = 0f,
+                animationSpec = tween(150)
+            ) + fadeOut(tween(100))
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .background(
+                        MaterialTheme.colorScheme.primary,
+                        shape = RoundedCornerShape(50)
+                    )
+            )
+        }
+    }
+}
+
+/**
+ * 设置页面卡片组件 - 带进入动画
+ */
+@Composable
+private fun AnimatedSettingsCard(
+    visible: Boolean,
+    delayMillis: Int,
+    modifier: Modifier = Modifier,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainer,
+    shape: RoundedCornerShape = RoundedCornerShape(20.dp),
+    cardOpacity: Float = 1f,
+    hazeState: HazeState? = null,
+    enableHaze: Boolean = false,
+    content: @Composable () -> Unit
+) {
+    val cardAlpha by animateFloatAsState(
+        targetValue = if (visible) 1f else 0f,
+        animationSpec = tween(400, delayMillis, easing = EasingFunctions.EaseOutExpo),
+        label = "cardAlpha"
+    )
+    val cardScale by animateFloatAsState(
+        targetValue = if (visible) 1f else 0.9f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessLow,
+            visibilityThreshold = 0.001f
+        ),
+        label = "cardScale"
+    )
+    val cardOffsetY by animateFloatAsState(
+        targetValue = if (visible) 0f else 40f,
+        animationSpec = tween(500, delayMillis, easing = EasingFunctions.EaseOutExpo),
+        label = "cardOffsetY"
+    )
+
+    if (enableHaze && hazeState != null) {
+        HazeCard(
+            hazeState = hazeState,
+            enabled = true,
+            hazeColor = containerColor.copy(alpha = cardOpacity * 0.7f),
+            modifier = modifier
+                .graphicsLayer {
+                    this.alpha = cardAlpha
+                    this.scaleX = cardScale
+                    this.scaleY = cardScale
+                    translationY = cardOffsetY
+                }
+                .clip(shape)
+        ) {
+            content()
+        }
+    } else {
+        Card(
+            modifier = modifier
+                .graphicsLayer {
+                    this.alpha = cardAlpha
+                    this.scaleX = cardScale
+                    this.scaleY = cardScale
+                    translationY = cardOffsetY
+                },
+            colors = CardDefaults.cardColors(
+                containerColor = containerColor.copy(alpha = cardOpacity)
+            ),
+            shape = shape,
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        ) {
+            content()
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MobileLayout(viewModel: MainViewModel, onClose: () -> Unit, hazeState: HazeState?) {
     val strings = LocalAppStrings.current
     val state by viewModel.uiState.collectAsState()
     val cardOpacity = state.backgroundSettings.cardOpacity
     
-    LazyColumn(
-        modifier = Modifier.padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(24.dp)
-    ) {
-        item {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(strings.settingsTitle, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.weight(1f))
-                IconButton(onClick = onClose) {
-                    Icon(Icons.Default.Close, strings.close)
+    // 页面进入动画
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        delay(100)
+        visible = true
+    }
+    
+    // 当使用自定义背景时，Scaffold 使用透明色
+    val scaffoldColor = if (state.backgroundSettings.hasCustomBackground) {
+        Color.Transparent
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+    
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(strings.settingsTitle) },
+                navigationIcon = {
+                    IconButton(onClick = onClose) {
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = strings.close)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = if (state.backgroundSettings.hasCustomBackground) {
+                        MaterialTheme.colorScheme.surface.copy(alpha = 0.7f)
+                    } else {
+                        MaterialTheme.colorScheme.surface.copy(alpha = cardOpacity)
+                    }
+                )
+            )
+        },
+        containerColor = scaffoldColor
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.padding(padding).padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            itemsIndexed(SettingsSection.entries.toList()) { index, section ->
+                // 使用 graphicsLayer 实现动画，不会阻塞滚动
+                var cardAnimated by remember { mutableStateOf(false) }
+                LaunchedEffect(Unit) {
+                    delay(100L + index * 80L)
+                    cardAnimated = true
                 }
-            }
-        }
-        
-        SettingsSection.entries.forEach { section ->
-            item {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = cardOpacity)
+                
+                val cardAlpha by animateFloatAsState(
+                    targetValue = if (cardAnimated) 1f else 0f,
+                    animationSpec = tween(350, easing = EasingFunctions.EaseOutExpo),
+                    label = "cardAlpha"
+                )
+                val cardScale by animateFloatAsState(
+                    targetValue = if (cardAnimated) 1f else 0.9f,
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                        stiffness = Spring.StiffnessLow
                     ),
-                    shape = RoundedCornerShape(16.dp)
+                    label = "cardScale"
+                )
+                val cardOffsetY by animateFloatAsState(
+                    targetValue = if (cardAnimated) 0f else 60f,
+                    animationSpec = tween(400, easing = EasingFunctions.EaseOutExpo),
+                    label = "cardOffsetY"
+                )
+                
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .graphicsLayer {
+                            this.alpha = cardAlpha
+                            this.scaleX = cardScale
+                            this.scaleY = cardScale
+                            translationY = cardOffsetY
+                        }
                 ) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Text(section.getLabel(strings), style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary)
-                        Spacer(Modifier.height(8.dp))
-                        SettingsContent(section, viewModel)
+                    if (state.backgroundSettings.enableHazeEffect && hazeState != null) {
+                        HazeSurface(
+                            hazeState = hazeState,
+                            enabled = true,
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(16.dp),
+                            color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = cardOpacity * 0.7f),
+                            hazeColor = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = cardOpacity * 0.7f)
+                        ) {
+                            Column(modifier = Modifier.padding(16.dp)) {
+                                Text(
+                                    section.getLabel(strings),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    fontWeight = FontWeight.Medium
+                                )
+                                Spacer(Modifier.height(12.dp))
+                                SettingsContent(section, viewModel)
+                            }
+                        }
+                    } else {
+                        Card(
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = cardOpacity)
+                            ),
+                            shape = RoundedCornerShape(16.dp),
+                            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+                        ) {
+                            Column(modifier = Modifier.padding(16.dp)) {
+                                Text(
+                                    section.getLabel(strings),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    fontWeight = FontWeight.Medium
+                                )
+                                Spacer(Modifier.height(12.dp))
+                                SettingsContent(section, viewModel)
+                            }
+                        }
                     }
                 }
             }
+            item { Spacer(Modifier.height(16.dp)) }
         }
     }
 }
@@ -285,216 +773,85 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
         when (section) {
             SettingsSection.General -> {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
-                            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
-                    ) {
-                        ListItem(
-                            headlineContent = { Text(strings.languageLabel) },
-                            trailingContent = {
-                                var expanded by remember { mutableStateOf(false) }
-                                Box {
-                                    TextButton(onClick = { expanded = true }) { 
-                                        Text(state.language.label) 
-                                    }
-                                    DropdownMenu(
-                                        expanded = expanded,
-                                        onDismissRequest = { expanded = false },
-                                        shape = RoundedCornerShape(16.dp)
-                                    ) {
-                                        AppLanguage.entries.forEach { lang ->
-                                            DropdownMenuItem(
-                                                text = { Text(lang.label) },
-                                                onClick = {
-                                                    viewModel.setLanguage(lang)
-                                                    expanded = false
-                                                },
-                                                trailingIcon = {
-                                                    if (state.language == lang) {
-                                                        Icon(Icons.Default.Check, contentDescription = null)
-                                                    }
-                                                }
-                                            )
-                                        }
-                                    }
-                                }
-                            },
-                            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-                        )
-                    }
+                    SettingsDropdownItem(
+                        headline = strings.languageLabel,
+                        selected = state.language,
+                        options = AppLanguage.entries.toList(),
+                        labelProvider = { it.label },
+                        onSelect = { viewModel.setLanguage(it) },
+                        cardOpacity = cardOpacity
+                    )
 
                     if (platform.type == PlatformType.Android) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
-                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
-                        ) {
-                            ListItem(
-                                headlineContent = { Text(strings.enableStreamingNotificationLabel) },
-                                trailingContent = {
-                                    Switch(
-                                        checked = state.enableStreamingNotification,
-                                        onCheckedChange = { viewModel.setEnableStreamingNotification(it) }
-                                    )
-                                },
-                                modifier = Modifier.clickable { viewModel.setEnableStreamingNotification(!state.enableStreamingNotification) },
-                                colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-                            )
-                        }
+                        SettingsSwitchItem(
+                            headline = strings.enableStreamingNotificationLabel,
+                            checked = state.enableStreamingNotification,
+                            onCheckedChange = { viewModel.setEnableStreamingNotification(it) },
+                            cardOpacity = cardOpacity
+                        )
 
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
-                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
-                        ) {
-                            ListItem(
-                                headlineContent = { Text(strings.keepScreenOnLabel) },
-                                supportingContent = { Text(strings.keepScreenOnDesc) },
-                                trailingContent = {
-                                    Switch(
-                                        checked = state.keepScreenOn,
-                                        onCheckedChange = { viewModel.setKeepScreenOn(it) }
-                                    )
-                                },
-                                modifier = Modifier.clickable { viewModel.setKeepScreenOn(!state.keepScreenOn) },
-                                colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-                            )
-                        }
+                        SettingsSwitchItem(
+                            headline = strings.keepScreenOnLabel,
+                            supporting = strings.keepScreenOnDesc,
+                            checked = state.keepScreenOn,
+                            onCheckedChange = { viewModel.setKeepScreenOn(it) },
+                            cardOpacity = cardOpacity
+                        )
                     }
 
                     if (platform.type == PlatformType.Desktop) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
-                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
-                        ) {
-                            ListItem(
-                                headlineContent = { Text(strings.autoStartLabel) },
-                                supportingContent = { Text(strings.autoStartDesc) },
-                                trailingContent = {
-                                    Switch(
-                                        checked = state.autoStart,
-                                        onCheckedChange = { viewModel.setAutoStart(it) }
-                                    )
-                                },
-                                modifier = Modifier.clickable { viewModel.setAutoStart(!state.autoStart) },
-                                colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-                            )
-                        }
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
-                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
-                        ) {
-                            ListItem(
-                                headlineContent = { Text(strings.closeActionLabel) },
-                                trailingContent = {
-                                    var expanded by remember { mutableStateOf(false) }
-                                    Box {
-                                        TextButton(onClick = { expanded = true }) {
-                                            Text(when (state.closeAction) {
-                                                CloseAction.Prompt -> strings.closeActionPrompt
-                                                CloseAction.Minimize -> strings.closeActionMinimize
-                                                CloseAction.Exit -> strings.closeActionExit
-                                            })
-                                        }
-                                        DropdownMenu(
-                                            expanded = expanded,
-                                            onDismissRequest = { expanded = false },
-                                            shape = RoundedCornerShape(16.dp)
-                                        ) {
-                                            CloseAction.entries.forEach { action ->
-                                                DropdownMenuItem(
-                                                    text = {
-                                                        Text(when (action) {
-                                                            CloseAction.Prompt -> strings.closeActionPrompt
-                                                            CloseAction.Minimize -> strings.closeActionMinimize
-                                                            CloseAction.Exit -> strings.closeActionExit
-                                                        })
-                                                    },
-                                                    onClick = {
-                                                        viewModel.setCloseAction(action)
-                                                        expanded = false
-                                                    },
-                                                    trailingIcon = {
-                                                        if (state.closeAction == action) {
-                                                            Icon(Icons.Default.Check, contentDescription = null)
-                                                        }
-                                                    }
-                                                )
-                                            }
-                                        }
-                                    }
-                                },
-                                colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-                            )
-                        }
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
-                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
-                        ) {
-                            ListItem(
-                                headlineContent = { Text(strings.pocketModeLabel) },
-                                supportingContent = { Text(strings.pocketModeDesc) },
-                                trailingContent = {
-                                    Switch(
-                                        checked = state.pocketMode,
-                                        onCheckedChange = { viewModel.setPocketMode(it) }
-                                    )
-                                },
-                                modifier = Modifier.clickable { viewModel.setPocketMode(!state.pocketMode) },
-                                colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-                            )
-                        }
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
-                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
-                        ) {
-                            ListItem(
-                                headlineContent = { Text(strings.floatingWindowLabel) },
-                                supportingContent = { Text(strings.floatingWindowDesc) },
-                                trailingContent = {
-                                    Switch(
-                                        checked = state.floatingWindowEnabled,
-                                        onCheckedChange = { viewModel.setFloatingWindowEnabled(it) }
-                                    )
-                                },
-                                modifier = Modifier.clickable { viewModel.setFloatingWindowEnabled(!state.floatingWindowEnabled) },
-                                colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-                            )
-                        }
+                        SettingsSwitchItem(
+                            headline = strings.autoStartLabel,
+                            supporting = strings.autoStartDesc,
+                            checked = state.autoStart,
+                            onCheckedChange = { viewModel.setAutoStart(it) },
+                            cardOpacity = cardOpacity
+                        )
+                        SettingsDropdownItem(
+                            headline = strings.closeActionLabel,
+                            selected = state.closeAction,
+                            options = CloseAction.entries.toList(),
+                            labelProvider = { action ->
+                                when (action) {
+                                    CloseAction.Prompt -> strings.closeActionPrompt
+                                    CloseAction.Minimize -> strings.closeActionMinimize
+                                    CloseAction.Exit -> strings.closeActionExit
+                                }
+                            },
+                            onSelect = { viewModel.setCloseAction(it) },
+                            cardOpacity = cardOpacity
+                        )
+                        SettingsSwitchItem(
+                            headline = strings.pocketModeLabel,
+                            supporting = strings.pocketModeDesc,
+                            checked = state.pocketMode,
+                            onCheckedChange = { viewModel.setPocketMode(it) },
+                            cardOpacity = cardOpacity
+                        )
+                        SettingsSwitchItem(
+                            headline = strings.useSystemTitleBarLabel,
+                            supporting = strings.useSystemTitleBarDesc,
+                            checked = state.useSystemTitleBar,
+                            onCheckedChange = { viewModel.setUseSystemTitleBar(it) },
+                            cardOpacity = cardOpacity
+                        )
+                        SettingsSwitchItem(
+                            headline = strings.floatingWindowLabel,
+                            supporting = strings.floatingWindowDesc,
+                            checked = state.floatingWindowEnabled,
+                            onCheckedChange = { viewModel.setFloatingWindowEnabled(it) },
+                            cardOpacity = cardOpacity
+                        )
                     }
 
                     // Auto check update toggle (all platforms)
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
-                            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
-                    ) {
-                        ListItem(
-                            headlineContent = { Text(strings.autoCheckUpdateLabel) },
-                            supportingContent = { Text(strings.autoCheckUpdateDesc) },
-                            trailingContent = {
-                                Switch(
-                                    checked = state.autoCheckUpdate,
-                                    onCheckedChange = { viewModel.setAutoCheckUpdate(it) }
-                                )
-                            },
-                            modifier = Modifier.clickable { viewModel.setAutoCheckUpdate(!state.autoCheckUpdate) },
-                            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-                        )
-                    }
+                    SettingsSwitchItem(
+                        headline = strings.autoCheckUpdateLabel,
+                        supporting = strings.autoCheckUpdateDesc,
+                        checked = state.autoCheckUpdate,
+                        onCheckedChange = { viewModel.setAutoCheckUpdate(it) },
+                        cardOpacity = cardOpacity
+                    )
                 }
             }
             SettingsSection.Appearance -> {
@@ -502,7 +859,7 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(MaterialTheme.shapes.medium)
                             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                     ) {
                         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -528,70 +885,74 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                         }
                     }
 
-                    if (platform.type == PlatformType.Android) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
-                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
-                        ) {
-                            ListItem(
-                                headlineContent = { Text(strings.useDynamicColorLabel) },
-                                trailingContent = {
-                                    Switch(
-                                        checked = state.useDynamicColor,
-                                        onCheckedChange = { viewModel.setUseDynamicColor(it) }
-                                    )
-                                },
-                                modifier = Modifier.clickable { viewModel.setUseDynamicColor(!state.useDynamicColor) },
-                                colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-                            )
-                        }
-                    }
-
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
-                            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
-                    ) {
-                        ListItem(
-                            headlineContent = { Text(strings.oledPureBlackLabel) },
-                            supportingContent = { Text(strings.oledPureBlackDesc) },
-                            trailingContent = {
-                                Switch(
-                                    checked = state.oledPureBlack,
-                                    onCheckedChange = { viewModel.setOledPureBlack(it) }
-                                )
-                            },
-                            modifier = Modifier.clickable { viewModel.setOledPureBlack(!state.oledPureBlack) },
-                            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+                    // 动态取色选项：Android 和 Windows 支持
+                    if (platform.type == PlatformType.Android || isDynamicColorSupported()) {
+                        SettingsSwitchItem(
+                            headline = strings.useDynamicColorLabel,
+                            supporting = strings.useDynamicColorDesc,
+                            checked = state.useDynamicColor,
+                            onCheckedChange = { viewModel.setUseDynamicColor(it) },
+                            cardOpacity = cardOpacity
                         )
                     }
 
+                    SettingsSwitchItem(
+                        headline = strings.oledPureBlackLabel,
+                        supporting = strings.oledPureBlackDesc,
+                        checked = state.oledPureBlack,
+                        onCheckedChange = { viewModel.setOledPureBlack(it) },
+                        cardOpacity = cardOpacity
+                    )
+
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(MaterialTheme.shapes.medium)
                             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                     ) {
                         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                             Text(strings.themeColorLabel, style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary)
                             val isSeedColorEnabled = !state.useDynamicColor
+                            // 当开启动态取色时，显示当前实际应用的主题主色（动态颜色）
+                            val displayColor = if (state.useDynamicColor) {
+                                MaterialTheme.colorScheme.primary.toArgb().toLong() and 0xFFFFFFFF
+                            } else {
+                                state.seedColor
+                            }
                             ColorSelectorWithPicker(
-                                selectedColor = state.seedColor,
+                                selectedColor = displayColor,
                                 presetColors = seedColors,
                                 onColorSelected = { viewModel.setSeedColor(it) },
                                 enabled = isSeedColorEnabled,
+                                disabledHint = strings.dynamicColorEnabledHint,
                                 modifier = Modifier.fillMaxWidth()
                             )
+                        }
+
+                        // 开启动态取色时，显示遮罩覆盖整个框
+                        if (state.useDynamicColor) {
+                            Box(
+                                modifier = Modifier
+                                    .matchParentSize()
+                                    .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.85f))
+                                    .clickable(enabled = false) { },
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = strings.dynamicColorEnabledHint,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.padding(horizontal = 24.dp)
+                                )
+                            }
                         }
                     }
 
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(MaterialTheme.shapes.medium)
                             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                     ) {
                         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -623,7 +984,7 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(MaterialTheme.shapes.medium)
                             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                     ) {
                         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -711,7 +1072,7 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
+                                .clip(MaterialTheme.shapes.medium)
                                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                         ) {
                             ListItem(
@@ -733,7 +1094,7 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
+                                .clip(MaterialTheme.shapes.medium)
                                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                         ) {
                             ListItem(
@@ -748,7 +1109,7 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                                         DropdownMenu(
                                             expanded = expanded,
                                             onDismissRequest = { expanded = false },
-                                            shape = RoundedCornerShape(16.dp)
+                                            shape = MaterialTheme.shapes.medium
                                         ) {
                                             SampleRate.entries.forEach { rate ->
                                                 DropdownMenuItem(text = { Text("${rate.value} Hz") }, onClick = { viewModel.setSampleRate(rate); expanded = false })
@@ -762,7 +1123,7 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
+                                .clip(MaterialTheme.shapes.medium)
                                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                         ) {
                             ListItem(
@@ -777,7 +1138,7 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                                         DropdownMenu(
                                             expanded = expanded,
                                             onDismissRequest = { expanded = false },
-                                            shape = RoundedCornerShape(16.dp)
+                                            shape = MaterialTheme.shapes.medium
                                         ) {
                                             ChannelCount.entries.forEach { count ->
                                                 DropdownMenuItem(text = { Text(count.label) }, onClick = { viewModel.setChannelCount(count); expanded = false })
@@ -791,13 +1152,14 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
+                                .clip(MaterialTheme.shapes.medium)
                                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                         ) {
                             ListItem(
                                 headlineContent = { Text(strings.audioFormatLabel) },
                                 trailingContent = {
                                     var expanded by remember { mutableStateOf(false) }
+                                    val formats = availableAudioFormats()
                                     Box {
                                         TextButton(
                                             onClick = { expanded = true },
@@ -806,9 +1168,9 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                                         DropdownMenu(
                                             expanded = expanded,
                                             onDismissRequest = { expanded = false },
-                                            shape = RoundedCornerShape(16.dp)
+                                            shape = MaterialTheme.shapes.medium
                                         ) {
-                                            AudioFormat.entries.forEach { format ->
+                                            formats.forEach { format ->
                                                 DropdownMenuItem(text = { Text(format.label) }, onClick = { viewModel.setAudioFormat(format); expanded = false })
                                             }
                                         }
@@ -817,128 +1179,114 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                                 colors = ListItemDefaults.colors(containerColor = Color.Transparent)
                             )
                         }
+                        
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
+                                .clip(MaterialTheme.shapes.medium)
                                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                         ) {
                             ListItem(
-                                headlineContent = { Text(strings.androidAudioProcessingLabel) },
-                                supportingContent = { Text(strings.androidAudioProcessingDesc) },
+                                headlineContent = { Text(strings.audioSourceLabel) },
                                 trailingContent = {
-                                    Switch(
-                                        checked = state.enableNS || state.enableAGC,
-                                        onCheckedChange = { viewModel.setAndroidAudioProcessing(it) }
-                                    )
+                                    var expanded by remember { mutableStateOf(false) }
+                                    val audioSourceOptions = getAudioSourceOptions()
+                                    val currentSource = audioSourceOptions.find { it.name == state.androidAudioSourceName } ?: audioSourceOptions.firstOrNull()
+                                    if (audioSourceOptions.isNotEmpty() && currentSource != null) {
+                                        Box {
+                                            TextButton(onClick = { expanded = true }) { Text(currentSource.label) }
+                                            DropdownMenu(
+                                                expanded = expanded,
+                                                onDismissRequest = { expanded = false },
+                                                shape = MaterialTheme.shapes.medium
+                                            ) {
+                                                audioSourceOptions.forEach { source ->
+                                                    DropdownMenuItem(
+                                                        text = { Text(source.label) },
+                                                        onClick = { viewModel.setAndroidAudioSource(source.name); expanded = false },
+                                                        trailingIcon = { if (currentSource == source) Icon(Icons.Default.Check, contentDescription = null) }
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
                                 },
-                                modifier = Modifier.clickable { viewModel.setAndroidAudioProcessing(!(state.enableNS || state.enableAGC)) },
                                 colors = ListItemDefaults.colors(containerColor = Color.Transparent)
                             )
                         }
                     }
                 } else {
+                    // Desktop audio settings
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        // 1. 增益 (Amplifier) - 第一行显示
+                        // 1. 降噪开关
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
-                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
-                        ) {
-                            Row(
-                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp).fillMaxWidth(),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(12.dp)
-                            ) {
-                                Text(strings.gainLabel, style = MaterialTheme.typography.titleSmall)
-
-                                Slider(
-                                    value = state.amplification,
-                                    onValueChange = { viewModel.setAmplification(it) },
-                                    valueRange = -50.0f..50.0f,
-                                    modifier = Modifier.weight(1f)
-                                )
-
-                                // 固定宽度避免进度条左右移动，"-50 dB" 是最宽的情况
-                                val gainText = if (state.amplification >= 0) "+${state.amplification.toInt()} dB" else "${state.amplification.toInt()} dB"
-                                Text(
-                                    gainText,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    modifier = Modifier.width(60.dp),
-                                    textAlign = TextAlign.End
-                                )
-                            }
-                        }
-
-                        // 2. 降噪 (Noise Suppression)
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
+                                .clip(MaterialTheme.shapes.medium)
                                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                         ) {
                             ListItem(
                                 headlineContent = { Text(strings.enableNsLabel) },
-                                trailingContent = { Switch(checked = state.enableNS, onCheckedChange = { viewModel.setEnableNS(it) }) },
+                                trailingContent = { 
+                                    Switch(
+                                        checked = state.enableNS, 
+                                        onCheckedChange = { viewModel.setEnableNS(it) }
+                                    ) 
+                                },
                                 modifier = Modifier.clickable { viewModel.setEnableNS(!state.enableNS) },
                                 colors = ListItemDefaults.colors(containerColor = Color.Transparent)
                             )
                         }
                         if (state.enableNS) {
-                            var showNsTypeHelp by remember { mutableStateOf(false) }
-
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .clip(RoundedCornerShape(12.dp))
+                                    .clip(MaterialTheme.shapes.medium)
                                     .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                             ) {
-                                ListItem(
-                                    headlineContent = { Text(strings.nsTypeLabel) },
-                                    trailingContent = {
-                                        Row(verticalAlignment = Alignment.CenterVertically) {
-                                            IconButton(onClick = { showNsTypeHelp = true }) {
-                                                Icon(
-                                                    imageVector = Icons.Default.Info,
-                                                    contentDescription = "降噪算法说明",
-                                                )
-                                            }
-
-                                            var expanded by remember { mutableStateOf(false) }
-                                            Box {
-                                                TextButton(onClick = { expanded = true }) { Text(state.nsType.name) }
-                                                DropdownMenu(
-                                                    expanded = expanded,
-                                                    onDismissRequest = { expanded = false },
-                                                    shape = RoundedCornerShape(16.dp)
-                                                ) {
-                                                    NoiseReductionType.entries.forEach { type ->
-                                                        DropdownMenuItem(text = { Text(type.name) }, onClick = { viewModel.setNsType(type); expanded = false })
-                                                    }
-                                                }
-                                            }
+                                Column(modifier = Modifier.padding(16.dp)) {
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Text(strings.nsTypeLabel, style = MaterialTheme.typography.bodyMedium)
+                                        var showHelp by remember { mutableStateOf(false) }
+                                        IconButton(onClick = { showHelp = true }) {
+                                            Icon(Icons.Default.Info, contentDescription = "Help", modifier = Modifier.size(20.dp))
                                         }
-                                    },
-                                    colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-                                )
-                            }
-
-                            if (showNsTypeHelp) {
-                                NoiseReductionHelpPopup(onDismiss = { showNsTypeHelp = false })
+                                        if (showHelp) {
+                                            NoiseReductionHelpPopup(onDismiss = { showHelp = false })
+                                        }
+                                    }
+                                    LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        items(NoiseReductionType.entries) { type ->
+                                            FilterChip(
+                                                selected = state.nsType == type,
+                                                onClick = { viewModel.setNsType(type) },
+                                                label = { Text(type.label) }
+                                            )
+                                        }
+                                    }
+                                }
                             }
                         }
 
-                        // 3. 去混响 (Dereverb)
+                        // 2. 去混响
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
+                                .clip(MaterialTheme.shapes.medium)
                                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                         ) {
                             ListItem(
                                 headlineContent = { Text(strings.enableDereverbLabel) },
-                                trailingContent = { Switch(checked = state.enableDereverb, onCheckedChange = { viewModel.setEnableDereverb(it) }) },
+                                trailingContent = { 
+                                    Switch(
+                                        checked = state.enableDereverb, 
+                                        onCheckedChange = { viewModel.setEnableDereverb(it) }
+                                    ) 
+                                },
                                 modifier = Modifier.clickable { viewModel.setEnableDereverb(!state.enableDereverb) },
                                 colors = ListItemDefaults.colors(containerColor = Color.Transparent)
                             )
@@ -947,15 +1295,57 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .clip(RoundedCornerShape(12.dp))
+                                    .clip(MaterialTheme.shapes.medium)
                                     .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                             ) {
                                 Column(modifier = Modifier.padding(16.dp)) {
-                                    Text("${strings.dereverbLevelLabel}: ${((state.dereverbLevel * 100).toInt()) / 100f}", style = MaterialTheme.typography.bodySmall)
+                                    Text("${strings.dereverbLevelLabel}: ${(state.dereverbLevel * 100).toInt()}%", style = MaterialTheme.typography.bodySmall)
                                     Slider(
                                         value = state.dereverbLevel,
                                         onValueChange = { viewModel.setDereverbLevel(it) },
-                                        valueRange = 0.0f..1.0f
+                                        valueRange = 0f..1f
+                                    )
+                                }
+                            }
+                        }
+
+                        // 3. 放大器
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(MaterialTheme.shapes.medium)
+                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
+                        ) {
+                            ListItem(
+                                headlineContent = { Text(strings.amplificationLabel) },
+                                supportingContent = { Text(strings.gainLabel) },
+                                trailingContent = { 
+                                    Switch(
+                                        checked = state.amplification > 0, 
+                                        onCheckedChange = { enabled ->
+                                            viewModel.setAmplification(if (enabled) 2.0f else 0f)
+                                        }
+                                    ) 
+                                },
+                                modifier = Modifier.clickable { 
+                                    viewModel.setAmplification(if (state.amplification > 0) 0f else 2.0f)
+                                },
+                                colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+                            )
+                        }
+                        if (state.amplification > 0) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(MaterialTheme.shapes.medium)
+                                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
+                            ) {
+                                Column(modifier = Modifier.padding(16.dp)) {
+                                    Text("${strings.amplificationMultiplierLabel}: ${state.amplification}x", style = MaterialTheme.typography.bodySmall)
+                                    Slider(
+                                        value = state.amplification,
+                                        onValueChange = { viewModel.setAmplification(it) },
+                                        valueRange = 0.5f..5f
                                     )
                                 }
                             }
@@ -965,12 +1355,17 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
+                                .clip(MaterialTheme.shapes.medium)
                                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                         ) {
                             ListItem(
                                 headlineContent = { Text(strings.enableAgcLabel) },
-                                trailingContent = { Switch(checked = state.enableAGC, onCheckedChange = { viewModel.setEnableAGC(it) }) },
+                                trailingContent = { 
+                                    Switch(
+                                        checked = state.enableAGC, 
+                                        onCheckedChange = { viewModel.setEnableAGC(it) }
+                                    ) 
+                                },
                                 modifier = Modifier.clickable { viewModel.setEnableAGC(!state.enableAGC) },
                                 colors = ListItemDefaults.colors(containerColor = Color.Transparent)
                             )
@@ -979,7 +1374,7 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .clip(RoundedCornerShape(12.dp))
+                                    .clip(MaterialTheme.shapes.medium)
                                     .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                             ) {
                                 Column(modifier = Modifier.padding(16.dp)) {
@@ -997,12 +1392,17 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(12.dp))
+                                .clip(MaterialTheme.shapes.medium)
                                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                         ) {
                             ListItem(
                                 headlineContent = { Text(strings.enableVadLabel) },
-                                trailingContent = { Switch(checked = state.enableVAD, onCheckedChange = { viewModel.setEnableVAD(it) }) },
+                                trailingContent = { 
+                                    Switch(
+                                        checked = state.enableVAD, 
+                                        onCheckedChange = { viewModel.setEnableVAD(it) }
+                                    ) 
+                                },
                                 modifier = Modifier.clickable { viewModel.setEnableVAD(!state.enableVAD) },
                                 colors = ListItemDefaults.colors(containerColor = Color.Transparent)
                             )
@@ -1011,7 +1411,7 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .clip(RoundedCornerShape(12.dp))
+                                    .clip(MaterialTheme.shapes.medium)
                                     .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                             ) {
                                 Column(modifier = Modifier.padding(16.dp)) {
@@ -1026,6 +1426,9 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                         }
                     }
                 }
+            }
+            SettingsSection.Plugins -> {
+                PluginSettingsContent(viewModel, cardOpacity)
             }
             SettingsSection.About -> {
                 val uriHandler = LocalUriHandler.current
@@ -1082,20 +1485,20 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(MaterialTheme.shapes.medium)
                             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                     ) {
                         ListItem(
                             headlineContent = { Text(strings.developerLabel) },
                             supportingContent = { Text("LanRhyme、ChinsaaWei") },
-                            leadingContent = { Icon(painterResource(Res.drawable.icon_star_fall_mini), null,modifier = Modifier.size(24.dp)) },
+                            leadingContent = { Icon(Icons.Rounded.Person, null,modifier = Modifier.size(24.dp)) },
                             colors = ListItemDefaults.colors(containerColor = Color.Transparent)
                         )
                     }
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(MaterialTheme.shapes.medium)
                             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                     ) {
                         ListItem(
@@ -1108,20 +1511,20 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                                     modifier = Modifier.clickable { uriHandler.openUri("https://github.com/LanRhyme/MicYou") }
                                 ) 
                             },
-                            leadingContent = { Icon(painterResource(Res.drawable.icon_planet), null,modifier = Modifier.size(24.dp)) },
+                            leadingContent = { Icon(Icons.Rounded.Language, null,modifier = Modifier.size(24.dp)) },
                             colors = ListItemDefaults.colors(containerColor = Color.Transparent)
                         )
                     }
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(MaterialTheme.shapes.medium)
                             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                     ) {
                         ListItem(
                             headlineContent = { Text(strings.contributorsLabel) },
                             supportingContent = { Text(strings.contributorsDesc) },
-                            leadingContent = { Icon(painterResource(Res.drawable.icon_star_fall), null,modifier = Modifier.size(24.dp)) },
+                            leadingContent = { Icon(Icons.Rounded.People, null,modifier = Modifier.size(24.dp)) },
                             modifier = Modifier.clickable { showContributorsDialog = true },
                             colors = ListItemDefaults.colors(containerColor = Color.Transparent)
                         )
@@ -1129,13 +1532,13 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(MaterialTheme.shapes.medium)
                             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                     ) {
                         ListItem(
                             headlineContent = { Text(strings.versionLabel) },
                             supportingContent = { Text(getAppVersion()) },
-                            leadingContent = { Icon(painterResource(Res.drawable.icon_compass), null,modifier = Modifier.size(24.dp)) },
+                            leadingContent = { Icon(Icons.Rounded.Info, null,modifier = Modifier.size(24.dp)) },
                             trailingContent = {
                                 TextButton(onClick = { viewModel.checkUpdateManual() }) {
                                     Text(strings.checkUpdate)
@@ -1147,13 +1550,13 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(MaterialTheme.shapes.medium)
                             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                     ) {
                         ListItem(
                             headlineContent = { Text(strings.openSourceLicense) },
                             supportingContent = { Text(strings.viewLibraries) },
-                            leadingContent = { Icon(painterResource(Res.drawable.icon_creative), null,modifier = Modifier.size(24.dp)) },
+                            leadingContent = { Icon(Icons.Rounded.Description, null,modifier = Modifier.size(24.dp)) },
                             modifier = Modifier.clickable { showLicenseDialog = true },
                             colors = ListItemDefaults.colors(containerColor = Color.Transparent)
                         )
@@ -1161,13 +1564,13 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(MaterialTheme.shapes.medium)
                             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = cardOpacity * 0.5f))
                     ) {
                         ListItem(
                             headlineContent = { Text(strings.exportLog) },
                             supportingContent = { Text(strings.exportLogDesc) },
-                            leadingContent = { Icon(painterResource(Res.drawable.icon_file), null,modifier = Modifier.size(24.dp)) },
+                            leadingContent = { Icon(Icons.AutoMirrored.Rounded.TextSnippet, null,modifier = Modifier.size(24.dp)) },
                             modifier = Modifier.clickable {
                                 viewModel.exportLog { path ->
                                     if (path != null) {
@@ -1186,7 +1589,7 @@ fun SettingsContent(section: SettingsSection, viewModel: MainViewModel) {
                     colors = CardDefaults.cardColors(
                         containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = cardOpacity * 0.7f)
                     ),
-                    shape = RoundedCornerShape(12.dp)
+                    shape = MaterialTheme.shapes.medium
                 ) {
                      Column(modifier = Modifier.padding(16.dp)) {
                         Text(strings.softwareIntro, style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSecondaryContainer)
@@ -1208,6 +1611,7 @@ fun SettingsSection.getLabel(strings: AppStrings): String {
         SettingsSection.General -> strings.generalSection
         SettingsSection.Appearance -> strings.appearanceSection
         SettingsSection.Audio -> strings.audioSection
+        SettingsSection.Plugins -> strings.pluginsSection
         SettingsSection.About -> strings.aboutSection
     }
 }
@@ -1224,7 +1628,7 @@ fun NoiseReductionHelpPopup(onDismiss: () -> Unit) {
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
-            shape = RoundedCornerShape(16.dp),
+            shape = MaterialTheme.shapes.medium,
             colors = CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surface
             )
@@ -1313,13 +1717,13 @@ private fun AlgorithmInfoItem(
                 title,
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurface,
-                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
+                fontWeight = FontWeight.Bold
             )
             if (recommendation.isNotEmpty()) {
                 Spacer(modifier = Modifier.width(8.dp))
                 Surface(
                     color = if (isRecommended) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.secondaryContainer,
-                    shape = RoundedCornerShape(4.dp)
+                    shape = MaterialTheme.shapes.extraSmall
                 ) {
                     Text(
                         recommendation,

--- a/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/lanrhyme/micyou/MainViewModel.kt
@@ -2,6 +2,8 @@ package com.lanrhyme.micyou
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.lanrhyme.micyou.plugin.PluginHost
+import com.lanrhyme.micyou.plugin.PluginInfo
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -67,6 +69,9 @@ data class AppUiState(
     
     val amplification: Float = 0.0f,
 
+    // Android only: Audio source selection (stored as string to avoid enum dependency)
+    val androidAudioSourceName: String = "Unprocessed",
+
     val audioConfigRevision: Int = 0,
 
     val enableStreamingNotification: Boolean = true,
@@ -103,8 +108,15 @@ data class AppUiState(
     // Floating Window Settings (Desktop only)
     val floatingWindowEnabled: Boolean = false,
     
-    // First Launch Dialog
-    val showFirstLaunchDialog: Boolean = false
+    // System Title Bar (Desktop only)
+    val useSystemTitleBar: Boolean = false,
+    val showFirstLaunchDialog: Boolean = false,
+    
+    val plugins: List<PluginInfo> = emptyList(),
+    
+    // Plugin Sync Warning
+    val showPluginSyncWarning: Boolean = false,
+    val missingPlugins: List<MissingPluginInfo> = emptyList()
 )
 
 enum class CloseAction(val label: String) {
@@ -120,9 +132,72 @@ class MainViewModel : ViewModel() {
     val audioLevels = audioEngine.audioLevels
     private val settings = SettingsFactory.getSettings()
     private val updateChecker = UpdateChecker()
+    private var pluginManager: PluginManagerProvider? = null
+    private lateinit var pluginHost: PluginHost
 
     init {
-        // Load settings
+        // Load settings first to get the language
+        val initialLanguage = try { 
+            AppLanguage.valueOf(settings.getString("language", AppLanguage.System.name)) 
+        } catch(e: Exception) { 
+            AppLanguage.System 
+        }
+        
+        // Create plugin host
+        pluginHost = createPluginHost(
+            audioEngine = audioEngine,
+            showSnackbarCallback = { message ->
+                _uiState.update { it.copy(snackbarMessage = message) }
+            },
+            showNotificationCallback = { title, message ->
+                Logger.i("PluginHost", "Notification: $title - $message")
+            }
+        )
+        
+        // Create plugin manager with language provider
+        pluginManager = createPluginManager(
+            pluginsDirPath = getPluginsDirPath(),
+            pluginHost = pluginHost,
+            appLanguageProvider = { 
+                val lang = _uiState.value.language
+                when (lang) {
+                    AppLanguage.Chinese -> "zh"
+                    AppLanguage.ChineseTraditional -> "zh-TW"
+                    AppLanguage.Cantonese -> "zh-HK"
+                    AppLanguage.English -> "en"
+                    AppLanguage.ChineseCat -> "cat"
+                    AppLanguage.ChineseHard -> "zh_hard"
+                    AppLanguage.System -> {
+                        val locale = java.util.Locale.getDefault().toLanguageTag()
+                        when {
+                            locale.startsWith("zh-HK") -> "zh-HK"
+                            locale.startsWith("zh-TW") || locale.startsWith("zh-Hant") -> "zh-TW"
+                            locale.startsWith("zh") -> "zh"
+                            else -> "en"
+                        }
+                    }
+                }
+            },
+            appStringProvider = { key ->
+                val strings = getStrings(_uiState.value.language)
+                // Use reflection to get the string value from AppStrings
+                try {
+                    val field = AppStrings::class.java.getDeclaredField(key)
+                    field.get(strings) as? String ?: key
+                } catch (e: Exception) {
+                    key
+                }
+            }
+        )
+        
+        pluginManager?.let { pm ->
+            viewModelScope.launch {
+                pm.plugins.collect { pluginList ->
+                    _uiState.update { it.copy(plugins = pluginList) }
+                }
+            }
+        }
+        // Load other settings
         val savedModeName = settings.getString("connection_mode", ConnectionMode.Wifi.name)
         val savedMode = when (savedModeName) {
             "WifiUdp" -> ConnectionMode.Bluetooth
@@ -135,9 +210,8 @@ class MainViewModel : ViewModel() {
         val savedThemeModeName = settings.getString("theme_mode", ThemeMode.System.name)
         val savedThemeMode = try { ThemeMode.valueOf(savedThemeModeName) } catch(e: Exception) { ThemeMode.System }
         
-        val savedSeedColor = settings.getLong("seed_color", 0xFF4285F4)
-        
-        val savedMonitoring = settings.getBoolean("monitoring_enabled", false)
+        val savedMonitoring = false
+        settings.putBoolean("monitoring_enabled", false)
 
         val savedSampleRateName = settings.getString("sample_rate", SampleRate.Rate48000.name)
         val savedSampleRate = try { SampleRate.valueOf(savedSampleRateName) } catch(e: Exception) { SampleRate.Rate48000 }
@@ -145,8 +219,10 @@ class MainViewModel : ViewModel() {
         val savedChannelCountName = settings.getString("channel_count", ChannelCount.Stereo.name)
         val savedChannelCount = try { ChannelCount.valueOf(savedChannelCountName) } catch(e: Exception) { ChannelCount.Stereo }
 
-        val savedAudioFormatName = settings.getString("audio_format", AudioFormat.PCM_FLOAT.name)
-        val savedAudioFormat = try { AudioFormat.valueOf(savedAudioFormatName) } catch(e: Exception) { AudioFormat.PCM_FLOAT }
+        val savedAudioFormatName = settings.getString("audio_format", defaultAudioFormat().name)
+        val savedAudioFormat = try { AudioFormat.valueOf(savedAudioFormatName) } catch(e: Exception) { defaultAudioFormat() }
+        // 校验已保存的格式在当前设备是否可用，不可用则回退到安全默认值
+        val effectiveAudioFormat = if (availableAudioFormats().contains(savedAudioFormat)) savedAudioFormat else defaultAudioFormat()
 
         val savedNS = settings.getBoolean("enable_ns", false)
         val savedNSTypeName = settings.getString("ns_type", NoiseReductionType.Ulunas.name)
@@ -160,8 +236,10 @@ class MainViewModel : ViewModel() {
         
         val savedDereverb = settings.getBoolean("enable_dereverb", false)
         val savedDereverbLevel = settings.getFloat("dereverb_level", 0.5f)
-        
+
         val savedAmplification = settings.getFloat("amplification", 0.0f)
+
+        val savedAndroidAudioSourceName = settings.getString("android_audio_source", "Unprocessed")
 
         val savedEnableStreamingNotification = settings.getBoolean("enable_streaming_notification", true)
         val savedKeepScreenOn = settings.getBoolean("keep_screen_on", false)
@@ -169,10 +247,9 @@ class MainViewModel : ViewModel() {
         
         val savedAutoStart = settings.getBoolean("auto_start", false)
 
-        val savedLanguageName = settings.getString("language", AppLanguage.System.name)
-        val savedLanguage = try { AppLanguage.valueOf(savedLanguageName) } catch(e: Exception) { AppLanguage.System }
-
         val savedUseDynamicColor = settings.getBoolean("use_dynamic_color", false)
+        val savedSeedColor = settings.getLong("seed_color", 0xFF4285F4)
+
         val savedBluetoothAddress = settings.getString("bluetooth_address", "")
         val savedIsAutoConfig = settings.getBoolean("is_auto_config", true)
         val savedMinimizeToTray = settings.getBoolean("minimize_to_tray", true)
@@ -198,10 +275,10 @@ class MainViewModel : ViewModel() {
         
         val savedFloatingWindowEnabled = settings.getBoolean("floating_window_enabled", false)
         val savedAutoCheckUpdate = settings.getBoolean("auto_check_update", true)
+        val savedUseSystemTitleBar = settings.getBoolean("use_system_title_bar", false)
         
         val hasLaunchedBefore = settings.getBoolean("has_launched_before", false)
-        val isDesktop = getPlatform().type == PlatformType.Desktop
-        val shouldShowFirstLaunchDialog = !hasLaunchedBefore && isDesktop
+        val shouldShowFirstLaunchDialog = !hasLaunchedBefore
         if (shouldShowFirstLaunchDialog) {
             settings.putBoolean("has_launched_before", true)
         }
@@ -216,7 +293,7 @@ class MainViewModel : ViewModel() {
                 monitoringEnabled = savedMonitoring,
                 sampleRate = savedSampleRate,
                 channelCount = savedChannelCount,
-                audioFormat = savedAudioFormat,
+                audioFormat = effectiveAudioFormat,
                 enableNS = savedNS,
                 nsType = savedNSType,
                 enableAGC = savedAGC,
@@ -226,11 +303,12 @@ class MainViewModel : ViewModel() {
                 enableDereverb = savedDereverb,
                 dereverbLevel = savedDereverbLevel,
                 amplification = savedAmplification,
+                androidAudioSourceName = savedAndroidAudioSourceName,
                 autoStart = savedAutoStart,
                 enableStreamingNotification = savedEnableStreamingNotification,
                 keepScreenOn = savedKeepScreenOn,
                 oledPureBlack = savedOledPureBlack,
-                language = savedLanguage,
+                language = initialLanguage,
                 useDynamicColor = savedUseDynamicColor,
                 bluetoothAddress = savedBluetoothAddress,
                 isAutoConfig = savedIsAutoConfig,
@@ -247,6 +325,7 @@ class MainViewModel : ViewModel() {
                 ),
                 floatingWindowEnabled = savedFloatingWindowEnabled,
                 autoCheckUpdate = savedAutoCheckUpdate,
+                useSystemTitleBar = savedUseSystemTitleBar,
                 showFirstLaunchDialog = shouldShowFirstLaunchDialog
             ) 
         }
@@ -268,6 +347,9 @@ class MainViewModel : ViewModel() {
         
         viewModelScope.launch {
             audioEngine.lastError.collect { error ->
+                if (error != null) {
+                    Logger.e("MainViewModel", "AudioEngine error: $error")
+                }
                 _uiState.update { it.copy(errorMessage = error) }
             }
         }
@@ -468,6 +550,11 @@ class MainViewModel : ViewModel() {
     fun setFloatingWindowEnabled(enabled: Boolean) {
         _uiState.update { it.copy(floatingWindowEnabled = enabled) }
         settings.putBoolean("floating_window_enabled", enabled)
+    }
+
+    fun setUseSystemTitleBar(enabled: Boolean) {
+        _uiState.update { it.copy(useSystemTitleBar = enabled) }
+        settings.putBoolean("use_system_title_bar", enabled)
     }
 
     fun handleCloseRequest(onExit: () -> Unit, onHide: () -> Unit) {
@@ -715,7 +802,14 @@ class MainViewModel : ViewModel() {
         settings.putFloat("amplification", amp)
         updateAudioEngineConfig()
     }
-    
+
+    fun setAndroidAudioSource(sourceName: String) {
+        _uiState.update { it.copy(androidAudioSourceName = sourceName) }
+        settings.putString("android_audio_source", sourceName)
+        // Call Android-specific method to update audio source
+        audioEngine.setAudioSource(sourceName)
+    }
+
     fun setAutoStart(enabled: Boolean) {
         _uiState.update { it.copy(autoStart = enabled) }
         settings.putBoolean("auto_start", enabled)
@@ -803,5 +897,39 @@ class MainViewModel : ViewModel() {
         BackgroundImagePicker.pickImage { path ->
             path?.let { setBackgroundImage(it) }
         }
+    }
+    
+    fun importPlugin(filePath: String, onResult: (Result<PluginInfo>) -> Unit) {
+        viewModelScope.launch {
+            val result = pluginManager?.importPlugin(filePath) 
+                ?: Result.failure(Exception("Plugins not supported on this platform"))
+            onResult(result)
+        }
+    }
+    
+    fun enablePlugin(pluginId: String) {
+        viewModelScope.launch {
+            pluginManager?.enablePlugin(pluginId)
+        }
+    }
+    
+    fun disablePlugin(pluginId: String) {
+        viewModelScope.launch {
+            pluginManager?.disablePlugin(pluginId)
+        }
+    }
+    
+    fun deletePlugin(pluginId: String) {
+        viewModelScope.launch {
+            pluginManager?.deletePlugin(pluginId)
+        }
+    }
+    
+    fun getPluginUIProvider(pluginId: String): Any? {
+        return pluginManager?.getPluginUIProvider(pluginId)
+    }
+    
+    fun getPluginSettingsProvider(pluginId: String): Any? {
+        return pluginManager?.getPluginSettingsProvider(pluginId)
     }
 }

--- a/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/lanrhyme/micyou/Platform.jvm.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
 import com.lanrhyme.micyou.platform.FirewallManager
 import com.lanrhyme.micyou.platform.PlatformInfo
+import com.lanrhyme.micyou.platform.WindowsAccentColorExtractor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.net.InetAddress
@@ -60,7 +61,7 @@ class JVMPlatform: Platform {
 actual fun getPlatform(): Platform = JVMPlatform()
 
 actual fun uninstallVBCable() {
-    VBCableManager.uninstallVBCable()
+    VirtualAudioDeviceManager.uninstallVBCable()
 }
 
 actual fun getAppVersion(): String {
@@ -98,7 +99,40 @@ actual suspend fun addFirewallRule(port: Int, protocol: String): Result<Unit> =
         }
     }
 
+actual fun isDynamicColorSupported(): Boolean {
+    // 目前只为 Windows 提供莫奈取色
+    return PlatformInfo.isWindows
+}
+
+actual fun getDynamicSeedColor(): Long? {
+    // 目前只为 Windows 提供动态种子色
+    if (!PlatformInfo.isWindows) {
+        return null
+    }
+    return WindowsAccentColorExtractor.getAccentColor()?.value?.toLong()
+}
+
 @Composable
 actual fun getDynamicColorScheme(isDark: Boolean): ColorScheme? {
-    return null
+    // 目前只为 Windows 提供莫奈取色
+    if (!PlatformInfo.isWindows) {
+        return null
+    }
+
+    // 每次都重新获取颜色，确保启动时能获取最新的系统主题色
+    val seedColor = WindowsAccentColorExtractor.getAccentColor()
+
+    // 如果无法获取系统主题色，返回 null 使用默认主题
+    val color = seedColor ?: return null
+
+    Logger.d("Platform", "Using Windows accent color: $color")
+
+    // 使用现有的颜色方案生成器
+    return generateColorScheme(color, isDark)
 }
+
+actual fun getAudioSourceOptions(): List<AudioSourceOption> = emptyList()
+
+actual fun availableAudioFormats(): List<AudioFormat> = AudioFormat.entries.toList()
+
+actual fun defaultAudioFormat(): AudioFormat = AudioFormat.PCM_FLOAT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,23 @@ composenativetray = "1.1.0"
 onnxruntime = "1.14.0"
 jtransforms = "3.2"
 
+# Android 低版本兼容模式版本（启用: -Pmicyou.androidCompat=true）
+compat-android-minSdk = "21"
+compat-android-targetSdk = "29"
+compat-composeMultiplatform = "1.7.3"
+compat-composeMaterial3 = "1.7.3"
+compat-kotlin = "2.1.20"
+compat-kotlinx-coroutines = "1.9.0"
+compat-kotlinx-serialization = "1.7.3"
+compat-ktor = "3.0.3"
+compat-androidx-activity = "1.8.2"
+compat-androidx-appcompat = "1.6.1"
+compat-androidx-core = "1.12.0"
+compat-androidx-lifecycle = "2.8.0"
+compat-androidx-espresso = "3.5.1"
+compat-multidex = "2.0.1"
+compat-desugarJdkLibs = "2.1.4"
+
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
@@ -60,7 +77,7 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "composeHotReload" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
-composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
## Android 5.0+ 兼容性支持 for v1.1.5（非破坏性，KMP）

通过 Gradle 属性 `-Pmicyou.androidCompat=true` 条件启用兼容模式。**不加该参数时，原版构建 100% 不变。**

### 构建命令

- 原版：`./gradlew :composeApp:assembleDebug`
- 兼容版：`./gradlew :composeApp:assembleDebug -Pmicyou.androidCompat=true`

> PowerShell 中必须加引号：`"-Pmicyou.androidCompat=true"`

### 修改文件（13 个）

**构建配置**（条件化，原版构建不受影响）：
- `libs.versions.toml`：保留原版版本号，新增 `compat-*` 兼容版本条目
- `build.gradle.kts`：条件化 minSdk=21 / targetSdk=29 / Compose 1.7.3 / Ktor 3.0.3
- `build.gradle.kts`：条件化 multiDexEnabled + coreLibraryDesugaring
- `build.gradle.kts`：resolutionStrategy 强制降级兼容依赖

**UI 修复**（运行时，始终生效，KMP expect/actual 模式）：
- `AudioSettings.kt`（commonMain）：`expect fun availableAudioFormats()` / `defaultAudioFormat()`
- `Platform.android.kt`（androidMain）：`actual` 实现 — API<23 时过滤 PCM_FLOAT
- `Platform.jvm.kt`（jvmMain）：`actual` 实现 — 所有格式可用
- `DesktopSettings.kt`：下拉选项只显示可用的格式
- `MainViewModel.kt`：读取已保存格式时校验设备是否支持

**运行时兼容**（始终生效）：
- `AudioEngine.android.kt`：PCM_FLOAT → PCM_16BIT 降级（API<23，运行时检查）
- `AudioEngine.android.kt`：`AudioRecord.read(float[])` 加 `SDK_INT>=M` 守卫
- `MicYouApplication.kt`：通过反射调用 MultiDex + 全局 UncaughtExceptionHandler
- `MicYouTileService.kt`：`startActivityAndCollapse` API 级别守卫
- `AndroidManifest.xml`：添加 `android:name` + `tools:ignore` 忽略高 API 权限警告

**文档**：
- `Android_Compatibility_Compile_Guide.md` / `Android_兼容性编译说明.md`

### 说明

- 基于 v1.1.5 tag 创建。PR diff 只显示这 13 个兼容文件（merge-base = v1.1.5 tag）。
- `behind_by: 209` 是正常的（legacy/v1 在 v1.1.5 之后有 209 个新提交），可以 cherry-pick。
- 使用 KMP `expect`/`actual` 模式实现平台特定格式过滤。
