### PR TITLE
fix(plugin): 修复 MessageTarget C ABI 序列化与文档不一致及 Windows 下集成测试稳定性问题

### DIFF
--- a/tauri-app/crates/micyou-plugin/src/host.rs
+++ b/tauri-app/crates/micyou-plugin/src/host.rs
@@ -98,11 +98,13 @@ pub struct DeviceSnapshot {
 
 /// Target of a cross-device plugin message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(tag = "type", rename_all = "camelCase")]
 pub enum MessageTarget {
     /// A plugin on the same host.
+    #[serde(rename_all = "camelCase")]
     Local { plugin_id: String },
     /// A plugin on the connected remote device.
+    #[serde(rename_all = "camelCase")]
     Remote { plugin_id: String },
     /// Broadcast to all hosts (local + remote) subscribed to the topic.
     Broadcast,

--- a/tauri-app/crates/micyou-plugin/src/manifest.rs
+++ b/tauri-app/crates/micyou-plugin/src/manifest.rs
@@ -645,7 +645,7 @@ mod tests {
     #[test]
     fn entry_path_ignores_wasm_runtime() {
         let json = r#"{
-            "id": "dev.micyou.wasm_test", "name": "Wasm", "version": "1.0.0",
+            "id": "dev.micyou.wasm-test", "name": "Wasm", "version": "1.0.0",
             "runtime": "wasm", "entry": "my_plugin"
         }"#;
         let manifest = PluginManifest::from_json(json).unwrap();

--- a/tauri-app/crates/micyou-plugin/tests/native_loader.rs
+++ b/tauri-app/crates/micyou-plugin/tests/native_loader.rs
@@ -12,6 +12,8 @@ use micyou_plugin::plugin::{AudioFrameCtx, PluginEvent, PluginRuntime};
 use micyou_plugin::{PluginLogLevel, PluginResult};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
 
 // ── Mock host ──────────────────────────────────────────────────────────────
 
@@ -154,13 +156,49 @@ fn fixture_dylib() -> PathBuf {
         Ok(dir) => PathBuf::from(dir).join("debug"),
         Err(_) => workspace_root().join("target").join("debug"),
     };
-    let prefix = "libmicyou_plugin_fixture_native";
+
+    // Cargo replaces hyphens with underscores in the output file name.
+    let base_name = "micyou_plugin_fixture_native";
+
+    // Determine the exact file name based on the target OS.
+    // Windows: my_crate.dll (No 'lib' prefix)
+    // macOS:   libmy_crate.dylib
+    // Linux:   libmy_crate.so
+    let exact_file_name = if cfg!(target_os = "windows") {
+        format!("{}.dll", base_name)
+    } else if cfg!(target_os = "macos") {
+        format!("lib{}.dylib", base_name)
+    } else {
+        format!("lib{}.so", base_name)
+    };
+
+    // 1. Try exact match in target/debug (Fastest and most reliable)
+    let direct_path = target_dir.join(&exact_file_name);
+    if direct_path.exists() {
+        return direct_path;
+    }
+
+    // 2. Try exact match in target/debug/deps
+    let deps_path = target_dir.join("deps").join(&exact_file_name);
+    if deps_path.exists() {
+        return deps_path;
+    }
+
+    // 3. Fallback to broad search in case Cargo appended hashes or used slightly different naming
     let mut candidates: Vec<PathBuf> = Vec::new();
     for root in [target_dir.clone(), target_dir.join("deps")] {
         if let Ok(entries) = std::fs::read_dir(&root) {
             for entry in entries.flatten() {
                 let name = entry.file_name().to_string_lossy().to_string();
-                if name.starts_with(prefix)
+                
+                // Fix: Dynamically determine the valid prefix based on the OS
+                let valid_prefix = if cfg!(target_os = "windows") {
+                    name.starts_with(base_name)
+                } else {
+                    name.starts_with(&format!("lib{}", base_name))
+                };
+
+                if valid_prefix
                     && (name.ends_with(".so") || name.ends_with(".dylib") || name.ends_with(".dll"))
                 {
                     candidates.push(entry.path());
@@ -168,6 +206,7 @@ fn fixture_dylib() -> PathBuf {
             }
         }
     }
+    
     candidates.sort();
     candidates.into_iter().next().unwrap_or_else(|| {
         panic!(
@@ -201,15 +240,16 @@ fn fixture_manifest() -> PluginManifest {
         ..Default::default()
     }
 }
+static COPY_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Build a plugin directory with the manifest + the artifact.
 /// Returns (temp dir, artifact path, manifest with the correct entry name).
 fn stage_fixture() -> (tempfile_dir::TempDir, PathBuf, PluginManifest) {
+    let _lock = COPY_MUTEX.lock().unwrap();
+
     let dir = tempfile_dir::TempDir::new("micyou-native-fixture");
     let dylib = fixture_dylib();
-    // Copy the dylib so the loader opens the staged copy (isolated from cargo).
-    // Tests must open the SAME staged file for helpers: dlopen deduplicates by
-    // path, so helper symbols and the plugin instance share one data segment.
+    
     let ext = dylib
         .extension()
         .unwrap_or_default()
@@ -217,7 +257,19 @@ fn stage_fixture() -> (tempfile_dir::TempDir, PathBuf, PluginManifest) {
         .to_string();
     let entry_name = format!("fixture_native.{ext}");
     let staged_path = dir.path().join(&entry_name);
-    std::fs::copy(&dylib, &staged_path).unwrap();
+    let mut attempts = 0;
+    loop {
+        match std::fs::copy(&dylib, &staged_path) {
+            Ok(_) => break,
+            Err(e) if e.raw_os_error() == Some(32) && attempts < 5 => {
+                // Error 32: The process cannot access the file because it is being used by another process.
+                attempts += 1;
+                thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => panic!("Failed to copy fixture dylib after retries: {}", e),
+        }
+    }
+
     let mut manifest = fixture_manifest();
     manifest.entry = entry_name;
     std::fs::write(


### PR DESCRIPTION
Closes #316

### 📝 背景与动机 (Background & Motivation)
在 Issue #316 中，指出 `send_message` C ABI 的 `target_json` 参数格式与官方文档描述严重不符。
文档描述的是 **内部标签 (Internally Tagged)** 格式（如 `{"type":"local","pluginId":"..."}`），但 `host.rs` 中的 `MessageTarget` 枚举使用了 Serde 默认的外部标签格式，且容器级的 `rename_all = "camelCase"` 未能级联作用于结构体变体内部的字段（导致 `plugin_id` 未被转换为驼峰命名）。

此外，在本地验证此修复时，发现现有的集成测试在 Windows 平台上存在严重的并发与路径兼容性问题，导致测试无法稳定运行。

### 🛠️ 变更内容 (Changes)

#### 1. 修复 `MessageTarget` 序列化逻辑 (Fix MessageTarget Serialization)
- 修改 `tauri-app/crates/micyou-plugin/src/host.rs`。
- 为 `MessageTarget` 添加 `#[serde(tag = "type")]`，强制采用文档描述的 **内部标签** 格式。
- 在 `Local` 和 `Remote` 变体上显式添加 `#[serde(rename_all = "camelCase")]`，确保内部字段 `plugin_id` 正确序列化为 `pluginId`。
- **结果**：C ABI 现在可以完美解析文档中规定的标准 JSON 格式（如 `{"type": "broadcast"}`、`{"type": "local", "pluginId": "..."}`）。

#### 2. 稳定 Windows 平台下的集成测试 (`native_loader.rs`)
- **跨平台动态库发现**：原代码硬编码了 Unix 的 `lib` 前缀，导致在 Windows 下无法找到 `.dll` 文件。重构了 `fixture_dylib()` 逻辑，基于 `cfg!(target_os)` 动态生成精确文件名并优先进行精确匹配。
- **并发与文件锁定 (Error 32)**：在 Windows 下，多线程并发测试极易导致复制 DLL 时抛出 `Os error 32`。引入了全局互斥锁 `COPY_MUTEX` 序列化复制过程，并增加了重试与短休眠机制，彻底解决了测试偶发崩溃的问题。

#### 3. 修复 Manifest 单元测试中的非法 ID (`manifest.rs`)
- 修正了继承自 PR #317 的单元测试 `entry_path_ignores_wasm_runtime`。
- 将测试载荷中的 ID 从 `"dev.micyou.wasm_test"` 改为 `"dev.micyou.wasm-test"`。原 ID 包含下划线 `_`，违反了 Manifest 校验规则（仅允许小写字母、数字、`.` 和 `-`），导致测试必定失败。由于这只是单字符修正且不影响生产代码，故一并包含在此 PR 中。

### 🧪 测试与验证计划 (Testing & Validation Plan)
- 本地单元测试与集成测试 (`cargo test -p micyou-plugin`) 在 Windows 环境下已全部通过。
- **实机验证 (WIP)**：我将下载此 PR 触发的 GitHub Actions CI 编译产物，编写真实的 Native C ABI 插件进行实机联调，以确认 `send_message` 的路由在真实宿主环境中完全修复。
